### PR TITLE
docs: add README for each package

### DIFF
--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,0 +1,24 @@
+# @zeltjs/adapter-node
+
+Node.js HTTP server adapter for Zelt applications.
+
+## Installation
+
+```bash
+npm install @zeltjs/adapter-node @zeltjs/core
+```
+
+## Usage
+
+```typescript
+import { serve } from '@zeltjs/adapter-node';
+import { createHttpApp } from '@zeltjs/core';
+
+const app = createHttpApp({ controllers: [...] });
+
+serve(app, { port: 3000 });
+```
+
+## Documentation
+
+See [zeltjs.dev](https://zeltjs.dev) for full documentation.

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -1,0 +1,29 @@
+# @zeltjs/openapi
+
+OpenAPI schema generator for Zelt applications.
+
+## Installation
+
+```bash
+npm install @zeltjs/openapi
+```
+
+## Usage
+
+### CLI
+
+```bash
+npx zelt-openapi generate --config zelt.config.ts
+```
+
+### Programmatic
+
+```typescript
+import { generateOpenApiSpec } from '@zeltjs/openapi';
+
+const spec = await generateOpenApiSpec({ controllers: [...] });
+```
+
+## Documentation
+
+See [zeltjs.dev](https://zeltjs.dev) for full documentation.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,29 @@
+# @zeltjs/core
+
+The core framework for building type-safe HTTP APIs with decorators and dependency injection.
+
+## Installation
+
+```bash
+npm install @zeltjs/core
+```
+
+## Quick Start
+
+```typescript
+import { Controller, Get, createHttpApp } from '@zeltjs/core';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/')
+  hello() {
+    return { message: 'Hello, World!' };
+  }
+}
+
+const app = createHttpApp({ controllers: [HelloController] });
+```
+
+## Documentation
+
+See [zeltjs.dev](https://zeltjs.dev) for full documentation.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,28 @@
+# @zeltjs/testing
+
+Testing utilities for Zelt applications.
+
+## Installation
+
+```bash
+npm install -D @zeltjs/testing
+```
+
+## Usage
+
+```typescript
+import { createTestApp } from '@zeltjs/testing';
+import { describe, it, expect } from 'vitest';
+
+describe('HelloController', () => {
+  it('returns hello message', async () => {
+    const app = createTestApp({ controllers: [HelloController] });
+    const res = await app.request('/hello');
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+## Documentation
+
+See [zeltjs.dev](https://zeltjs.dev) for full documentation.


### PR DESCRIPTION
## Summary

Add basic README files with installation and usage examples for each npm package.

## Changes

- `packages/core/README.md` - Quick start example
- `packages/adapter-node/README.md` - Node.js server usage
- `packages/contract/README.md` - OpenAPI CLI and programmatic usage
- `packages/testing/README.md` - Testing utilities with vitest

These READMEs will be displayed on npm package pages.