### PR TITLE
docs: add missing documentation for scheduler, auth-jwt, and examples

### DIFF
--- a/website/docs/authentication.md
+++ b/website/docs/authentication.md
@@ -215,6 +215,103 @@ class PostController {
 }
 ```
 
+## Using @zeltjs/auth-jwt
+
+For JWT authentication, Zelt provides the `@zeltjs/auth-jwt` package with ready-to-use middleware and services.
+
+### Installation
+
+```bash
+pnpm add @zeltjs/auth-jwt
+```
+
+### Basic Setup
+
+1. Set the `JWT_SECRET` environment variable
+2. Register the `JwtMiddleware` and `JwtConfig`:
+
+```typescript
+import { createHttpApp } from '@zeltjs/core';
+import { JwtMiddleware, JwtConfig } from '@zeltjs/auth-jwt';
+
+const app = createHttpApp({
+  controllers: [UserController],
+  middlewares: [JwtMiddleware],
+  configs: [JwtConfig],
+});
+```
+
+### Generating Tokens
+
+Use `JwtService` to sign tokens:
+
+```typescript
+import { Controller, Post, bodyParam, inject } from '@zeltjs/core';
+import { JwtService } from '@zeltjs/auth-jwt';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.string(),
+  password: v.string(),
+});
+
+@Controller('/auth')
+class AuthController {
+  constructor(private jwtService = inject(JwtService)) {}
+
+  @Post('/login')
+  async login(body = bodyParam(LoginSchema)) {
+    const user = await validateCredentials(body.email, body.password);
+    const token = await this.jwtService.sign({ sub: user.id, roles: user.roles });
+    return { token };
+  }
+}
+```
+
+### Custom Configuration
+
+Extend `JwtConfig` to customize behavior:
+
+```typescript
+import { JwtConfig, type ResolveUserResult, type JwtPayload } from '@zeltjs/auth-jwt';
+import { Config } from '@zeltjs/core';
+
+@Config
+class CustomJwtConfig extends JwtConfig {
+  override get expiresIn(): string {
+    return '7d';
+  }
+
+  override get resolveUser(): (payload: JwtPayload) => Promise<ResolveUserResult> {
+    return async (payload) => {
+      const user = await findUserById(payload.sub);
+      return {
+        user: { id: user.id, name: user.name, email: user.email },
+        roles: user.roles,
+      };
+    };
+  }
+}
+```
+
+Register the custom config:
+
+```typescript
+const app = createHttpApp({
+  controllers: [AuthController, UserController],
+  middlewares: [JwtMiddleware],
+  configs: [CustomJwtConfig],
+});
+```
+
+### JwtService Methods
+
+| Method | Description |
+|--------|-------------|
+| `sign(payload)` | Create a signed JWT token |
+| `verify(token)` | Verify and decode a token (throws on invalid) |
+| `decode(token)` | Decode without verification (returns `null` on error) |
+
 ## Best Practices
 
 1. **Set authentication early** — Register auth middleware globally so it runs before route handlers

--- a/website/docs/examples.md
+++ b/website/docs/examples.md
@@ -1,0 +1,212 @@
+---
+sidebar_position: 10
+---
+
+# Examples
+
+Zelt includes example applications demonstrating real-world usage patterns.
+
+## Drizzle Todo
+
+A simple Todo API using Drizzle ORM with SQLite.
+
+**Location:** `examples/drizzle-todo`
+
+### Features
+
+- CRUD operations with Drizzle ORM
+- Request validation with Valibot
+- SQLite database with better-sqlite3
+- Disposable pattern for cleanup
+
+### Running
+
+```bash
+cd examples/drizzle-todo
+pnpm install
+pnpm dev
+```
+
+### Key Code
+
+**Controller with validation:**
+
+```typescript
+import { Controller, Get, Post, inject, pathParam, validated } from '@zeltjs/core';
+import * as v from 'valibot';
+
+const CreateTodoBody = v.object({
+  title: v.pipe(v.string(), v.minLength(1)),
+});
+
+@Controller('/todos')
+class TodoController {
+  constructor(private todoService = inject(TodoService)) {}
+
+  @Get('/')
+  findAll() {
+    return this.todoService.findAll();
+  }
+
+  @Post('/')
+  create(body = validated(CreateTodoBody), res = response()) {
+    const todo = this.todoService.create({ title: body.title });
+    return res.json(todo, 201);
+  }
+}
+```
+
+**Drizzle service with Disposable:**
+
+```typescript
+import { Injectable } from '@zeltjs/core';
+import type { Disposable } from '@zeltjs/core';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
+@Injectable()
+class DrizzleService implements Disposable {
+  private sqlite: Database.Database;
+  readonly db;
+
+  constructor() {
+    this.sqlite = new Database('./data/todo.db');
+    this.db = drizzle(this.sqlite, { schema });
+  }
+
+  dispose() {
+    this.sqlite.close();
+  }
+}
+```
+
+### API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/todos` | List all todos |
+| GET | `/todos/:id` | Get a todo by ID |
+| POST | `/todos` | Create a new todo |
+| PATCH | `/todos/:id` | Update a todo |
+| DELETE | `/todos/:id` | Delete a todo |
+
+---
+
+## Workers URL Shortener
+
+A URL shortener running on Cloudflare Workers with KV storage.
+
+**Location:** `examples/workers-url-shortener`
+
+### Features
+
+- Cloudflare Workers deployment
+- KV storage for persistence
+- URL validation
+- Hit counter for analytics
+
+### Running
+
+```bash
+cd examples/workers-url-shortener
+pnpm install
+pnpm dev
+```
+
+### Key Code
+
+**Worker entry point:**
+
+```typescript
+import { app } from './app';
+
+export default {
+  fetch: app.fetch,
+};
+```
+
+**Controller with KV access:**
+
+```typescript
+import { Controller, Get, Post, inject, pathParam, requestContext, validated } from '@zeltjs/core';
+import * as v from 'valibot';
+
+const ShortenBody = v.object({
+  url: v.pipe(v.string(), v.url()),
+});
+
+@Controller('/')
+class UrlController {
+  constructor(private kv = inject(KVService)) {}
+
+  @Post('/shorten')
+  async shorten(body = validated(ShortenBody), res = response(), ctx = requestContext()) {
+    const code = generateCode();
+    await this.kv.set(ctx, code, { url: body.url, createdAt: Date.now(), hits: 0 });
+    return res.json({ code, shortUrl: `/${code}` }, 201);
+  }
+
+  @Get('/:code')
+  async redirect(code = pathParam('code'), res = response(), ctx = requestContext()) {
+    const record = await this.kv.get(ctx, code);
+    if (!record) throw new HTTPException(404, { message: 'URL not found' });
+    await this.kv.incrementHits(ctx, code);
+    return res.redirect(record.url, 302);
+  }
+}
+```
+
+**KV service:**
+
+```typescript
+import { Injectable } from '@zeltjs/core';
+
+@Injectable()
+class KVService {
+  async get(c: RequestContext, code: string) {
+    return c.env.URLS.get(`url:${code}`, 'json');
+  }
+
+  async set(c: RequestContext, code: string, record: UrlRecord) {
+    await c.env.URLS.put(`url:${code}`, JSON.stringify(record));
+  }
+}
+```
+
+### API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/shorten` | Create a short URL |
+| GET | `/:code` | Redirect to original URL |
+| GET | `/stats/:code` | Get URL statistics |
+
+### wrangler.toml
+
+```toml
+name = "url-shortener"
+main = "src/worker.ts"
+compatibility_date = "2024-01-01"
+
+[[kv_namespaces]]
+binding = "URLS"
+id = "your-kv-namespace-id"
+```
+
+---
+
+## Running Examples
+
+All examples are in the `examples/` directory. Each has its own `package.json`:
+
+```bash
+# Install dependencies for an example
+cd examples/<example-name>
+pnpm install
+
+# Run in development mode
+pnpm dev
+
+# Run tests (if available)
+pnpm test
+```

