### PR TITLE
feat(core): add target parameter to validated() for form-data support

### DIFF
--- a/packages/contract/src/analyzer/handler.ts
+++ b/packages/contract/src/analyzer/handler.ts
@@ -1,8 +1,15 @@
 import { type CallExpression, type MethodDeclaration, Node, SyntaxKind } from 'ts-morph';
 
+export type ValidationTarget = 'json' | 'form';
+
 export type RequestSchemaRef =
-  | { kind: 'valibot-named'; readonly module: string; readonly exportName: string }
-  | { kind: 'valibot-inline'; readonly schemaText: string }
+  | {
+      kind: 'valibot-named';
+      readonly module: string;
+      readonly exportName: string;
+      readonly target: ValidationTarget;
+    }
+  | { kind: 'valibot-inline'; readonly schemaText: string; readonly target: ValidationTarget }
   | { kind: 'none' };
 
 export type HandlerSignatureInfo = {
@@ -45,7 +52,17 @@ const resolveSchemaModule = (expr: CallExpression, exportName: string): string |
   return undefined;
 };
 
+const extractTarget = (expr: CallExpression): ValidationTarget => {
+  const args = expr.getArguments();
+  const targetArg = args[1];
+  if (!targetArg) return 'json';
+  const text = targetArg.getText();
+  if (text === "'form'" || text === '"form"') return 'form';
+  return 'json';
+};
+
 const analyzeValidatedCall = (expr: CallExpression): RequestSchemaRef => {
+  const target = extractTarget(expr);
   const id = identifierArg(expr);
   if (id) {
     const module = resolveSchemaModule(expr, id.exportName);
@@ -54,10 +71,10 @@ const analyzeValidatedCall = (expr: CallExpression): RequestSchemaRef => {
         `zelt/openapi: cannot resolve module for validated(${id.exportName}). Schema must be a module-level export.`,
       );
     }
-    return { kind: 'valibot-named', module, exportName: id.exportName };
+    return { kind: 'valibot-named', module, exportName: id.exportName, target };
   }
   const arg = expr.getArguments()[0];
-  return { kind: 'valibot-inline', schemaText: arg?.getText() ?? '' };
+  return { kind: 'valibot-inline', schemaText: arg?.getText() ?? '', target };
 };
 
 export const analyzeHandlerSignature = (m: MethodDeclaration): HandlerSignatureInfo => {

--- a/packages/contract/src/emit/json-schema-input.ts
+++ b/packages/contract/src/emit/json-schema-input.ts
@@ -4,11 +4,16 @@ import { pathToFileURL } from 'node:url';
 import { toJsonSchema } from '@valibot/to-json-schema';
 import * as v from 'valibot';
 
-import type { RequestSchemaRef } from '../analyzer/handler';
+import type { RequestSchemaRef, ValidationTarget } from '../analyzer/handler';
 
 export type RequestSchemaJson =
-  | { kind: 'ref'; readonly name: string; readonly schema: unknown }
-  | { kind: 'inline'; readonly schema: unknown }
+  | {
+      kind: 'ref';
+      readonly name: string;
+      readonly schema: unknown;
+      readonly target: ValidationTarget;
+    }
+  | { kind: 'inline'; readonly schema: unknown; readonly target: ValidationTarget }
   | { kind: 'none' };
 
 type AnyValibotSchema = v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>;
@@ -65,5 +70,5 @@ export const resolveRequestSchema = async (ref: RequestSchemaRef): Promise<Reque
     );
   }
   const schema = narrowToValibotSchema(value);
-  return { kind: 'ref', name: ref.exportName, schema: toJsonSchema(schema) };
+  return { kind: 'ref', name: ref.exportName, schema: toJsonSchema(schema), target: ref.target };
 };

--- a/packages/contract/src/emit/openapi.ts
+++ b/packages/contract/src/emit/openapi.ts
@@ -29,13 +29,17 @@ const refTo = (name: string): { $ref: string } => ({
   $ref: `#/components/schemas/${name}`,
 });
 
