### PR TITLE
feat: add @zeltjs/auth-jwt package

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -104,7 +104,7 @@ export default tseslint.config(
   },
   {
     // framework error strategy: throw + global error handler (spec §4.9 / koya phase2)
-    files: ['packages/core/src/**/*.{ts,tsx}'],
+    files: ['packages/core/src/**/*.{ts,tsx}', 'packages/auth-jwt/src/**/*.{ts,tsx}'],
     rules: {
       '@9wick/strict-type-rules/no-throw': 'off',
       '@9wick/strict-type-rules/no-try-catch': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,7 @@ export default tseslint.config(
   ...strictTypes.configs.barrel,
   {
     files: ['**/*.*.{ts,tsx}'],
-    ignores: ['**/*.lib.{ts,tsx}'],
+    ignores: ['**/*.lib.{ts,tsx}', '**/*.types.{ts,tsx}'],
     rules: {
       '@9wick/strict-type-rules/nestjs-like-di-for-needle-di': [
         'error',
@@ -104,7 +104,7 @@ export default tseslint.config(
   },
   {
     // framework error strategy: throw + global error handler (spec §4.9 / koya phase2)
-    files: ['packages/core/src/**/*.{ts,tsx}', 'packages/auth-jwt/src/**/*.{ts,tsx}'],
+    files: ['packages/core/src/**/*.{ts,tsx}'],
     rules: {
       '@9wick/strict-type-rules/no-throw': 'off',
       '@9wick/strict-type-rules/no-try-catch': 'off',
@@ -176,13 +176,6 @@ export default tseslint.config(
     },
   },
   {
-    // *.types.ts files are pure type declaration files and cannot export @injectable() classes.
-    files: ['**/*.types.ts'],
-    rules: {
-      '@9wick/strict-type-rules/nestjs-like-di-for-needle-di': 'off',
-    },
-  },
-  {
     // Example apps: relaxed rules for demo code clarity
     // - HTTPException requires throw
     // - raw fetch returns untyped JSON
@@ -193,6 +186,13 @@ export default tseslint.config(
       '@9wick/strict-type-rules/nestjs-like-di-for-needle-di': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       'max-lines-per-function': 'off',
+    },
+  },
+  {
+    // *.types.ts files are pure type declaration files and cannot export @injectable() classes.
+    files: ['**/*.types.ts'],
+    rules: {
+      '@9wick/strict-type-rules/nestjs-like-di-for-needle-di': 'off',
     },
   },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -175,4 +175,11 @@ export default tseslint.config(
       '@9wick/strict-type-rules/no-process-access': 'off',
     },
   },
+  {
+    // *.types.ts files are pure type declaration files and cannot export @injectable() classes.
+    files: ['**/*.types.ts'],
+    rules: {
+      '@9wick/strict-type-rules/nestjs-like-di-for-needle-di': 'off',
+    },
+  },
 );

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -29,8 +29,7 @@
     "@zeltjs/core": "workspace:*"
   },
   "dependencies": {
-    "jose": "6.0.11",
-    "neverthrow": "8.2.0"
+    "jose": "6.0.11"
   },
   "devDependencies": {
     "@needle-di/core": "1.1.2",

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -29,7 +29,8 @@
     "@zeltjs/core": "workspace:*"
   },
   "dependencies": {
-    "jose": "6.0.11"
+    "jose": "6.0.11",
+    "neverthrow": "8.2.0"
   },
   "devDependencies": {
     "@needle-di/core": "1.1.2",

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@needle-di/core": "1.1.2",
     "@types/node": "22.19.17",
-    "@zeltjs/core": "workspace:*",
-    "hono": "4.12.16"
+    "@zeltjs/core": "workspace:*"
   }
 }

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@zeltjs/auth-jwt",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zeltjs/zelt.git",
+    "directory": "packages/auth-jwt"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run",
+    "typecheck": "tsc -b"
+  },
+  "peerDependencies": {
+    "@zeltjs/core": "workspace:*"
+  },
+  "dependencies": {
+    "jose": "6.0.11"
+  },
+  "devDependencies": {
+    "@zeltjs/core": "workspace:*",
+    "@types/node": "22.19.17",
+    "hono": "4.12.16"
+  }
+}

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -29,12 +29,13 @@
     "@zeltjs/core": "workspace:*"
   },
   "dependencies": {
-    "jose": "6.0.11"
+    "jose": "6.0.11",
+    "neverthrow": "8.2.0"
   },
   "devDependencies": {
     "@needle-di/core": "1.1.2",
-    "@zeltjs/core": "workspace:*",
     "@types/node": "22.19.17",
+    "@zeltjs/core": "workspace:*",
     "hono": "4.12.16"
   }
 }

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -17,7 +17,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsdown",
     "test": "vitest run",
