### PR TITLE
feat(core): add authentication and authorization primitives

### DIFF
--- a/packages/core/src/decorators/authorized.test.ts
+++ b/packages/core/src/decorators/authorized.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { createHttpApp } from '../http/app';
+import type { FunctionMiddleware } from '../middleware/types';
+import { setUser } from '../primitives/auth';
+
+import { Authorized } from './authorized';
+import { Controller } from './controller';
+import { Get } from './http-method';
+
+const authMiddleware: FunctionMiddleware = async (c, next) => {
+  const authHeader = c.req.header('Authorization');
+  if (authHeader === 'Bearer valid-token') {
+    setUser({ id: 1, name: 'alice' }, ['user']);
+  } else if (authHeader === 'Bearer admin-token') {
+    setUser({ id: 2, name: 'admin' }, ['admin', 'user']);
+  }
+  await next();
+};
+
+describe('@Authorized', () => {
+  it('returns 401 when user is not authenticated', async () => {
+    @Controller('/test')
+    class TestController {
+      @Authorized()
+      @Get('/')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [TestController],
+      middlewares: [authMiddleware],
+    });
+
+    const res = await app.request('/test/');
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      code: 'UNAUTHORIZED',
+      message: 'Authentication required',
+    });
+  });
+
+  it('allows access when user is authenticated', async () => {
+    @Controller('/test')
+    class TestController {
+      @Authorized()
+      @Get('/')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [TestController],
+      middlewares: [authMiddleware],
+    });
+
+    const res = await app.request('/test/', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('returns 403 when user lacks required role', async () => {
+    @Controller('/admin')
+    class AdminController {
+      @Authorized(['admin'])
+      @Get('/')
+      get() {
+        return { secret: 'data' };
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [AdminController],
+      middlewares: [authMiddleware],
+    });
+
+    const res = await app.request('/admin/', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      code: 'FORBIDDEN',
+      message: 'Insufficient permissions',
+    });
+  });
+
+  it('allows access when user has required role', async () => {
+    @Controller('/admin')
+    class AdminController {
+      @Authorized(['admin'])
+      @Get('/')
+      get() {
+        return { secret: 'data' };
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [AdminController],
+      middlewares: [authMiddleware],
+    });
+
+    const res = await app.request('/admin/', {
+      headers: { Authorization: 'Bearer admin-token' },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ secret: 'data' });
+  });
+
+  it('allows access when user has one of multiple required roles', async () => {
+    @Controller('/content')
+    class ContentController {
+      @Authorized(['editor', 'admin'])
+      @Get('/')
+      get() {
+        return { content: 'editable' };
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [ContentController],
+      middlewares: [authMiddleware],
+    });
+
+    const res = await app.request('/content/', {
+      headers: { Authorization: 'Bearer admin-token' },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ content: 'editable' });
+  });
+});

--- a/packages/core/src/decorators/authorized.ts
+++ b/packages/core/src/decorators/authorized.ts
@@ -1,0 +1,13 @@
+import { setAuthorizedMetadata } from '../internal/metadata';
+import type { RequestContextSchema } from '../primitives/get-context';
+
+type Roles = RequestContextSchema['authRoles'];
+
+export const Authorized =
+  (roles: Roles = []) =>
+  (target: object, propertyKey: string | symbol): void => {
+    if (typeof target === 'function') {
+      throw new Error('zelt: @Authorized cannot be applied to static methods');
+    }
+    setAuthorizedMetadata(target.constructor, propertyKey, roles);
+  };

--- a/packages/core/src/http/app.test.ts
+++ b/packages/core/src/http/app.test.ts
@@ -19,7 +19,6 @@ import { createHttpApp } from './app';
 declare module '@zeltjs/core' {
   interface RequestContextSchema {
     configValue: string;
-    user: { id: number; name: string };
   }
 }
 