+const targetToContentType = (target: 'json' | 'form'): string =>
+  target === 'form' ? 'multipart/form-data' : 'application/json';
+
 const buildRequestBody = (req: RequestSchemaJson, schemas: SchemaMap): Operation | undefined => {
   if (req.kind === 'none') return undefined;
+  const contentType = targetToContentType(req.target);
   if (req.kind === 'ref') {
     schemas[req.name] = req.schema;
-    return { required: true, content: { 'application/json': { schema: refTo(req.name) } } };
+    return { required: true, content: { [contentType]: { schema: refTo(req.name) } } };
   }
-  return { required: true, content: { 'application/json': { schema: req.schema } } };
+  return { required: true, content: { [contentType]: { schema: req.schema } } };
 };
 
 const buildPathParams = (

--- a/packages/contract/src/test/analyzer.test.ts
+++ b/packages/contract/src/test/analyzer.test.ts
@@ -6,6 +6,7 @@ import { analyzeControllers } from '../analyzer/internal-representation';
 import { createProject } from '../analyzer/project';
 
 const fixturePath = resolve(import.meta.dirname, 'fixtures/sample.controller.ts');
+const uploadFixturePath = resolve(import.meta.dirname, 'fixtures/upload.controller.ts');
 const tsConfigFilePath = resolve(import.meta.dirname, '../../tsconfig.json');
 
 describe('analyzeControllers', () => {
@@ -26,6 +27,7 @@ describe('analyzeControllers', () => {
       kind: 'valibot-named',
       module: fixturePath,
       exportName: 'CreateUserBody',
+      target: 'json',
     });
   });
 
@@ -40,5 +42,19 @@ describe('analyzeControllers', () => {
     if (show?.responseType.kind === 'ts-named') {
       expect(show.responseType.name).toBe('User');
     }
+  });
+
+  it('detects validated() with form target', () => {
+    const uploadProject = createProject({ tsConfigFilePath, controllerFiles: [uploadFixturePath] });
+    const uploadIr = analyzeControllers(uploadProject, [
+      { filePath: uploadFixturePath, exportName: 'UploadController' },
+    ]);
+    const upload = uploadIr[0]?.routes.find((r) => r.method === 'POST');
+    expect(upload?.requestSchema).toEqual({
+      kind: 'valibot-named',
+      module: uploadFixturePath,
+      exportName: 'UploadBody',
+      target: 'form',
+    });
   });
 });

--- a/packages/contract/src/test/fixtures/upload.controller.ts
+++ b/packages/contract/src/test/fixtures/upload.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Post, validated } from '@zeltjs/core';
+import * as v from 'valibot';
+
+export const UploadBody = v.object({
+  name: v.string(),
+  description: v.optional(v.string()),
+});
+export type UploadBody = v.InferOutput<typeof UploadBody>;
+
+export type UploadResult = {
+  success: boolean;
+  name: string;
+};
+
+@Controller('/upload')
+export class UploadController {
+  @Post('/')
+  async upload(body = validated(UploadBody, 'form')): Promise<UploadResult> {
+    return { success: true, name: body.name };
+  }
+}

--- a/packages/contract/src/test/openapi.test.ts
+++ b/packages/contract/src/test/openapi.test.ts
@@ -7,6 +7,7 @@ import { createProject } from '../analyzer/project';
 import { emitOpenApi } from '../emit/openapi';
 
 const fixturePath = resolve(import.meta.dirname, 'fixtures/sample.controller.ts');
+const uploadFixturePath = resolve(import.meta.dirname, 'fixtures/upload.controller.ts');
 const tsconfigPath = resolve(import.meta.dirname, '../../tsconfig.json');
 
 // These keys access Record<string, ...> index signatures.
