### PR TITLE
fix(core): add license section to README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,3 +27,7 @@ const app = createHttpApp({ controllers: [HelloController] });
 ## Documentation
 
 See [zeltjs.dev](https://zeltjs.dev) for full documentation.
+
+## License
+
+MIT


### PR DESCRIPTION
Add license section to core package README. This will trigger a new release to test the Node.js 24 CI fix.