### PR TITLE
ci: setup release-please for automated npm publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release-please:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      paths_released: ${{ steps.release.outputs.paths_released }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish packages
+        run: |
+          for pkg in packages/core packages/adapter-node packages/contract packages/testing; do
+            echo "Publishing $pkg..."
+            pnpm --filter "./$pkg" publish --access public --no-git-checks --provenance
+          done
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,6 @@
+{
+  "packages/core": "0.0.1",
+  "packages/adapter-node": "0.0.1",
+  "packages/contract": "0.0.1",
+  "packages/testing": "0.0.1"
+}

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeltjs/adapter-node",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeltjs/openapi",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeltjs/core",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeltjs/testing",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "include-component-in-tag": true,
+  "packages": {
+    "packages/core": {
+      "component": "core"
+    },
+    "packages/adapter-node": {
+      "component": "adapter-node"
+    },
+    "packages/contract": {
+      "component": "openapi"
+    },
+    "packages/testing": {
+      "component": "testing"
+    }
+  },
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "zeltjs",
+      "components": ["core", "adapter-node", "openapi", "testing"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add Release Please workflow with `linked-versions` plugin to synchronize all package versions
- Configure manifest and config files for monorepo release management
- Bump all packages to v0.0.1 to match already published `@zeltjs/core`

## What this enables

1. Push conventional commits to main (`feat:`, `fix:`, etc.)
2. Release Please automatically creates a Release PR
3. Merge the Release PR → all packages published to npm with the same version

## Files added/modified

- `.github/workflows/release-please.yml` - GitHub Actions workflow
- `release-please-config.json` - Monorepo configuration with linked-versions
- `.release-please-manifest.json` - Version manifest
- `packages/*/package.json` - Version bump to 0.0.1

## Post-merge TODO

Configure npm trusted publisher for OIDC authentication on each package:
- https://www.npmjs.com/package/@zeltjs/core/access
- https://www.npmjs.com/package/@zeltjs/adapter-node/access
- https://www.npmjs.com/package/@zeltjs/openapi/access
- https://www.npmjs.com/package/@zeltjs/testing/access