### PR TITLE
chore(deps): migrate eslint and precommit tools to npm packages

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-npx prepush-hash check
+npx precommit-verify check

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-npx prepush-hash verify-footer "$1" "${2:-}"
+npx precommit-verify verify-footer "$1" "${2:-}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup SSH for private dependencies
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.DEPLOY_PRIVATE_KEY_FOR_9WICK_ESLINT_RULES }}
-
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "knip": "knip",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "prepush": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm build && pnpm test && npx prepush-hash save",
+    "precommit": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm build && pnpm test && npx precommit-verify save",
     "prepare": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
-    "@9wick/eslint-plugin-strict-type-rules": "github:9wick/eslint-strict-type-rules#081ca1c7c414375e4efd906a1b3a84dd65e74e4f",
+    "@9wick/eslint-plugin-strict-type-rules": "1.0.2",
     "@biomejs/biome": "2.4.14",
     "@eslint-community/eslint-plugin-eslint-comments": "4.7.1",
     "@vitest/coverage-v8": "4.1.5",
@@ -30,6 +30,7 @@
     "knip": "6.10.0",
     "nx": "21.6.10",
     "oxlint": "1.62.0",
+    "precommit-verify": "0.1.7",
     "tsdown": "0.21.10",
     "typescript": "6.0.2",
     "typescript-eslint": "8.59.1",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -31,6 +31,7 @@
     "vitest": ">=4 <5"
   },
   "devDependencies": {
+    "@needle-di/core": "1.1.2",
     "valibot": "1.3.1"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -31,7 +31,6 @@
     "vitest": ">=4 <5"
   },
   "devDependencies": {
-    "@needle-di/core": "1.1.2",
-    "valibot": "1.3.1"
+    "@needle-di/core": "1.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@9wick/eslint-plugin-strict-type-rules':
-        specifier: github:9wick/eslint-strict-type-rules#081ca1c7c414375e4efd906a1b3a84dd65e74e4f
-        version: git+https://git@github.com:9wick/eslint-strict-type-rules.git#081ca1c7c414375e4efd906a1b3a84dd65e74e4f(@eslint-community/eslint-plugin-eslint-comments@4.7.1(eslint@10.3.0(jiti@2.6.1)))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.3.0(jiti@2.6.1)))(eslint-plugin-sonarjs@4.0.3(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1))(typescript-eslint@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))
+        specifier: 1.0.2
+        version: 1.0.2(@eslint-community/eslint-plugin-eslint-comments@4.7.1(eslint@10.3.0(jiti@2.6.1)))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.3.0(jiti@2.6.1)))(eslint-plugin-sonarjs@4.0.3(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1))(typescript-eslint@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))
       '@biomejs/biome':
         specifier: 2.4.14
         version: 2.4.14
@@ -41,6 +41,9 @@ importers:
       oxlint:
         specifier: 1.62.0
         version: 1.62.0
+      precommit-verify:
+        specifier: 0.1.7
+        version: 0.1.7
       tsdown:
         specifier: 0.21.10
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2)
@@ -137,24 +140,22 @@ importers:
       '@koya/core':
         specifier: workspace:*
         version: link:../core
-      '@needle-di/core':
-        specifier: 1.1.2
-        version: 1.1.2
       vitest:
         specifier: '>=4 <5'
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
+      '@needle-di/core':
+        specifier: 1.1.2
+        version: 1.1.2
       valibot:
         specifier: 1.3.1
         version: 1.3.1(typescript@6.0.2)
 
 packages:
 
-  '@9wick/eslint-plugin-strict-type-rules@git+https://git@github.com:9wick/eslint-strict-type-rules.git#081ca1c7c414375e4efd906a1b3a84dd65e74e4f':
-    resolution: {commit: 081ca1c7c414375e4efd906a1b3a84dd65e74e4f, repo: git@github.com:9wick/eslint-strict-type-rules.git, type: git}
-    version: 0.1.0
+  '@9wick/eslint-plugin-strict-type-rules@1.0.2':
+    resolution: {integrity: sha512-9uLHtjnQW/kXzeT4v5T2fxbRSRps7B1NPhKUkKFqgTyWEVkG2zwbZxqNQn7NGWs1EUQ7/+qaMsYH3+M0qpVpXg==}
     engines: {node: '>=18.18.0'}
-    hasBin: true
     peerDependencies:
       '@eslint-community/eslint-plugin-eslint-comments': ^4.0.0
       eslint: ^9.0.0
@@ -2170,6 +2171,13 @@ packages:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
+  precommit-verify@0.1.7:
+    resolution: {integrity: sha512-iovZ9ugAiIWXlrZ4JX9XjArqKrht1bfCHC3xmqUkqkRItiTC+NruVmm2RSeokmBeCTPj3+WXAWkOIAXsp+MIMQ==}
+    engines: {node: '>=18'}
+    cpu: [x64, arm64]
+    os: [linux, darwin, win32]
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2598,7 +2606,7 @@ packages:
 
 snapshots:
 
-  '@9wick/eslint-plugin-strict-type-rules@git+https://git@github.com:9wick/eslint-strict-type-rules.git#081ca1c7c414375e4efd906a1b3a84dd65e74e4f(@eslint-community/eslint-plugin-eslint-comments@4.7.1(eslint@10.3.0(jiti@2.6.1)))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.3.0(jiti@2.6.1)))(eslint-plugin-sonarjs@4.0.3(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1))(typescript-eslint@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))':
+  '@9wick/eslint-plugin-strict-type-rules@1.0.2(@eslint-community/eslint-plugin-eslint-comments@4.7.1(eslint@10.3.0(jiti@2.6.1)))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.3.0(jiti@2.6.1)))(eslint-plugin-sonarjs@4.0.3(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1))(typescript-eslint@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))':
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@10.3.0(jiti@2.6.1))
       eslint: 10.3.0(jiti@2.6.1)
@@ -4302,6 +4310,8 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  precommit-verify@0.1.7: {}
 
   prelude-ls@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       '@needle-di/core':
         specifier: 1.1.2
         version: 1.1.2
-      valibot:
-        specifier: 1.3.1
-        version: 1.3.1(typescript@6.0.2)
 
 packages:
 


### PR DESCRIPTION
## Summary
- `@9wick/eslint-plugin-strict-type-rules` を GitHub → npm `1.0.2` に変更
- `precommit-verify@0.1.7` を追加し、`prepush-hash` から移行
- スクリプト名を `prepush` → `precommit` に変更