@@ -30,6 +32,7 @@
     "jose": "6.0.11"
   },
   "devDependencies": {
+    "@needle-di/core": "1.1.2",
     "@zeltjs/core": "workspace:*",
     "@types/node": "22.19.17",
     "hono": "4.12.16"

--- a/packages/auth-jwt/src/index.ts
+++ b/packages/auth-jwt/src/index.ts
@@ -1,4 +1,5 @@
 export { JwtConfig } from './jwt.config';
+export type { ResolveUserResult } from './jwt.config';
 export { JwtService } from './jwt.service';
 export { JwtMiddleware } from './jwt.middleware';
 export type { JwtPayload } from './jwt.types';

--- a/packages/auth-jwt/src/index.ts
+++ b/packages/auth-jwt/src/index.ts
@@ -1,0 +1,4 @@
+export { JwtConfig } from './jwt.config';
+export { JwtService } from './jwt.service';
+export { JwtMiddleware } from './jwt.middleware';
+export type { JwtPayload } from './jwt.types';

--- a/packages/auth-jwt/src/jwt.config.ts
+++ b/packages/auth-jwt/src/jwt.config.ts
@@ -1,0 +1,33 @@
+import { Config } from '@zeltjs/core';
+import type { RequestContextSchema } from '@zeltjs/core';
+
+import type { JwtPayload } from './jwt.types';
+
+export interface ResolveUserResult {
+  user: RequestContextSchema['user'];
+  roles: RequestContextSchema['authRoles'];
+}
+
+@Config
+export class JwtConfig {
+  static readonly Token = JwtConfig;
+
+  get secret(): string {
+    const secret = process.env['JWT_SECRET'];
+    if (!secret) {
+      throw new Error('JWT_SECRET environment variable is required');
+    }
+    return secret;
+  }
+
+  get expiresIn(): string {
+    return '1h';
+  }
+
+  get resolveUser(): (payload: JwtPayload) => Promise<ResolveUserResult> {
+    return async (payload) => ({
+      user: payload.sub,
+      roles: [],
+    });
+  }
+}

--- a/packages/auth-jwt/src/jwt.middleware.test.ts
+++ b/packages/auth-jwt/src/jwt.middleware.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { Hono } from 'hono';
+import { describe, it, expect } from 'vitest';
 import { Container } from '@needle-di/core';
-import type { RequestContext, Next } from '@zeltjs/core';
+import {
+  Controller,
+  Get,
+  UseMiddleware,
+  createHttpApp,
+  currentUser,
+  currentRoles,
+} from '@zeltjs/core';
 
 import { JwtMiddleware } from './jwt.middleware';
 import { JwtService } from './jwt.service';
@@ -21,30 +27,36 @@ class TestJwtConfig extends JwtConfig {
   }
 }
 
