### PR TITLE
feat(testing): add createTestContainer as public API

### DIFF
--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,1 +1,5 @@
-export { resolveWith, type ResolverHandle } from './test-container';
+export { createTestContainer } from './test-container';
+export type { CreateTestContainerOptions, TestContainerResult } from './test-container';
+
+export { resolveWith } from '@zeltjs/core';
+export type { ResolverHandle } from '@zeltjs/core';

--- a/packages/testing/src/test-container.test.ts
+++ b/packages/testing/src/test-container.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { Injectable, inject } from '@zeltjs/core';
+
+import { createTestContainer } from './test-container';
+
+describe('createTestContainer', () => {
+  it('resolves a simple injectable class', () => {
+    @Injectable()
+    class SimpleService {
+      getValue() {
+        return 'hello';
+      }
+    }
+
+    const { target } = createTestContainer(SimpleService);
+
+    expect(target.getValue()).toBe('hello');
+  });
+
+  it('resolves with dependency injection', () => {
+    @Injectable()
+    class Repository {
+      getData() {
+        return 'real-data';
+      }
+    }
+
+    @Injectable()
+    class Service {
+      constructor(private repo = inject(Repository)) {}
+
+      process() {
+        return `processed: ${this.repo.getData()}`;
+      }
+    }
+
+    const { target } = createTestContainer(Service);
+
+    expect(target.process()).toBe('processed: real-data');
+  });
+
+  it('allows overriding dependencies with mock values', () => {
+    @Injectable()
+    class Repository {
+      getData() {
+        return 'real-data';
+      }
+    }
+
+    @Injectable()
+    class Service {
+      constructor(private repo = inject(Repository)) {}
+
+      process() {
+        return `processed: ${this.repo.getData()}`;
+      }
+    }
+
+    const mockRepo = {
+      getData: () => 'mock-data',
+    };
+
+    const { target } = createTestContainer(Service, {
+      overrides: [{ provide: Repository, useValue: mockRepo as Repository }],
+    });
+
+    expect(target.process()).toBe('processed: mock-data');
+  });
+
+  it('exposes container.get for resolving additional dependencies', () => {
+    @Injectable()
+    class ServiceA {
+      name = 'A';
+    }
+
+    @Injectable()
+    class ServiceB {
+      name = 'B';
+    }
+
+    const { target, get } = createTestContainer(ServiceA);
+
+    expect(target.name).toBe('A');
+
+    const serviceB = get(ServiceB);
+    expect(serviceB.name).toBe('B');
+  });
+
+  it('works with class-based token injection', () => {
+    @Injectable()
+    class ConfigService {
+      apiUrl = 'https://default.api';
+    }
+
+    @Injectable()
+    class ApiClient {
+      constructor(private config = inject(ConfigService)) {}
+
+      getUrl() {
+        return this.config.apiUrl;
+      }
+    }
+
+    const mockConfig = { apiUrl: 'https://test.api' };
+
+    const { target } = createTestContainer(ApiClient, {
+      overrides: [{ provide: ConfigService, useValue: mockConfig as ConfigService }],
+    });
+
+    expect(target.getUrl()).toBe('https://test.api');
+  });
+});

--- a/packages/testing/src/test-container.ts
+++ b/packages/testing/src/test-container.ts
@@ -1,2 +1,29 @@
-export { resolveWith } from '@zeltjs/core';
-export type { ResolverHandle } from '@zeltjs/core';
+import { resolveWith } from '@zeltjs/core';
+
+type Class<T> = new (...args: never[]) => T;
+
+type Override<T> = {
+  readonly provide: Class<T>;
+  readonly useValue: T;
+};
+
+export type CreateTestContainerOptions = {
+  readonly overrides?: readonly Override<unknown>[];
+};
+
+export type TestContainerResult<T> = {
+  readonly target: T;
+  readonly get: <U extends object>(cls: Class<U>) => U;
+};
+
+export const createTestContainer = <T extends object>(
+  targetClass: Class<T>,
+  options: CreateTestContainerOptions = {},
+): TestContainerResult<T> => {
+  const { target, resolver } = resolveWith(targetClass, options);
+
+  return {
+    target,
+    get: resolver.get,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,9 +281,6 @@ importers:
 
   packages/testing:
     dependencies:
-      '@needle-di/core':
-        specifier: 1.1.2
-        version: 1.1.2
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
 
   packages/testing:
     dependencies:
+      '@needle-di/core':
+        specifier: 1.1.2
+        version: 1.1.2
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

- Add `createTestContainer` function as the public testing utility API
- Wrap internal `resolveWith` for proper encapsulation
- Remove direct `@needle-di/core` dependency from testing package

## Test plan

- [x] Unit tests for `createTestContainer` added
- [x] All existing tests pass
- [x] Type checking passes