@@ -108,5 +109,24 @@ describe('emitOpenApi', () => {
     expect(getOp?.[parametersKey]).toEqual([
       { in: 'path', name: 'id', required: true, schema: { type: 'string' } },
     ]);
+  });
+
+  it('emits multipart/form-data content-type for form target', async () => {
+    const project = createProject({
+      tsConfigFilePath: tsconfigPath,
+      controllerFiles: [uploadFixturePath],
+    });
+    const ir = analyzeControllers(project, [
+      { filePath: uploadFixturePath, exportName: 'UploadController' },
+    ]);
+    const doc = await emitOpenApi(ir, { distDir: '/tmp/generated', tsconfigPath });
+
+    const postOp = doc.paths['/upload']?.[postKey];
+    expect(postOp).toBeDefined();
+    const requestBody = postOp?.['requestBody'] as Record<string, unknown>;
+    expect(requestBody).toBeDefined();
+    const content = requestBody['content'] as Record<string, unknown>;
+    expect(content['multipart/form-data']).toBeDefined();
+    expect(content['application/json']).toBeUndefined();
   });
 });

--- a/packages/core/src/http/app.test.ts
+++ b/packages/core/src/http/app.test.ts
@@ -47,7 +47,22 @@ class EchoController {
   }
 }
 
