### PR TITLE
fix(core): externalize valibot to avoid duplicate bundling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,12 +38,12 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
-    "hono": "4.12.16"
+    "hono": "4.12.16",
+    "valibot": "1.3.1"
   },
   "devDependencies": {
     "@needle-di/core": "1.1.2",
     "@types/node": "22.19.17",
-    "neverthrow": "8.2.0",
-    "valibot": "1.3.1"
+    "neverthrow": "8.2.0"
   }
 }

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   clean: true,
   fixedExtension: false,
   deps: {
-    neverBundle: ['hono', /^hono\//, /^@hono\//],
+    neverBundle: ['hono', /^hono\//, /^@hono\//, 'valibot'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       hono:
         specifier: 4.12.16
         version: 4.12.16
+      valibot:
+        specifier: 1.3.1
+        version: 1.3.1(typescript@6.0.2)
     devDependencies:
       '@needle-di/core':
         specifier: 1.1.2
@@ -141,9 +144,6 @@ importers:
       neverthrow:
         specifier: 8.2.0
         version: 8.2.0
-      valibot:
-        specifier: 1.3.1
-        version: 1.3.1(typescript@6.0.2)
 
   packages/testing:
     dependencies:


### PR DESCRIPTION
## Summary

- Move `valibot` from `devDependencies` to `dependencies` in `@zeltjs/core`
- Add `valibot` to `neverBundle` in tsdown config

## Why

Users define their own valibot schemas and import valibot directly. If core bundles valibot internally, it duplicates the dependency and increases bundle size. By externalizing, the user's single valibot installation is shared.

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Verified `dist/index.js` contains `import ... from "valibot"` (not bundled code)