### PR TITLE
refactor(testing): rename createTestContainer to createTestTarget

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,8 +56,8 @@ export type {
 export { Config, injectConfig } from './config';
 export type { ConfigClass } from './config';
 
-export { createTestContainer } from './internal/container';
-export type { CreateTestContainerOptions, TestContainerResult } from './internal/container';
+export { createTestTarget } from './internal/container';
+export type { CreateTestTargetOptions, TestTargetResult } from './internal/container';
 
 export { LifecycleManager } from './lifecycle';
 export type { Disposable } from './lifecycle';

--- a/packages/core/src/internal/container.ts
+++ b/packages/core/src/internal/container.ts
@@ -37,12 +37,12 @@ type Override<T> = {
   readonly useValue: T;
 };
 
-export type CreateTestContainerOptions = {
+export type CreateTestTargetOptions = {
   readonly configs?: readonly Class<unknown>[];
   readonly overrides?: readonly Override<unknown>[];
 };
 
-export type TestContainerResult<T> = {
+export type TestTargetResult<T> = {
   readonly target: T;
   readonly get: <U extends object>(cls: Class<U>) => U;
 };
@@ -53,10 +53,10 @@ const bindOverrides = (container: Container, overrides: readonly Override<unknow
   }
 };
 
-export const createTestContainer = <T extends object>(
+export const createTestTarget = <T extends object>(
   targetClass: Class<T>,
-  options: CreateTestContainerOptions = {},
-): TestContainerResult<T> => {
+  options: CreateTestTargetOptions = {},
+): TestTargetResult<T> => {
   const container = new Container();
   bindConfigs(container, options.configs ?? []);
   bindOverrides(container, options.overrides ?? []);

--- a/packages/core/src/modules/env/env.service.test.ts
+++ b/packages/core/src/modules/env/env.service.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createTestContainer } from '../../internal/container';
+import { createTestTarget } from '../../internal/container';
 
 import { ProcessEnvConfig } from './env.config';
 import { EnvService } from './env.service';
 
 const createEnvService = () => {
-  const { target } = createTestContainer(EnvService, {
+  const { target } = createTestTarget(EnvService, {
     configs: [ProcessEnvConfig],
   });
   return target;

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,2 +1,2 @@
-export { createTestContainer } from './test-container';
-export type { CreateTestContainerOptions, TestContainerResult } from './test-container';
+export { createTestTarget } from './test-target';
+export type { CreateTestTargetOptions, TestTargetResult } from './test-target';

--- a/packages/testing/src/test-container.ts
+++ b/packages/testing/src/test-container.ts
@@ -1,2 +1,0 @@
-export { createTestContainer } from '@zeltjs/core';
-export type { CreateTestContainerOptions, TestContainerResult } from '@zeltjs/core';

--- a/packages/testing/src/test-target.test.ts
+++ b/packages/testing/src/test-target.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { Injectable, inject } from '@zeltjs/core';
 
-import { createTestContainer } from './test-container';
+import { createTestTarget } from './test-target';
 
-describe('createTestContainer', () => {
+describe('createTestTarget', () => {
   it('resolves a simple injectable class', () => {
     @Injectable()
     class SimpleService {
@@ -12,7 +12,7 @@ describe('createTestContainer', () => {
       }
     }
 
-    const { target } = createTestContainer(SimpleService);
+    const { target } = createTestTarget(SimpleService);
 
     expect(target.getValue()).toBe('hello');
   });
@@ -34,7 +34,7 @@ describe('createTestContainer', () => {
       }
     }
 
-    const { target } = createTestContainer(Service);
+    const { target } = createTestTarget(Service);
 
     expect(target.process()).toBe('processed: real-data');
   });
@@ -60,7 +60,7 @@ describe('createTestContainer', () => {
       getData: () => 'mock-data',
     };
 
-    const { target } = createTestContainer(Service, {
+    const { target } = createTestTarget(Service, {
       overrides: [{ provide: Repository, useValue: mockRepo as Repository }],
     });
 
@@ -78,7 +78,7 @@ describe('createTestContainer', () => {
       name = 'B';
     }
 
-    const { target, get } = createTestContainer(ServiceA);
+    const { target, get } = createTestTarget(ServiceA);
 
     expect(target.name).toBe('A');
 
@@ -103,7 +103,7 @@ describe('createTestContainer', () => {
 
     const mockConfig = { apiUrl: 'https://test.api' };
 
-    const { target } = createTestContainer(ApiClient, {
+    const { target } = createTestTarget(ApiClient, {
       overrides: [{ provide: ConfigService, useValue: mockConfig as ConfigService }],
     });
 

--- a/packages/testing/src/test-target.ts
+++ b/packages/testing/src/test-target.ts
@@ -1,0 +1,2 @@
+export { createTestTarget } from '@zeltjs/core';
+export type { CreateTestTargetOptions, TestTargetResult } from '@zeltjs/core';


### PR DESCRIPTION
## Summary

- Rename `createTestContainer` → `createTestTarget` to avoid naming collision with Docker Testcontainers library
- Rename associated types: `CreateTestContainerOptions` → `CreateTestTargetOptions`, `TestContainerResult` → `TestTargetResult`
- Rename files: `test-container.ts` → `test-target.ts`

## Test plan

- [x] Build passes
- [x] Tests pass in @zeltjs/testing and @zeltjs/core