### PR TITLE
feat(core): add @ErrorHandler decorator and errorHandlers option

### DIFF
--- a/packages/core/src/decorators/error-handler.test.ts
+++ b/packages/core/src/decorators/error-handler.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { Container } from '@needle-di/core';
+import type { Context } from 'hono';
+
+import { ErrorHandler } from './error-handler';
+
+describe('@ErrorHandler', () => {
+  it('makes class injectable and resolvable by container', () => {
+    @ErrorHandler
+    class TestErrorHandler {
+      onError(_error: Error, _c: Context) {
+        return Response.json({ error: 'handled' }, { status: 500 });
+      }
+    }
+
+    const container = new Container();
+    const instance = container.get(TestErrorHandler);
+    expect(instance).toBeInstanceOf(TestErrorHandler);
+    expect(typeof instance.onError).toBe('function');
+  });
+
+  it('preserves class identity after decoration', () => {
+    @ErrorHandler
+    class CustomErrorHandler {
+      onError(_error: Error, _c: Context) {
+        return undefined;
+      }
+    }
+
+    expect(CustomErrorHandler.name).toBe('CustomErrorHandler');
+  });
+});

--- a/packages/core/src/decorators/error-handler.ts
+++ b/packages/core/src/decorators/error-handler.ts
@@ -2,7 +2,7 @@ import { injectable } from '@needle-di/core';
 
 type AnyClass = new (...args: never[]) => object;
 
-export const Middleware = <T extends AnyClass>(target: T): T => {
+export const ErrorHandler = <T extends AnyClass>(target: T): T => {
   injectable<T>()(target);
   return target;
 };

--- a/packages/core/src/http/app.test.ts
+++ b/packages/core/src/http/app.test.ts
@@ -4,6 +4,7 @@ import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 
 import { Controller } from '../decorators/controller';
+import { ErrorHandler } from '../decorators/error-handler';
 import { Get, Post } from '../decorators/http-method';
 import { Middleware } from '../decorators/middleware';
 import { SkipMiddleware } from '../decorators/skip-middleware';
@@ -370,5 +371,143 @@ describe('middleware', () => {
     const res = await app.request('/test/');
     expect(res.status).toBe(403);
     expect(await res.json()).toEqual({ blocked: true });
+  });
+});
+
+describe('errorHandlers', () => {
+  it('handles errors thrown in controller', async () => {
+    class CustomError extends Error {
+      constructor(
+        message: string,
+        public code: string,
+      ) {
+        super(message);
+      }
+    }
+
+    @ErrorHandler
+    class CustomErrorHandler {
+      onError(error: Error, _c: Context) {
+        if (error instanceof CustomError) {
+          return Response.json({ code: error.code, message: error.message }, { status: 400 });
+        }
+        return undefined;
+      }
+    }
+
+    @Controller('/test')
+    class TestController {
+      @Get('/')
+      get() {
+        throw new CustomError('invalid input', 'INVALID_INPUT');
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [TestController],
+      errorHandlers: [CustomErrorHandler],
+    });
+
+    const res = await app.request('/test/');
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ code: 'INVALID_INPUT', message: 'invalid input' });
+  });
+
+  it('falls back to default handler when error handler returns undefined', async () => {
+    @ErrorHandler
+    class SelectiveErrorHandler {
+      onError(_error: Error, _c: Context) {
+        return undefined;
+      }
+    }
+
+    @Controller('/test')
+    class TestController {
+      @Get('/')
+      get() {
+        throw new Error('unhandled error');
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [TestController],
+      errorHandlers: [SelectiveErrorHandler],
+    });
+
+    const res = await app.request('/test/');
+    expect(res.status).toBe(500);
+  });
+
+  it('executes multiple error handlers in order until one handles', async () => {
+    const order: string[] = [];
+
+    @ErrorHandler
+    class FirstErrorHandler {
+      onError(_error: Error, _c: Context) {
+        order.push('first');
+        return undefined;
+      }
+    }
+
+    @ErrorHandler
+    class SecondErrorHandler {
+      onError(error: Error, _c: Context) {
+        order.push('second');
+        return Response.json({ handled: true, message: error.message }, { status: 500 });
+      }
+    }
+
+    @Controller('/test')
+    class TestController {
+      @Get('/')
+      get() {
+        throw new Error('test error');
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [TestController],
+      errorHandlers: [FirstErrorHandler, SecondErrorHandler],
+    });
+
+    const res = await app.request('/test/');
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ handled: true, message: 'test error' });
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('middlewares and errorHandlers work together', async () => {
+    const executed: string[] = [];
+
+    const beforeMiddleware: MiddlewareHandler = async (_c, next) => {
+      executed.push('middleware');
+      await next();
+    };
+
+    @ErrorHandler
+    class TestErrorHandler {
+      onError(error: Error, _c: Context) {
+        executed.push('errorHandler');
+        return Response.json({ error: error.message }, { status: 500 });
+      }
+    }
+
+    @Controller('/test')
+    class TestController {
+      @Get('/')
+      get() {
+        executed.push('handler');
+        throw new Error('test');
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [TestController],
+      middlewares: [beforeMiddleware],
+      errorHandlers: [TestErrorHandler],
+    });
+
+    await app.request('/test/');
+    expect(executed).toEqual(['middleware', 'handler', 'errorHandler']);
   });
 });