-describe('JwtMiddleware', () => {
-  let app: Hono;
-  let jwtService: JwtService;
-  let middleware: JwtMiddleware;
+@Controller('/protected')
+@UseMiddleware(JwtMiddleware)
+class ProtectedController {
+  @Get('/')
+  get() {
+    return { message: 'success' };
+  }
+}
 
-  beforeEach(() => {
-    const container = new Container();
-    container.bind({ provide: JwtConfig.Token, useClass: TestJwtConfig });
-    jwtService = container.get(JwtService);
-    middleware = container.get(JwtMiddleware);
-
-    app = new Hono();
-    app.use('/*', (c, next) => middleware.use(c as RequestContext, next as Next));
-    app.get('/protected', (c) => c.json({ message: 'success' }));
+const buildApp = () =>
+  createHttpApp({
+    controllers: [ProtectedController],
+    configs: [TestJwtConfig],
   });
 
+const buildJwtService = () => {
+  const container = new Container();
+  container.bind({ provide: JwtConfig.Token, useClass: TestJwtConfig });
+  return container.get(JwtService);
+};
+
+describe('JwtMiddleware', () => {
   it('should return 401 when no Authorization header', async () => {
-    const res = await app.request('/protected');
+    const res = await buildApp().request('/protected/');
 
     expect(res.status).toBe(401);
   });
 
   it('should return 401 when Authorization header is not Bearer', async () => {
-    const res = await app.request('/protected', {
+    const res = await buildApp().request('/protected/', {
       headers: { Authorization: 'Basic abc123' },
     });
 
@@ -52,7 +64,7 @@ describe('JwtMiddleware', () => {
   });
 
   it('should return 401 when token is invalid', async () => {
-    const res = await app.request('/protected', {
+    const res = await buildApp().request('/protected/', {
       headers: { Authorization: 'Bearer invalid-token' },
     });
 
@@ -60,8 +72,9 @@ describe('JwtMiddleware', () => {
   });
 
   it('should allow request with valid token', async () => {
+    const jwtService = buildJwtService();
     const token = await jwtService.sign({ sub: 'user-123' });
-    const res = await app.request('/protected', {
+    const res = await buildApp().request('/protected/', {
       headers: { Authorization: `Bearer ${token}` },
     });
 
@@ -86,10 +99,44 @@ describe('JwtMiddleware', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    const res = await app.request('/protected', {
+    const res = await buildApp().request('/protected/', {
       headers: { Authorization: `Bearer ${token}` },
     });
 
     expect(res.status).toBe(401);
+  });
+});
+
+describe('JwtMiddleware — setUser integration', () => {
+  it('should expose currentUser and currentRoles after middleware runs', async () => {
+    let capturedUser: unknown;
+    let capturedRoles: string[] = [];
+
+    @Controller('/user-check')
+    @UseMiddleware(JwtMiddleware)
+    class UserCheckController {
+      @Get('/')
+      get() {
+        capturedUser = currentUser();
+        capturedRoles = currentRoles();
+        return { ok: true };
+      }
+    }
+
+    const httpApp = createHttpApp({
+      controllers: [UserCheckController],
+      configs: [TestJwtConfig],
+    });
+
+    const jwtService = buildJwtService();
+    const token = await jwtService.sign({ sub: 'user-42' });
+
+    const res = await httpApp.request('/user-check/', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedUser).toBe('user-42');
+    expect(capturedRoles).toEqual(['user', 'admin']);
   });
 });

--- a/packages/auth-jwt/src/jwt.middleware.test.ts
+++ b/packages/auth-jwt/src/jwt.middleware.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { Container } from '@needle-di/core';
+import type { RequestContext, Next } from '@zeltjs/core';
+
+import { JwtMiddleware } from './jwt.middleware';
+import { JwtService } from './jwt.service';
+import { JwtConfig } from './jwt.config';
+import type { JwtPayload } from './jwt.types';
+
+class TestJwtConfig extends JwtConfig {
+  override get secret(): string {
+    return 'test-secret-key-for-testing-only';
+  }
+
+  override get resolveUser() {
+    return async (payload: JwtPayload) => ({
+      user: payload.sub,
+      roles: ['user', 'admin'] as string[],
+    });
+  }
+}
+
+describe('JwtMiddleware', () => {
+  let app: Hono;
+  let jwtService: JwtService;
+  let middleware: JwtMiddleware;
+
+  beforeEach(() => {
+    const container = new Container();
+    container.bind({ provide: JwtConfig.Token, useClass: TestJwtConfig });
+    jwtService = container.get(JwtService);
+    middleware = container.get(JwtMiddleware);
+
+    app = new Hono();
+    app.use('/*', (c, next) => middleware.use(c as RequestContext, next as Next));
+    app.get('/protected', (c) => c.json({ message: 'success' }));
+  });
+
+  it('should return 401 when no Authorization header', async () => {
+    const res = await app.request('/protected');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 401 when Authorization header is not Bearer', async () => {
+    const res = await app.request('/protected', {
+      headers: { Authorization: 'Basic abc123' },
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 401 when token is invalid', async () => {
+    const res = await app.request('/protected', {
+      headers: { Authorization: 'Bearer invalid-token' },
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should allow request with valid token', async () => {
+    const token = await jwtService.sign({ sub: 'user-123' });
+    const res = await app.request('/protected', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toBe('success');
+  });
+
+  it('should return 401 for expired token', async () => {
+    const expiredContainer = new Container();
+    class ExpiredConfig extends JwtConfig {
+      override get secret(): string {
+        return 'test-secret-key-for-testing-only';
+      }
+      override get expiresIn(): string {
+        return '0s';
+      }
+    }
+    expiredContainer.bind({ provide: JwtConfig.Token, useClass: ExpiredConfig });
+    const expiredJwtService = expiredContainer.get(JwtService);
+    const token = await expiredJwtService.sign({ sub: 'user-123' });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const res = await app.request('/protected', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/auth-jwt/src/jwt.middleware.ts
+++ b/packages/auth-jwt/src/jwt.middleware.ts
@@ -1,13 +1,13 @@
-import { Injectable, injectConfig } from '@zeltjs/core';
+import { Middleware, inject, injectConfig, setUser } from '@zeltjs/core';
 import type { RequestContext, Next } from '@zeltjs/core';
 
 import { JwtConfig } from './jwt.config';
 import { JwtService } from './jwt.service';
 
-@Injectable()
+@Middleware
 export class JwtMiddleware {
   constructor(
-    private readonly jwtService = new JwtService(injectConfig(JwtConfig)),
+    private readonly jwtService = inject(JwtService),
     private readonly config = injectConfig(JwtConfig),
   ) {}
 
@@ -28,7 +28,8 @@ export class JwtMiddleware {
       return c.json({ error: 'Unauthorized' }, 401);
     }
 
-    await this.config.resolveUser(verified.payload);
+    const { user, roles } = await this.config.resolveUser(verified.payload);
+    setUser(user, roles);
     await next();
     return undefined;
   }

--- a/packages/auth-jwt/src/jwt.middleware.ts
+++ b/packages/auth-jwt/src/jwt.middleware.ts
@@ -1,0 +1,35 @@
+import { Injectable, injectConfig } from '@zeltjs/core';
+import type { RequestContext, Next } from '@zeltjs/core';
+
+import { JwtConfig } from './jwt.config';
+import { JwtService } from './jwt.service';
+
+@Injectable()
+export class JwtMiddleware {
+  constructor(
+    private readonly jwtService = new JwtService(injectConfig(JwtConfig)),
+    private readonly config = injectConfig(JwtConfig),
+  ) {}
+
+  async use(c: RequestContext, next: Next): Promise<Response | undefined> {
+    const authHeader = c.req.header('Authorization');
+
+    if (!authHeader?.startsWith('Bearer ')) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const token = authHeader.slice(7);
+    const verified = await this.jwtService.verify(token).then(
+      (payload) => ({ ok: true as const, payload }),
+      () => ({ ok: false as const }),
+    );
+
+    if (!verified.ok) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    await this.config.resolveUser(verified.payload);
+    await next();
+    return undefined;
+  }
+}

--- a/packages/auth-jwt/src/jwt.service.test.ts
+++ b/packages/auth-jwt/src/jwt.service.test.ts
@@ -39,7 +39,7 @@ describe('JwtService', () => {
       const payload = await jwtService.verify(token);
 
       expect(payload.sub).toBe('user-123');
-      expect(payload.customClaim).toBe('value');
+      expect(payload['customClaim']).toBe('value');
       expect(payload.iat).toBeDefined();
       expect(payload.exp).toBeDefined();
     });
@@ -50,7 +50,7 @@ describe('JwtService', () => {
 
     it('should throw error for tampered token', async () => {
       const token = await jwtService.sign({ sub: 'user-123' });
-      const tamperedToken = token.slice(0, -5) + 'xxxxx';
+      const tamperedToken = `${token.slice(0, -5)}xxxxx`;
 
       await expect(jwtService.verify(tamperedToken)).rejects.toThrow();
     });

--- a/packages/auth-jwt/src/jwt.service.test.ts
+++ b/packages/auth-jwt/src/jwt.service.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Container } from '@needle-di/core';
+
+import { JwtService } from './jwt.service';
+import { JwtConfig } from './jwt.config';
+
+class TestJwtConfig extends JwtConfig {
+  override get secret(): string {
+    return 'test-secret-key-for-testing-only';
+  }
+
+  override get expiresIn(): string {
+    return '1h';
+  }
+}
+
+describe('JwtService', () => {
+  let jwtService: JwtService;
+
+  beforeEach(() => {
+    const container = new Container();
+    container.bind({ provide: JwtConfig.Token, useClass: TestJwtConfig });
+    jwtService = container.get(JwtService);
+  });
+
+  describe('sign', () => {
+    it('should generate a valid JWT token', async () => {
+      const token = await jwtService.sign({ sub: 'user-123' });
+
+      expect(token).toBeDefined();
+      expect(typeof token).toBe('string');
+      expect(token.split('.')).toHaveLength(3);
+    });
+  });
+
+  describe('verify', () => {
+    it('should verify and return payload for valid token', async () => {
+      const token = await jwtService.sign({ sub: 'user-123', customClaim: 'value' });
+      const payload = await jwtService.verify(token);
+
+      expect(payload.sub).toBe('user-123');
+      expect(payload.customClaim).toBe('value');
+      expect(payload.iat).toBeDefined();
+      expect(payload.exp).toBeDefined();
+    });
+
+    it('should throw error for invalid token', async () => {
+      await expect(jwtService.verify('invalid-token')).rejects.toThrow();
+    });
+
+    it('should throw error for tampered token', async () => {
+      const token = await jwtService.sign({ sub: 'user-123' });
+      const tamperedToken = token.slice(0, -5) + 'xxxxx';
+
+      await expect(jwtService.verify(tamperedToken)).rejects.toThrow();
+    });
+  });
+
+  describe('decode', () => {
+    it('should decode token without verification', async () => {
+      const token = await jwtService.sign({ sub: 'user-123' });
+      const payload = jwtService.decode(token);
+
+      expect(payload).not.toBeNull();
+      expect(payload?.sub).toBe('user-123');
+    });
+
+    it('should return null for invalid token', () => {
+      const payload = jwtService.decode('not-a-valid-jwt');
+
+      expect(payload).toBeNull();
+    });
+  });
+});

--- a/packages/auth-jwt/src/jwt.service.ts
+++ b/packages/auth-jwt/src/jwt.service.ts
@@ -1,5 +1,4 @@
 import { SignJWT, jwtVerify, decodeJwt } from 'jose';
-import { fromThrowable } from 'neverthrow';
 import { Injectable, injectConfig } from '@zeltjs/core';
 
 import { JwtConfig } from './jwt.config';
@@ -29,8 +28,11 @@ export class JwtService {
   }
 
   decode(token: string): JwtPayload | null {
-    const safeDecode = fromThrowable(decodeJwt<JwtPayload>);
-    return safeDecode(token).unwrapOr(null);
+    try {
+      return decodeJwt<JwtPayload>(token);
+    } catch {
+      return null;
+    }
   }
 
   private parseExpiresIn(expiresIn: string): string | number {

--- a/packages/auth-jwt/src/jwt.service.ts
+++ b/packages/auth-jwt/src/jwt.service.ts
@@ -1,4 +1,5 @@
 import { SignJWT, jwtVerify, decodeJwt } from 'jose';
+import { fromThrowable } from 'neverthrow';
 import { Injectable, injectConfig } from '@zeltjs/core';
 
 import { JwtConfig } from './jwt.config';
@@ -28,11 +29,8 @@ export class JwtService {
   }
 
   decode(token: string): JwtPayload | null {
-    try {
-      return decodeJwt<JwtPayload>(token);
-    } catch {
-      return null;
-    }
+    const safeDecode = fromThrowable(decodeJwt<JwtPayload>);
+    return safeDecode(token).unwrapOr(null);
   }
 
   private parseExpiresIn(expiresIn: string): string | number {

--- a/packages/auth-jwt/src/jwt.service.ts
+++ b/packages/auth-jwt/src/jwt.service.ts
@@ -1,0 +1,51 @@
+import { SignJWT, jwtVerify, decodeJwt } from 'jose';
+import { fromThrowable } from 'neverthrow';
+import { Injectable, injectConfig } from '@zeltjs/core';
+
+import { JwtConfig } from './jwt.config';
+import type { JwtPayload } from './jwt.types';
+
+@Injectable()
+export class JwtService {
+  constructor(private config = injectConfig(JwtConfig)) {}
+
+  async sign(payload: Record<string, unknown>): Promise<string> {
+    const secret = new TextEncoder().encode(this.config.secret);
+    const expiresIn = this.parseExpiresIn(this.config.expiresIn);
+
+    const jwt = await new SignJWT(payload)
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt()
+      .setExpirationTime(expiresIn)
+      .sign(secret);
+
+    return jwt;
+  }
+
+  async verify(token: string): Promise<JwtPayload> {
+    const secret = new TextEncoder().encode(this.config.secret);
+    const { payload } = await jwtVerify<JwtPayload>(token, secret);
+    return payload;
+  }
+
+  decode(token: string): JwtPayload | null {
+    const safeDecode = fromThrowable(decodeJwt<JwtPayload>);
+    return safeDecode(token).unwrapOr(null);
+  }
+
+  private parseExpiresIn(expiresIn: string): string | number {
+    const match = /^(\d+)([smhd])$/.exec(expiresIn);
+    if (match) {
+      const value = parseInt(match[1] ?? '0', 10);
+      const unit = match[2] ?? '';
+      const unitMap: Record<string, string> = {
+        s: 'seconds',
+        m: 'minutes',
+        h: 'hours',
+        d: 'days',
+      };
+      return `${value} ${unitMap[unit]}`;
+    }
+    return expiresIn;
+  }
+}

--- a/packages/auth-jwt/src/jwt.types.ts
+++ b/packages/auth-jwt/src/jwt.types.ts
@@ -1,0 +1,6 @@
+export interface JwtPayload {
+  sub?: string;
+  iat?: number;
+  exp?: number;
+  [key: string]: unknown;
+}

--- a/packages/auth-jwt/tsconfig.json
+++ b/packages/auth-jwt/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@9wick/eslint-plugin-strict-type-rules/tsconfig/strictest.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "experimentalDecorators": true,
+    "erasableSyntaxOnly": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/auth-jwt/tsdown.config.ts
+++ b/packages/auth-jwt/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  fixedExtension: false,
+  deps: {
+    neverBundle: ['hono', /^hono\//, /^@hono\//, '@zeltjs/core', /^@zeltjs\/core\//],
+  },
+});

--- a/packages/auth-jwt/vitest.config.ts
+++ b/packages/auth-jwt/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: '@zeltjs/auth-jwt',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/auth-jwt/vitest.config.ts
+++ b/packages/auth-jwt/vitest.config.ts
@@ -1,8 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
 
 export default defineConfig({
   test: {
     name: '@zeltjs/auth-jwt',
     include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      // Resolve @zeltjs/core from source to share the same @needle-di/core instance as direct imports.
+      '@zeltjs/core': resolve(__dirname, '../core/src/index.ts'),
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,9 +106,6 @@ importers:
       jose:
         specifier: 6.0.11
         version: 6.0.11
-      neverthrow:
-        specifier: 8.2.0
-        version: 8.2.0
     devDependencies:
       '@needle-di/core':
         specifier: 1.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       jose:
         specifier: 6.0.11
         version: 6.0.11
+      neverthrow:
+        specifier: 8.2.0
+        version: 8.2.0
     devDependencies:
       '@needle-di/core':
         specifier: 1.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,22 @@ importers:
         specifier: 22.19.17
         version: 22.19.17
 
+  packages/auth-jwt:
+    dependencies:
+      jose:
+        specifier: 6.0.11
+        version: 6.0.11
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.17
+        version: 22.19.17
+      '@zeltjs/core':
+        specifier: workspace:*
+        version: link:../core
+      hono:
+        specifier: 4.12.16
+        version: 4.12.16
+
   packages/cli:
     dependencies:
       c12:
@@ -199,12 +215,6 @@ importers:
       vitest:
         specifier: '>=4 <5'
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-
-  packages/zeltjs:
-    dependencies:
-      '@zeltjs/core':
-        specifier: '>=0.0.1'
-        version: 0.1.1(typescript@6.0.2)
 
   website:
     dependencies:
@@ -3354,9 +3364,6 @@ packages:
     resolution: {integrity: sha512-/HcYgtUSiJiot/XWGLOlGxPYUG65+/31V8oqk17vZLW1xlCoR4PampyePljOxY2n8/3jz9+tIFzICsyGujJZoA==}
     engines: {node: '>=18.12.0'}
 
-  '@zeltjs/core@0.1.1':
-    resolution: {integrity: sha512-GKTuDOMuD9NUmLyEXdg9gzco185hV5tU7Xk5EXgrb3JB6wJ47dZYAZywVA9uNlD6taD5OyHvO4eUVgyAdPEAaQ==}
-
   '@zkochan/js-yaml@0.0.7':
     resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
     hasBin: true
@@ -5154,6 +5161,9 @@ packages:
 
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
+  jose@6.0.11:
+    resolution: {integrity: sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -11389,15 +11399,6 @@ snapshots:
       js-yaml: 3.14.2
       tslib: 2.8.1
 
-  '@zeltjs/core@0.1.1(typescript@6.0.2)':
-    dependencies:
-      '@needle-di/core': 1.1.2
-      hono: 4.12.16
-      neverthrow: 8.2.0
-      valibot: 1.3.1(typescript@6.0.2)
-    transitivePeerDependencies:
-      - typescript
-
   '@zkochan/js-yaml@0.0.7':
     dependencies:
       argparse: 2.0.1
@@ -13349,6 +13350,8 @@ snapshots:
       '@sideway/address': 4.1.5
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
+
+  jose@6.0.11: {}
 
   js-tokens@10.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
         specifier: 6.0.11
         version: 6.0.11
     devDependencies:
+      '@needle-di/core':
+        specifier: 1.1.2
+        version: 1.1.2
       '@types/node':
         specifier: 22.19.17
         version: 22.19.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       jose:
         specifier: 6.0.11
         version: 6.0.11
+      neverthrow:
+        specifier: 8.2.0
+        version: 8.2.0
     devDependencies:
       '@needle-di/core':
         specifier: 1.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,9 +144,6 @@ importers:
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
-      hono:
-        specifier: 4.12.16
-        version: 4.12.16
 
   packages/cli:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     { "path": "packages/contract" },
     { "path": "packages/testing" },
     { "path": "packages/adapter-node" },
-    { "path": "packages/cli" }
+    { "path": "packages/cli" },
+    { "path": "packages/auth-jwt" }
   ],
   "files": []
 }


### PR DESCRIPTION
## Summary

- Add new `@zeltjs/auth-jwt` package for JWT Bearer authentication
- Integrates with `@zeltjs/core` authentication primitives (`setUser`, `@Authorized`)
- Uses `jose` library for JWT operations (Edge/Workers compatible)

## Features

- `JwtConfig` - Configurable settings (secret, expiresIn, resolveUser)
- `JwtService` - JWT operations (sign, verify, decode)
- `JwtMiddleware` - Bearer token extraction and user resolution

## Test Plan

- [x] JwtService tests (sign, verify, decode, tampered token, invalid token)
- [x] JwtMiddleware tests (401 for missing/invalid/expired tokens, 200 for valid)
- [x] setUser integration test (currentUser/currentRoles return correct values)
- [x] Typecheck passes
- [x] Build passes