### PR TITLE
ci: use paths_released from release-please for publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,8 +47,10 @@ jobs:
         run: pnpm build
 
       - name: Publish packages
+        env:
+          PATHS_RELEASED: ${{ needs.release-please.outputs.paths_released }}
         run: |
-          for pkg in packages/core packages/adapter-node packages/contract packages/testing; do
+          echo "$PATHS_RELEASED" | jq -r '.[]' | while read -r pkg; do
             echo "Publishing $pkg..."
             pnpm --filter "./$pkg" publish --access public --no-git-checks --provenance
           done


### PR DESCRIPTION
## Summary

- Use `paths_released` output from release-please instead of hardcoded package list
- release-please-config.json becomes the single source of truth for packages

## Before
```yaml
for pkg in packages/core packages/adapter-node packages/contract packages/testing; do
```

## After
```yaml
echo "$PATHS_RELEASED" | jq -r '.[]' | while read -r pkg; do
```