--- a/website/docs/scheduler.md
+++ b/website/docs/scheduler.md
@@ -1,0 +1,246 @@
+---
+sidebar_position: 7
+---
+
+# Scheduler
+
+Zelt provides declarative scheduling decorators for running tasks at specified intervals or cron expressions.
+
+## Overview
+
+The scheduler API consists of:
+
+- **`@Scheduled`** — Class decorator marking a class as a scheduler
+- **`@Cron(expression)`** — Run at specific cron expression
+- **`@Daily({ hour, minute? })`** — Run once per day
+- **`@Hourly({ minute? })`** — Run once per hour
+- **`@Weekly({ day, hour, minute? })`** — Run once per week
+- **`@Every({ minutes | seconds })`** — Run at fixed intervals
+
+## Basic Usage
+
+### Creating a Scheduler
+
+```typescript
+import { Scheduled, Cron, Daily, Hourly } from '@zeltjs/core';
+
+@Scheduled()
+class ReportScheduler {
+  @Daily({ hour: 9 })
+  async sendDailyReport() {
+    console.log('Sending daily report...');
+  }
+
+  @Hourly()
+  async checkHealth() {
+    console.log('Health check...');
+  }
+}
+```
+
+### Registering Schedulers
+
+Pass scheduler classes to `createHttpApp()`:
+
+```typescript
+import { createHttpApp } from '@zeltjs/core';
+
+const app = createHttpApp({
+  controllers: [UserController],
+  schedulers: [ReportScheduler],
+});
+```
+
+### Starting the Scheduler
+
+Call `startScheduler()` to begin executing scheduled tasks:
+
+```typescript
+app.startScheduler();
+```
+
+To stop the scheduler gracefully:
+
+```typescript
+await app.stopScheduler();
+```
+
+## Decorator Reference
+
+### @Cron
+
+Run at specific cron expression:
+
+```typescript
+@Scheduled()
+class BackupScheduler {
+  @Cron('0 2 * * *')
+  async runBackup() {
+    // Runs at 2:00 AM every day
+  }
+
+  @Cron('*/5 * * * *')
+  async quickCheck() {
+    // Runs every 5 minutes
+  }
+}
+```
+
+With timezone:
+
+```typescript
+@Cron('0 9 * * *', { tz: 'Asia/Tokyo' })
+async morningTask() {
+  // Runs at 9:00 AM JST
+}
+```
+
+### @Daily
+
+Run once per day at specified hour:
+
+```typescript
+@Scheduled()
+class DailyTasks {
+  @Daily({ hour: 6 })
+  async earlyMorning() {
+    // Runs at 6:00 AM
+  }
+
+  @Daily({ hour: 23, minute: 30 })
+  async lateNight() {
+    // Runs at 11:30 PM
+  }
+
+  @Daily({ hour: 9, tz: 'America/New_York' })
+  async newYorkMorning() {
+    // Runs at 9:00 AM EST/EDT
+  }
+}
+```
+
+### @Hourly
+
+Run once per hour:
+
+```typescript
+@Scheduled()
+class HourlyTasks {
+  @Hourly()
+  async everyHour() {
+    // Runs at minute 0 of every hour
+  }
+
+  @Hourly({ minute: 30 })
+  async halfPast() {
+    // Runs at minute 30 of every hour
+  }
+}
+```
+
+### @Weekly
+
+Run once per week:
+
+```typescript
+@Scheduled()
+class WeeklyTasks {
+  @Weekly({ day: 'monday', hour: 9 })
+  async mondayMeeting() {
+    // Runs every Monday at 9:00 AM
+  }
+
+  @Weekly({ day: 'friday', hour: 17, minute: 30 })
+  async weeklyReport() {
+    // Runs every Friday at 5:30 PM
+  }
+}
+```
+
+Available days: `'sunday'`, `'monday'`, `'tuesday'`, `'wednesday'`, `'thursday'`, `'friday'`, `'saturday'`
+
+### @Every
+
+Run at fixed intervals:
+
+```typescript
+@Scheduled()
+class PollingTasks {
+  @Every({ minutes: 5 })
+  async pollApi() {
+    // Runs every 5 minutes
+  }
+
+  @Every({ seconds: 30 })
+  async frequentCheck() {
+    // Runs every 30 seconds
+  }
+}
+```
+
+## Dependency Injection
+
+Schedulers support dependency injection like controllers:
+
+```typescript
+import { Scheduled, Daily, inject } from '@zeltjs/core';
+
+@Scheduled()
+class NotificationScheduler {
+  constructor(
+    private emailService = inject(EmailService),
+    private userRepo = inject(UserRepository),
+  ) {}
+
+  @Daily({ hour: 8 })
+  async sendReminders() {
+    const users = await this.userRepo.findWithPendingReminders();
+    for (const user of users) {
+      await this.emailService.send(user.email, 'Reminder', '...');
+    }
+  }
+}
+```
+
+## Node.js Entry Point
+
+For Node.js applications, start the scheduler in your entry point:
+
+```typescript
+import { listen } from '@zeltjs/adapter-node';
+import { app } from './app';
+
+listen(app, { port: 3000 });
+app.startScheduler();
+
+process.on('SIGTERM', async () => {
+  await app.stopScheduler();
+  process.exit(0);
+});
+```
+
+## Cron Expression Format
+
+Zelt uses standard cron format with optional seconds:
+
+```
+┌──────────── second (optional, 0-59)
+│ ┌────────── minute (0-59)
+│ │ ┌──────── hour (0-23)
+│ │ │ ┌────── day of month (1-31)
+│ │ │ │ ┌──── month (1-12)
+│ │ │ │ │ ┌── day of week (0-6, Sunday=0)
+│ │ │ │ │ │
+* * * * * *
+```
+
+Common patterns:
+
+| Pattern | Description |
+|---------|-------------|
+| `* * * * *` | Every minute |
+| `0 * * * *` | Every hour |
+| `0 0 * * *` | Every day at midnight |
+| `0 9 * * 1` | Every Monday at 9:00 AM |
+| `*/15 * * * *` | Every 15 minutes |
+| `0 0 1 * *` | First day of every month |


### PR DESCRIPTION
## Summary

- Add `scheduler.md` documenting `@Cron`, `@Daily`, `@Every`, `@Hourly`, `@Weekly`, `@Scheduled` decorators
- Add `@zeltjs/auth-jwt` section to `authentication.md` with setup, token generation, and custom configuration examples
- Add `examples.md` documenting `drizzle-todo` and `workers-url-shortener` example applications

## Test plan

- [ ] Verify website builds successfully
- [ ] Review rendered documentation pages