--- a/packages/core/src/http/app.ts
+++ b/packages/core/src/http/app.ts
@@ -2,15 +2,22 @@ import { Hono } from 'hono';
 
 import { createContainer } from '../internal/container';
 import { buildRoutes } from '../internal/route-builder';
-import type { MiddlewareInput } from '../middleware/types';
+import type {
+  ErrorHandlerClass,
+  ErrorHandlerInstance,
+  MiddlewareInput,
+  RequestContext,
+} from '../middleware/types';
 
 import { handleError } from './error-handler';
 
 type ControllerClass = new (...args: never[]) => object;
+type Resolver = { get: <T extends object>(cls: new (...args: never[]) => T) => T };
 
 export type CreateHttpAppOptions = {
   readonly controllers: readonly ControllerClass[];
   readonly middlewares?: readonly MiddlewareInput[];
+  readonly errorHandlers?: readonly ErrorHandlerClass[];
   readonly configs?: readonly (new (...args: never[]) => unknown)[];
 };
 
@@ -19,13 +26,34 @@ export type HttpApp = {
   readonly request: (input: string | Request, init?: RequestInit) => Promise<Response>;
 };
 
+const createErrorHandler =
+  (errorHandlers: readonly ErrorHandlerInstance[]) =>
+  async (err: Error, c: RequestContext): Promise<Response> => {
+    for (const handler of errorHandlers) {
+      const result = await handler.onError(err, c);
+      if (result) return result;
+    }
+    return handleError(err);
+  };
+
+const resolveErrorHandler = (cls: ErrorHandlerClass, resolver: Resolver): ErrorHandlerInstance => {
+  const instance: ErrorHandlerInstance = resolver.get(cls);
+  return instance;
+};
+
+const resolveErrorHandlers = (
+  classes: readonly ErrorHandlerClass[],
+  resolver: Resolver,
+): ErrorHandlerInstance[] => classes.map((cls) => resolveErrorHandler(cls, resolver));
+
 export const createHttpApp = (options: CreateHttpAppOptions): HttpApp => {
   const resolver = createContainer({ configs: options.configs });
   // strict:false で `/echo` と `/echo/` を同一視する。joinPath が末尾スラッシュを正規化するため、
   // 利用者が `@Post('/')` と書いた場合でも `/echo/` リクエストにマッチさせる必要がある。
   const hono = new Hono({ strict: false });
 
-  hono.onError((err) => handleError(err));
+  const errorHandlers = resolveErrorHandlers(options.errorHandlers ?? [], resolver);
+  hono.onError(createErrorHandler(errorHandlers));
 
   buildRoutes(hono, options.controllers, resolver, options.middlewares ?? []);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export type { ErrorBody } from './http/error-schema';
 export { HTTPException } from 'hono/http-exception';
 
 export { Controller } from './decorators/controller';
+export { ErrorHandler } from './decorators/error-handler';
 export { Delete, Get, Patch, Post, Put } from './decorators/http-method';
 export { Injectable } from './decorators/injectable';
 export { Middleware } from './decorators/middleware';
@@ -16,6 +17,8 @@ export { SkipMiddleware } from './decorators/skip-middleware';
 export { UseMiddleware } from './decorators/use-middleware';
 
 export type {
+  ErrorHandlerClass,
+  ErrorHandlerInstance,
   FunctionMiddleware,
   MiddlewareClass,
   MiddlewareIdentifier,

--- a/packages/core/src/middleware/types.ts
+++ b/packages/core/src/middleware/types.ts
@@ -14,3 +14,9 @@ export type MiddlewareInstance = {
 export type MiddlewareInput = FunctionMiddleware | MiddlewareClass;
 
 export type MiddlewareIdentifier = FunctionMiddleware | MiddlewareClass;
+
+export type ErrorHandlerClass = new (...args: never[]) => ErrorHandlerInstance;
+
+export type ErrorHandlerInstance = {
+  onError(error: Error, c: RequestContext): Response | Promise<Response | undefined> | undefined;
+};


### PR DESCRIPTION
## Summary

- Add `@ErrorHandler` decorator for marking error handler classes
- Add `errorHandlers` option to `createHttpApp` for registering handlers
- Error handlers execute in order until one returns a Response
- Falls back to default error handler if none handle the error

## Usage

```typescript
@ErrorHandler
class PrismaErrorHandler {
  onError(error: Error, c: RequestContext) {
    if (error instanceof PrismaError) {
      return Response.json({ code: 'CONFLICT' }, { status: 409 });
    }
    return undefined;  // pass to next handler
  }
}

createHttpApp({
  controllers: [MyController],
  middlewares: [LoggingMiddleware],
  errorHandlers: [PrismaErrorHandler],
})
```

## Design decisions

- Separate concept from `@Middleware` (clear separation of concerns)
- DI-enabled via `@injectable()` internally
- Chain pattern: handlers execute in order, first non-undefined response wins

## Test plan

- [x] Unit tests for `@ErrorHandler` decorator
- [x] Integration tests for `errorHandlers` in `createHttpApp`
- [x] Multiple handlers chain correctly
- [x] Fallback to default handler works