@@ -310,7 +309,7 @@ describe('middleware', () => {
     class TestController {
       @Get('/')
       get() {
-        const user = getContext('user');
+        const user = getContext('user') as { id: number; name: string } | undefined;
         return { userId: user?.id, userName: user?.name };
       }
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export type { ErrorBody } from './http/error-schema';
 
 export { HTTPException } from 'hono/http-exception';
 
+export { Authorized } from './decorators/authorized';
 export { Controller } from './decorators/controller';
 export { ErrorHandler } from './decorators/error-handler';
 export { Delete, Get, Patch, Post, Put } from './decorators/http-method';
@@ -28,6 +29,7 @@ export type {
   RequestContext,
 } from './middleware/types';
 
+export { currentRoles, currentUser, setUser } from './primitives/auth';
 export { getContext, setContext } from './primitives/get-context';
 export type { RequestContextSchema } from './primitives/get-context';
 export { inject } from './primitives/inject';

--- a/packages/core/src/internal/metadata.ts
+++ b/packages/core/src/internal/metadata.ts
@@ -26,11 +26,17 @@ type SkipMiddlewareMetadata = {
   readonly skipped: readonly MiddlewareIdentifier[];
 };
 
+type AuthorizedMetadata = {
+  readonly methodName: string | symbol;
+  readonly roles: readonly string[];
+};
+
 const controllerStore = new WeakMap<object, ControllerMetadata>();
 const routeStore = new WeakMap<object, RouteMetadata[]>();
 const controllerMiddlewareStore = new WeakMap<object, ControllerMiddlewareMetadata>();
 const methodMiddlewareStore = new WeakMap<object, MethodMiddlewareMetadata[]>();
 const skipMiddlewareStore = new WeakMap<object, SkipMiddlewareMetadata[]>();
+const authorizedStore = new WeakMap<object, AuthorizedMetadata[]>();
 
 export const setControllerMetadata = (cls: object, meta: ControllerMetadata): void => {
   controllerStore.set(cls, meta);
@@ -85,3 +91,20 @@ export const appendSkipMiddlewareMetadata = (
 
 export const getSkipMiddlewareMetadata = (cls: object): readonly SkipMiddlewareMetadata[] =>
   skipMiddlewareStore.get(cls) ?? [];
+
+export const setAuthorizedMetadata = (
+  cls: object,
+  methodName: string | symbol,
+  roles: readonly string[],
+): void => {
+  const existing = authorizedStore.get(cls) ?? [];
+  authorizedStore.set(cls, [...existing, { methodName, roles }]);
+};
+
+export const getAuthorizedMetadata = (
+  cls: object,
+  methodName: string | symbol,
+): AuthorizedMetadata | undefined => {
+  const all = authorizedStore.get(cls) ?? [];
+  return all.find((m) => m.methodName === methodName);
+};

--- a/packages/core/src/internal/route-builder.ts
+++ b/packages/core/src/internal/route-builder.ts
@@ -105,14 +105,20 @@ const createAuthorizationMiddleware = (requiredRoles: readonly string[]): Functi
   return async (_c, next) => {
     const user = currentUser();
     if (user === undefined) {
-      return Response.json({ code: 'UNAUTHORIZED', message: 'Authentication required' }, { status: 401 });
+      return Response.json(
+        { code: 'UNAUTHORIZED', message: 'Authentication required' },
+        { status: 401 },
+      );
     }
 
     if (requiredRoles.length > 0) {
       const userRoles = currentRoles();
       const hasRequiredRole = requiredRoles.some((role) => userRoles.includes(role));
       if (!hasRequiredRole) {
-        return Response.json({ code: 'FORBIDDEN', message: 'Insufficient permissions' }, { status: 403 });
+        return Response.json(
+          { code: 'FORBIDDEN', message: 'Insufficient permissions' },
+          { status: 403 },
+        );
       }
     }
 

--- a/packages/core/src/internal/route-builder.ts
+++ b/packages/core/src/internal/route-builder.ts
@@ -2,10 +2,12 @@ import type { Context, Env, Hono, Input } from 'hono';
 import * as v from 'valibot';
 
 import type { FunctionMiddleware, MiddlewareClass, MiddlewareInput } from '../middleware/types';
+import { currentRoles, currentUser } from '../primitives/auth';
 
 import type { ResolverHandle } from './container';
 import { runInEntryContext } from './entry-context';
 import {
+  getAuthorizedMetadata,
   getControllerMetadata,
   getControllerMiddlewareMetadata,
   getMethodMiddlewareMetadata,
@@ -99,6 +101,26 @@ const resolveMiddleware = (
   return middleware;
 };
 
+const createAuthorizationMiddleware = (requiredRoles: readonly string[]): FunctionMiddleware => {
+  return async (_c, next) => {
+    const user = currentUser();
+    if (user === undefined) {
+      return Response.json({ code: 'UNAUTHORIZED', message: 'Authentication required' }, { status: 401 });
+    }
+
+    if (requiredRoles.length > 0) {
+      const userRoles = currentRoles();
+      const hasRequiredRole = requiredRoles.some((role) => userRoles.includes(role));
+      if (!hasRequiredRole) {
+        return Response.json({ code: 'FORBIDDEN', message: 'Insufficient permissions' }, { status: 403 });
+      }
+    }
+
+    await next();
+    return undefined;
+  };
+};
+
 const collectRouteMiddlewares = (
   globalMiddlewares: readonly MiddlewareInput[],
   controllerClass: ControllerClass,
@@ -112,6 +134,7 @@ const collectRouteMiddlewares = (
   const skipMetas = getSkipMiddlewareMetadata(controllerClass).filter(
     (m) => m.methodName === methodName,
   );
+  const authorizedMeta = getAuthorizedMetadata(controllerClass, methodName);
 
   const skippedSet = new Set<MiddlewareInput>(skipMetas.flatMap((m) => m.skipped));
 
@@ -121,7 +144,13 @@ const collectRouteMiddlewares = (
     ...methodMetas.flatMap((m) => m.middlewares.filter((mw) => !skippedSet.has(mw))),
   ];
 
-  return allMiddlewares.map((m) => resolveMiddleware(m, resolver));
+  const resolvedMiddlewares = allMiddlewares.map((m) => resolveMiddleware(m, resolver));
+
+  if (authorizedMeta) {
+    resolvedMiddlewares.push(createAuthorizationMiddleware(authorizedMeta.roles));
+  }
+
+  return resolvedMiddlewares;
 };
 
 const composeHandler = (
@@ -174,17 +203,20 @@ const registerRoute = (
   );
 
   const finalHandler = async (c: MiddlewareContext): Promise<Response> => {
-    const body = await parseRequestBody(c);
-    const pathParams: Readonly<Record<string, string>> = c.req.param();
-    const result = await runInEntryContext(
-      { input: { body, pathParams }, honoContext: c },
-      async () => invoke(),
-    );
+    const result = await invoke();
     if (result instanceof Response) return result;
     return c.json(result);
   };
 
-  const handler = composeHandler(middlewares, finalHandler);
+  const composedHandler = composeHandler(middlewares, finalHandler);
+
+  const handler = async (c: MiddlewareContext): Promise<Response> => {
+    const body = await parseRequestBody(c);
+    const pathParams: Readonly<Record<string, string>> = c.req.param();
+    return runInEntryContext({ input: { body, pathParams }, honoContext: c }, () =>
+      composedHandler(c),
+    );
+  };
 
   const methods = {
     GET: () => hono.get(route.fullPath, handler),

--- a/packages/core/src/primitives/auth.test.ts
+++ b/packages/core/src/primitives/auth.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { Context } from 'hono';
+
+import { runInEntryContext, type EntryContext } from '../internal/entry-context';
+
+import { setUser, currentUser, currentRoles } from './auth';
+
+const createMockEntryContext = (): EntryContext => {
+  const store: Record<string, unknown> = {};
+  return {
+    input: { body: {}, pathParams: {} },
+    honoContext: {
+      get: (key: string) => store[key],
+      set: (key: string, value: unknown) => {
+        store[key] = value;
+      },
+    } as unknown as Context,
+  };
+};
+
+describe('setUser', () => {
+  it('sets user and roles in context', () => {
+    const ctx = createMockEntryContext();
+    runInEntryContext(ctx, () => {
+      setUser({ id: 1, name: 'alice' }, ['admin', 'user']);
+      expect(currentUser()).toEqual({ id: 1, name: 'alice' });
+      expect(currentRoles()).toEqual(['admin', 'user']);
+    });
+  });
+
+  it('defaults roles to empty array', () => {
+    const ctx = createMockEntryContext();
+    runInEntryContext(ctx, () => {
+      setUser({ id: 2, name: 'bob' });
+      expect(currentUser()).toEqual({ id: 2, name: 'bob' });
+      expect(currentRoles()).toEqual([]);
+    });
+  });
+});
+
+describe('currentUser', () => {
+  it('returns undefined when user is not set', () => {
+    const ctx = createMockEntryContext();
+    const result = runInEntryContext(ctx, () => currentUser());
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('currentRoles', () => {
+  it('returns empty array when roles are not set', () => {
+    const ctx = createMockEntryContext();
+    const result = runInEntryContext(ctx, () => currentRoles());
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/core/src/primitives/auth.ts
+++ b/packages/core/src/primitives/auth.ts
@@ -1,0 +1,17 @@
+import { getContext, setContext, type RequestContextSchema } from './get-context';
+
+export const setUser = <U extends RequestContextSchema['user']>(
+  user: U,
+  roles: RequestContextSchema['authRoles'] = [],
+): void => {
+  setContext('user', user);
+  setContext('authRoles', roles);
+};
+
+export const currentUser = (): RequestContextSchema['user'] | undefined => {
+  return getContext('user');
+};
+
+export const currentRoles = (): RequestContextSchema['authRoles'] => {
+  return getContext('authRoles') ?? [];
+};

--- a/packages/core/src/primitives/get-context.test.ts
+++ b/packages/core/src/primitives/get-context.test.ts
@@ -7,7 +7,6 @@ import { getContext, setContext } from './get-context';
 
 declare module '@zeltjs/core' {
   interface RequestContextSchema {
-    user: { id: number; name: string };
     nonexistent: unknown;
   }
 }

--- a/packages/core/src/primitives/get-context.ts
+++ b/packages/core/src/primitives/get-context.ts
@@ -1,7 +1,9 @@
 import { getEntryContext } from '../internal/entry-context';
 
-// biome-ignore lint/suspicious/noEmptyInterface: users extend this interface via module augmentation
-export interface RequestContextSchema {}
+export interface RequestContextSchema {
+  user: unknown;
+  authRoles: string[];
+}
 
 export const getContext = <K extends keyof RequestContextSchema>(
   key: K,


### PR DESCRIPTION
## Summary

- Add `setUser(user, roles)` / `currentUser()` / `currentRoles()` for auth state management in middleware and handlers
- Add `@Authorized(roles?)` decorator for declarative role-based access control
- Extend `RequestContextSchema` with `user` and `authRoles` fields for type-safe context
- Move `runInEntryContext` to wrap the entire middleware chain, enabling context access in middleware

## Usage

```typescript
// Authentication middleware (user-created)
const jwtAuth: FunctionMiddleware = async (c, next) => {
  const token = c.req.header('Authorization')?.replace('Bearer ', '');
  if (token) {
    const payload = await verifyJwt(token);
    setUser({ id: payload.sub, name: payload.name }, ['admin', 'user']);
  }
  await next();
};

// Controller with authorization
@Controller('/profile')
class ProfileController {
  @Authorized()
  @Get('/me')
  me(user = currentUser()) {
    return user;
  }

  @Authorized(['admin'])
  @Delete('/:id')
  remove(id = pathParam('id')) { ... }
}
```

## Test plan

- [x] Unit tests for `setUser`, `currentUser`, `currentRoles`
- [x] Integration tests for `@Authorized` decorator
- [x] All existing tests pass