-const buildApp = () => createHttpApp({ controllers: [HelloController, EchoController] });
+const FileSchema = v.object({
+  description: v.string(),
+  file: v.instance(File),
+});
+
+@Controller('/upload')
+class UploadController {
+  @Post('/')
+  upload() {
+    const body = validated(FileSchema, 'form');
+    return { description: body.description, filename: body.file.name, size: body.file.size };
+  }
+}
+
+const buildApp = () =>
+  createHttpApp({ controllers: [HelloController, EchoController, UploadController] });
 
 describe('createHttpApp() — fetch', () => {
   it('serves a constructor-injected GET endpoint with pathParam', async () => {
@@ -68,6 +83,22 @@ describe('createHttpApp() — fetch', () => {
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ msg: 'ok' });
+  });
+
+  it('parses multipart/form-data with File via validated(schema, "form")', async () => {
+    const app = buildApp();
+    const formData = new FormData();
+    formData.append('description', 'test file');
+    formData.append('file', new File(['hello world'], 'test.txt', { type: 'text/plain' }));
+
+    const res = await app.fetch(
+      new Request('https://example.com/upload/', {
+        method: 'POST',
+        body: formData,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ description: 'test file', filename: 'test.txt', size: 11 });
   });
 
   it('mounts multiple controllers under different base paths', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,7 +37,13 @@ export { pathParam } from './primitives/path-param';
 export { response } from './primitives/response';
 export type { ResponseBuilder } from './primitives/response';
 export { validated } from './primitives/validated';
-export type { ValidatedMarker, ExtractValidated, IsValidated } from './primitives/validated';
+export type {
+  ValidatedMarker,
+  ExtractValidated,
+  ExtractValidationTarget,
+  IsValidated,
+  ValidationTarget,
+} from './primitives/validated';
 
 export { Config, injectConfig } from './config';
 export type { ConfigClass } from './config';

--- a/packages/core/src/internal/entry-context.test.ts
+++ b/packages/core/src/internal/entry-context.test.ts
@@ -6,7 +6,7 @@ import { getEntryContext, runInEntryContext, type EntryContext } from './entry-c
 describe('entry-context', () => {
   it('returns the running context inside runInEntryContext', () => {
     const ctx: EntryContext = {
-      input: { body: { hello: 'world' }, pathParams: {} },
+      input: { jsonBody: { hello: 'world' }, formBody: undefined, pathParams: {} },
       honoContext: {} as unknown as Context,
     };
     const got = runInEntryContext(ctx, () => getEntryContext());
@@ -19,19 +19,19 @@ describe('entry-context', () => {
 
   it('isolates concurrent contexts', async () => {
     const ctxA: EntryContext = {
-      input: { body: 'A', pathParams: {} },
+      input: { jsonBody: 'A', formBody: undefined, pathParams: {} },
       honoContext: {} as unknown as Context,
     };
     const ctxB: EntryContext = {
-      input: { body: 'B', pathParams: {} },
+      input: { jsonBody: 'B', formBody: undefined, pathParams: {} },
       honoContext: {} as unknown as Context,
     };
     const [a, b] = await Promise.all([
       runInEntryContext(ctxA, async () => {
         await new Promise((r) => setTimeout(r, 10));
-        return getEntryContext().input.body;
+        return getEntryContext().input.jsonBody;
       }),
-      runInEntryContext(ctxB, async () => getEntryContext().input.body),
+      runInEntryContext(ctxB, async () => getEntryContext().input.jsonBody),
     ]);
     expect(a).toBe('A');
     expect(b).toBe('B');

--- a/packages/core/src/internal/entry-context.ts
+++ b/packages/core/src/internal/entry-context.ts
@@ -2,8 +2,11 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { Context } from 'hono';
 
+type FormBody = Record<string, string | File | (string | File)[]>;
+
 type EntryInput = {
-  readonly body: unknown;
+  readonly jsonBody: unknown;
+  readonly formBody: FormBody | undefined;
   readonly pathParams: Readonly<Record<string, string>>;
 };
 

--- a/packages/core/src/internal/route-builder.ts
+++ b/packages/core/src/internal/route-builder.ts
@@ -73,10 +73,32 @@ const resolveHandler = (instance: object, methodName: string | symbol): (() => u
   };
 };
 
-const parseRequestBody = async (c: Parameters<Parameters<Hono['on']>[2]>[0]): Promise<unknown> => {
-  const contentType = c.req.header('content-type');
-  if (contentType?.includes('application/json') !== true) return undefined;
-  return c.req.json<unknown>().catch(() => undefined);
+type FormBody = Record<string, string | File | (string | File)[]>;
+
+type ParsedBodies = {
+  jsonBody: unknown;
+  formBody: FormBody | undefined;
+};
+
+const parseRequestBodies = async (
+  c: Parameters<Parameters<Hono['on']>[2]>[0],
+): Promise<ParsedBodies> => {
+  const contentType = c.req.header('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    const jsonBody = await c.req.json<unknown>().catch(() => undefined);
+    return { jsonBody, formBody: undefined };
+  }
+
+  if (
+    contentType.includes('multipart/form-data') ||
+    contentType.includes('application/x-www-form-urlencoded')
+  ) {
+    const formBody: FormBody = await c.req.parseBody({ all: true }).catch(() => ({}));
+    return { jsonBody: undefined, formBody };
+  }
+
+  return { jsonBody: undefined, formBody: undefined };
 };
 
 const hasUseMethod = (proto: unknown): boolean => {
@@ -217,9 +239,9 @@ const registerRoute = (
   const composedHandler = composeHandler(middlewares, finalHandler);
 
   const handler = async (c: MiddlewareContext): Promise<Response> => {
-    const body = await parseRequestBody(c);
+    const { jsonBody, formBody } = await parseRequestBodies(c);
     const pathParams: Readonly<Record<string, string>> = c.req.param();
-    return runInEntryContext({ input: { body, pathParams }, honoContext: c }, () =>
+    return runInEntryContext({ input: { jsonBody, formBody, pathParams }, honoContext: c }, () =>
       composedHandler(c),
     );
   };

--- a/packages/core/src/primitives/auth.test.ts
+++ b/packages/core/src/primitives/auth.test.ts
@@ -8,7 +8,7 @@ import { setUser, currentUser, currentRoles } from './auth';
 const createMockEntryContext = (): EntryContext => {
   const store: Record<string, unknown> = {};
   return {
-    input: { body: {}, pathParams: {} },
+    input: { jsonBody: {}, formBody: undefined, pathParams: {} },
     honoContext: {
       get: (key: string) => store[key],
       set: (key: string, value: unknown) => {

--- a/packages/core/src/primitives/get-context.test.ts
+++ b/packages/core/src/primitives/get-context.test.ts
@@ -12,7 +12,7 @@ declare module '@zeltjs/core' {
 }
 
 const createMockEntryContext = (contextValues: Record<string, unknown> = {}): EntryContext => ({
-  input: { body: {}, pathParams: {} },
+  input: { jsonBody: {}, formBody: undefined, pathParams: {} },
   honoContext: {
     get: (key: string) => contextValues[key],
     set: vi.fn(),

--- a/packages/core/src/primitives/path-param.test.ts
+++ b/packages/core/src/primitives/path-param.test.ts
@@ -9,7 +9,7 @@ describe('pathParam()', () => {
   it('returns the path param value', () => {
     const result = runInEntryContext(
       {
-        input: { body: undefined, pathParams: { id: '42' } },
+        input: { jsonBody: undefined, formBody: undefined, pathParams: { id: '42' } },
         honoContext: {} as unknown as Context,
       },
       () => pathParam('id'),
@@ -20,7 +20,10 @@ describe('pathParam()', () => {
   it('throws when the path param is absent', () => {
     expect(() =>
       runInEntryContext(
-        { input: { body: undefined, pathParams: {} }, honoContext: {} as unknown as Context },
+        {
+          input: { jsonBody: undefined, formBody: undefined, pathParams: {} },
+          honoContext: {} as unknown as Context,
+        },
         () => pathParam('id'),
       ),
     ).toThrow(/path parameter "id" is not defined/);

--- a/packages/core/src/primitives/validated.test.ts
+++ b/packages/core/src/primitives/validated.test.ts
@@ -10,10 +10,10 @@ import { validated } from './validated';
 const Schema = v.object({ name: v.string(), age: v.number() });
 
 describe('validated()', () => {
-  it('returns parsed body when schema matches', () => {
+  it('returns parsed body when schema matches (json)', () => {
     const result = runInEntryContext(
       {
-        input: { body: { name: 'Ada', age: 36 }, pathParams: {} },
+        input: { jsonBody: { name: 'Ada', age: 36 }, formBody: undefined, pathParams: {} },
         honoContext: {} as unknown as Context,
       },
       () => validated(Schema),
@@ -21,10 +21,25 @@ describe('validated()', () => {
     expect(result).toEqual({ name: 'Ada', age: 36 });
   });
 
+  it('returns parsed body when schema matches (form)', () => {
+    const FormSchema = v.object({ name: v.string() });
+    const result = runInEntryContext(
+      {
+        input: { jsonBody: undefined, formBody: { name: 'Ada' }, pathParams: {} },
+        honoContext: {} as unknown as Context,
+      },
+      () => validated(FormSchema, 'form'),
+    );
+    expect(result).toEqual({ name: 'Ada' });
+  });
+
   it('throws HTTPException with 400 when schema does not match', () => {
     expect(() =>
       runInEntryContext(
-        { input: { body: { name: 'Ada' }, pathParams: {} }, honoContext: {} as unknown as Context },
+        {
+          input: { jsonBody: { name: 'Ada' }, formBody: undefined, pathParams: {} },
+          honoContext: {} as unknown as Context,
+        },
         () => validated(Schema),
       ),
     ).toThrow(HTTPException);
@@ -33,7 +48,10 @@ describe('validated()', () => {
   it('HTTPException contains VALIDATION_FAILED response', async () => {
     try {
       runInEntryContext(
-        { input: { body: { name: 'Ada' }, pathParams: {} }, honoContext: {} as unknown as Context },
+        {
+          input: { jsonBody: { name: 'Ada' }, formBody: undefined, pathParams: {} },
+          honoContext: {} as unknown as Context,
+        },
         () => validated(Schema),
       );
       throw new Error('should have thrown');

--- a/packages/core/src/primitives/validated.ts
+++ b/packages/core/src/primitives/validated.ts
@@ -3,37 +3,44 @@ import { safeParse, type GenericSchema, type InferOutput } from 'valibot';
 
 import { getEntryContext } from '../internal/entry-context';
 
-// 型レベル marker。@zeltjs/openapi が handler signature から validated() 引数を検出するために使う。
-// runtime 値は parse 結果そのもので、brand は phantom (compile time only)。
-declare const __zeltValidatedBrand: unique symbol;
-// __zeltValidatedType は T を phantom field として保持し、conditional type の infer で
-// 自己参照交差型を避けて安全に T を取り出せるようにするためのタグ。
-declare const __zeltValidatedType: unique symbol;
+export type ValidationTarget = 'json' | 'form';
 
-export type ValidatedMarker<T> = T & {
+declare const __zeltValidatedBrand: unique symbol;
+declare const __zeltValidatedType: unique symbol;
+declare const __zeltValidatedTarget: unique symbol;
+
+export type ValidatedMarker<T, Target extends ValidationTarget = 'json'> = T & {
   [__zeltValidatedBrand]: true;
   [__zeltValidatedType]: T;
+  [__zeltValidatedTarget]: Target;
 };
 
-// Extracts T from ValidatedMarker<T> by reading the phantom [__zeltValidatedType] key.
-// Defined in @zeltjs/core (same module as the symbols) so that the lookup is a simple
-// property access, avoiding complex cross-module conditional type inference.
 export type ExtractValidated<H> =
   NonNullable<H> extends Record<typeof __zeltValidatedType, infer T> ? T : never;
 
-// Returns true if NonNullable<H> contains the [__zeltValidatedBrand] marker.
+export type ExtractValidationTarget<H> =
+  NonNullable<H> extends Record<typeof __zeltValidatedTarget, infer T extends ValidationTarget>
+    ? T
+    : 'json';
+
 export type IsValidated<H> =
   NonNullable<H> extends Record<typeof __zeltValidatedBrand, true> ? true : false;
 
-// Public overload returns the branded type so contract analyzer can detect it.
-// Implementation signature returns the underlying parsed value; the brand is
-// erased at runtime (it's a phantom optional symbol field).
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
-): ValidatedMarker<InferOutput<Schema>>;
-export function validated<Schema extends GenericSchema>(schema: Schema): InferOutput<Schema> {
+  target?: 'json',
+): ValidatedMarker<InferOutput<Schema>, 'json'>;
+export function validated<Schema extends GenericSchema>(
+  schema: Schema,
+  target: 'form',
+): ValidatedMarker<InferOutput<Schema>, 'form'>;
+export function validated<Schema extends GenericSchema>(
+  schema: Schema,
+  target: ValidationTarget = 'json',
+): InferOutput<Schema> {
   const ctx = getEntryContext();
-  const result = safeParse(schema, ctx.input.body);
+  const body = target === 'json' ? ctx.input.jsonBody : ctx.input.formBody;
+  const result = safeParse(schema, body);
   if (!result.success) {
     throw new HTTPException(400, {
       res: Response.json({ code: 'VALIDATION_FAILED', issues: result.issues }, { status: 400 }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,12 +200,6 @@ importers:
         specifier: '>=4 <5'
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
-  packages/zeltjs:
-    dependencies:
-      '@zeltjs/core':
-        specifier: '>=0.0.1'
-        version: 0.1.1(typescript@6.0.2)
-
   website:
     dependencies:
       '@docusaurus/core':
@@ -3353,9 +3347,6 @@ packages:
   '@yarnpkg/parsers@3.0.2':
     resolution: {integrity: sha512-/HcYgtUSiJiot/XWGLOlGxPYUG65+/31V8oqk17vZLW1xlCoR4PampyePljOxY2n8/3jz9+tIFzICsyGujJZoA==}
     engines: {node: '>=18.12.0'}
-
-  '@zeltjs/core@0.1.1':
-    resolution: {integrity: sha512-GKTuDOMuD9NUmLyEXdg9gzco185hV5tU7Xk5EXgrb3JB6wJ47dZYAZywVA9uNlD6taD5OyHvO4eUVgyAdPEAaQ==}
 
   '@zkochan/js-yaml@0.0.7':
     resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
@@ -11388,15 +11379,6 @@ snapshots:
     dependencies:
       js-yaml: 3.14.2
       tslib: 2.8.1
-
-  '@zeltjs/core@0.1.1(typescript@6.0.2)':
-    dependencies:
-      '@needle-di/core': 1.1.2
-      hono: 4.12.16
-      neverthrow: 8.2.0
-      valibot: 1.3.1(typescript@6.0.2)
-    transitivePeerDependencies:
-      - typescript
 
   '@zkochan/js-yaml@0.0.7':
     dependencies:

--- a/website/docs/validation.md
+++ b/website/docs/validation.md
@@ -30,6 +30,69 @@ export class UserController {
 }
 ```
 
+## Form Data and File Uploads
+
+Use `validated(schema, 'form')` to validate `multipart/form-data` requests, including file uploads:
+
+```typescript
+import { Controller, Post, validated, response } from '@zeltjs/core';
+import * as v from 'valibot';
+
+const UploadSchema = v.object({
+  file: v.instance(File),
+  description: v.optional(v.string()),
+});
+
+@Controller('/upload')
+export class UploadController {
+  @Post('/')
+  upload(body = validated(UploadSchema, 'form'), res = response()) {
+    // body.file is a File object
+    console.log(body.file.name, body.file.size, body.file.type);
+    return res.json({ filename: body.file.name, size: body.file.size }, 201);
+  }
+}
+```
+
+### Target Options
+
+The second argument to `validated()` specifies the request body format:
+
+| Target | Content-Type | Use Case |
+|--------|-------------|----------|
+| `'json'` (default) | `application/json` | JSON API requests |
+| `'form'` | `multipart/form-data`, `application/x-www-form-urlencoded` | File uploads, HTML forms |
+
+### Multiple Files
+
+```typescript
+const MultiUploadSchema = v.object({
+  files: v.array(v.instance(File)),
+  category: v.string(),
+});
+
+@Post('/bulk')
+bulkUpload(body = validated(MultiUploadSchema, 'form')) {
+  for (const file of body.files) {
+    console.log(file.name);
+  }
+  return { count: body.files.length };
+}
+```
+
+### OpenAPI Generation
+
+When using `'form'` target, OpenAPI output automatically uses `multipart/form-data` as the content type:
+
+```yaml
+requestBody:
+  required: true
+  content:
+    multipart/form-data:
+      schema:
+        $ref: '#/components/schemas/UploadSchema'
+```
+
 ## Validation Error Response
 
 When validation fails, Zelt automatically returns a 400 response:


### PR DESCRIPTION
## Summary

- Add second argument `target` to `validated(schema, target?)` function
- `'json'` (default): parses `application/json` request body
- `'form'`: parses `multipart/form-data` and `application/x-www-form-urlencoded`, enabling file uploads
- OpenAPI generation outputs correct content-type based on target

## Usage

```typescript
// JSON (default)
body = validated(CreateUserSchema)
body = validated(CreateUserSchema, 'json')

// Form data with file upload
const UploadSchema = v.object({
  file: v.instance(File),
  description: v.optional(v.string()),
});

@Post('/upload')
upload(body = validated(UploadSchema, 'form')) {
  console.log(body.file.name, body.file.size);
}
```

## Changes

- `packages/core/src/primitives/validated.ts` - Add target parameter and type exports
- `packages/core/src/internal/route-builder.ts` - Parse both JSON and form-data
- `packages/core/src/internal/entry-context.ts` - Split body into jsonBody/formBody
- `packages/contract/src/analyzer/handler.ts` - Extract target from static analysis
- `packages/contract/src/emit/openapi.ts` - Output multipart/form-data for form target
- `website/docs/validation.md` - Document form-data and file upload usage

## Test plan

- [x] Unit tests for validated() with form target
- [x] E2E test for multipart/form-data with File object
- [x] OpenAPI generation test for multipart/form-data content-type
- [x] All existing tests pass