### PR TITLE
feat(core): add Hono context primitives

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
     "croner": "9.1.0",
     "dotenv": "17.4.2",
     "hono": "4.12.16",
+    "ts-pattern": "5.6.2",
     "valibot": "1.3.1"
   },
   "devDependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,14 +36,19 @@ export type {
 } from './middleware/types';
 
 export { currentRoles, currentUser, setUser } from './primitives/auth';
+export { body } from './primitives/body';
+export { cookie } from './primitives/cookie';
 export { ip } from './primitives/ip';
 export { getContext, setContext } from './primitives/get-context';
 export type { RequestContextSchema } from './primitives/get-context';
+export { header } from './primitives/header';
 export { inject } from './primitives/inject';
 export { pathParam } from './primitives/path-param';
+export { queryParam, queryParams } from './primitives/query-param';
 export { requestContext } from './primitives/request-context';
 export { response } from './primitives/response';
-export type { ResponseBuilder } from './primitives/response';
+export type { CookieOptions, ResponseBuilder } from './primitives/response';
+export { method, path, url } from './primitives/url';
 export { validated } from './primitives/validated';
 export type {
   ValidatedMarker,

--- a/packages/core/src/primitives/body.test.ts
+++ b/packages/core/src/primitives/body.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { createHttpApp } from '../http/app';
+import { Controller } from '../decorators/controller';
+import { Post } from '../decorators/http-method';
+import { body } from './body';
+
+describe('body', () => {
+  it('parses text body', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/text')
+      async text() {
+        const text = await body('text');
+        return { text };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(
+      new Request('http://localhost/text', {
+        method: 'POST',
+        body: 'hello world',
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    );
+    expect(await res.json()).toEqual({ text: 'hello world' });
+  });
+
+  it('parses json body', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/json')
+      async json() {
+        const data = await body('json');
+        return { data };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(
+      new Request('http://localhost/json', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'test' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    expect(await res.json()).toEqual({ data: { name: 'test' } });
+  });
+
+  it('parses form body', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/form')
+      async form() {
+        const formData = await body('form');
+        return { name: formData.get('name') };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const formData = new FormData();
+    formData.append('name', 'John');
+
+    const res = await app.fetch(
+      new Request('http://localhost/form', {
+        method: 'POST',
+        body: formData,
+      }),
+    );
+    expect(await res.json()).toEqual({ name: 'John' });
+  });
+
+  it('parses arrayBuffer body', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/buffer')
+      async buffer() {
+        const buf = await body('arrayBuffer');
+        return { size: buf.byteLength };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(
+      new Request('http://localhost/buffer', {
+        method: 'POST',
+        body: new Uint8Array([1, 2, 3, 4, 5]),
+      }),
+    );
+    expect(await res.json()).toEqual({ size: 5 });
+  });
+
+  it('parses blob body', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/blob')
+      async blob() {
+        const b = await body('blob');
+        return { size: b.size, type: b.type };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(
+      new Request('http://localhost/blob', {
+        method: 'POST',
+        body: new Blob(['hello'], { type: 'text/plain' }),
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    );
+    expect(await res.json()).toEqual({ size: 5, type: 'text/plain' });
+  });
+});

--- a/packages/core/src/primitives/body.test.ts
+++ b/packages/core/src/primitives/body.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { createHttpApp } from '../http/app';
 import { Controller } from '../decorators/controller';
 import { Post } from '../decorators/http-method';
+import { createHttpApp } from '../http/app';
+
 import { body } from './body';
 
 describe('body', () => {

--- a/packages/core/src/primitives/body.ts
+++ b/packages/core/src/primitives/body.ts
@@ -1,0 +1,24 @@
+import { getEntryContext } from '../internal/entry-context';
+
+type BodyType = 'text' | 'json' | 'form' | 'arrayBuffer' | 'blob';
+
+export function body(type: 'text'): Promise<string>;
+export function body(type: 'json'): Promise<unknown>;
+export function body(type: 'form'): Promise<FormData>;
+export function body(type: 'arrayBuffer'): Promise<ArrayBuffer>;
+export function body(type: 'blob'): Promise<Blob>;
+export function body(type: BodyType): Promise<string | unknown | FormData | ArrayBuffer | Blob> {
+  const req = getEntryContext().honoContext.req;
+  switch (type) {
+    case 'text':
+      return req.text();
+    case 'json':
+      return req.json();
+    case 'form':
+      return req.formData();
+    case 'arrayBuffer':
+      return req.arrayBuffer();
+    case 'blob':
+      return req.blob();
+  }
+}

--- a/packages/core/src/primitives/body.ts
+++ b/packages/core/src/primitives/body.ts
@@ -1,18 +1,29 @@
+import { match } from 'ts-pattern';
+
 import { getEntryContext } from '../internal/entry-context';
 
-type BodyType = 'text' | 'json' | 'form' | 'arrayBuffer' | 'blob';
-type BodyResult = Promise<string | unknown | FormData | ArrayBuffer | Blob>;
+type BodyTypeMap = {
+  text: string;
+  json: unknown;
+  form: FormData;
+  arrayBuffer: ArrayBuffer;
+  blob: Blob;
+};
+
+type BodyType = keyof BodyTypeMap;
 
 export function body(type: 'text'): Promise<string>;
 export function body(type: 'json'): Promise<unknown>;
 export function body(type: 'form'): Promise<FormData>;
 export function body(type: 'arrayBuffer'): Promise<ArrayBuffer>;
 export function body(type: 'blob'): Promise<Blob>;
-export function body(type: BodyType): BodyResult {
+export function body(type: BodyType): Promise<BodyTypeMap[BodyType]> {
   const req = getEntryContext().honoContext.req;
-  if (type === 'text') return req.text();
-  if (type === 'json') return req.json();
-  if (type === 'form') return req.formData();
-  if (type === 'arrayBuffer') return req.arrayBuffer();
-  return req.blob();
+  return match(type)
+    .with('text', () => req.text())
+    .with('json', () => req.json())
+    .with('form', () => req.formData())
+    .with('arrayBuffer', () => req.arrayBuffer())
+    .with('blob', () => req.blob())
+    .exhaustive();
 }

--- a/packages/core/src/primitives/body.ts
+++ b/packages/core/src/primitives/body.ts
@@ -1,24 +1,18 @@
 import { getEntryContext } from '../internal/entry-context';
 
 type BodyType = 'text' | 'json' | 'form' | 'arrayBuffer' | 'blob';
+type BodyResult = Promise<string | unknown | FormData | ArrayBuffer | Blob>;
 
 export function body(type: 'text'): Promise<string>;
 export function body(type: 'json'): Promise<unknown>;
 export function body(type: 'form'): Promise<FormData>;
 export function body(type: 'arrayBuffer'): Promise<ArrayBuffer>;
 export function body(type: 'blob'): Promise<Blob>;
-export function body(type: BodyType): Promise<string | unknown | FormData | ArrayBuffer | Blob> {
+export function body(type: BodyType): BodyResult {
   const req = getEntryContext().honoContext.req;
-  switch (type) {
-    case 'text':
-      return req.text();
-    case 'json':
-      return req.json();
-    case 'form':
-      return req.formData();
-    case 'arrayBuffer':
-      return req.arrayBuffer();
-    case 'blob':
-      return req.blob();
-  }
+  if (type === 'text') return req.text();
+  if (type === 'json') return req.json();
+  if (type === 'form') return req.formData();
+  if (type === 'arrayBuffer') return req.arrayBuffer();
+  return req.blob();
 }

--- a/packages/core/src/primitives/cookie.test.ts
+++ b/packages/core/src/primitives/cookie.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { createHttpApp } from '../http/app';
+import { Controller } from '../decorators/controller';
+import { Get } from '../decorators/http-method';
+import { cookie } from './cookie';
+
+describe('cookie', () => {
+  it('returns cookie value', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/')
+      index(session = cookie('session')) {
+        return { session };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(
+      new Request('http://localhost/', {
+        headers: { Cookie: 'session=abc123' },
+      }),
+    );
+    expect(await res.json()).toEqual({ session: 'abc123' });
+  });
+
+  it('returns undefined for missing cookie', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/')
+      index(session = cookie('session')) {
+        return { session: session ?? 'none' };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/'));
+    expect(await res.json()).toEqual({ session: 'none' });
+  });
+});

--- a/packages/core/src/primitives/cookie.test.ts
+++ b/packages/core/src/primitives/cookie.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { createHttpApp } from '../http/app';
 import { Controller } from '../decorators/controller';
 import { Get } from '../decorators/http-method';
+import { createHttpApp } from '../http/app';
+
 import { cookie } from './cookie';
 
 describe('cookie', () => {

--- a/packages/core/src/primitives/cookie.ts
+++ b/packages/core/src/primitives/cookie.ts
@@ -1,0 +1,7 @@
+import { getCookie } from 'hono/cookie';
+
+import { getEntryContext } from '../internal/entry-context';
+
+export const cookie = (name: string): string | undefined => {
+  return getCookie(getEntryContext().honoContext, name);
+};

--- a/packages/core/src/primitives/header.test.ts
+++ b/packages/core/src/primitives/header.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { createHttpApp } from '../http/app';
+import { Controller } from '../decorators/controller';
+import { Get } from '../decorators/http-method';
+import { header } from './header';
+
+describe('header', () => {
+  it('returns header value', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/')
+      index(ua = header('user-agent')) {
+        return { ua };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(
+      new Request('http://localhost/', {
+        headers: { 'User-Agent': 'test-agent' },
+      }),
+    );
+    expect(await res.json()).toEqual({ ua: 'test-agent' });
+  });
+
+  it('returns undefined for missing header', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/')
+      index(custom = header('x-custom')) {
+        return { custom: custom ?? 'none' };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/'));
+    expect(await res.json()).toEqual({ custom: 'none' });
+  });
+});

--- a/packages/core/src/primitives/header.test.ts
+++ b/packages/core/src/primitives/header.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { createHttpApp } from '../http/app';
 import { Controller } from '../decorators/controller';
 import { Get } from '../decorators/http-method';
+import { createHttpApp } from '../http/app';
+
 import { header } from './header';
 
 describe('header', () => {

--- a/packages/core/src/primitives/header.ts
+++ b/packages/core/src/primitives/header.ts
@@ -1,0 +1,5 @@
+import { getEntryContext } from '../internal/entry-context';
+
+export const header = (name: string): string | undefined => {
+  return getEntryContext().honoContext.req.header(name);
+};

--- a/packages/core/src/primitives/query-param.test.ts
+++ b/packages/core/src/primitives/query-param.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { createHttpApp } from '../http/app';
+import { Controller } from '../decorators/controller';
+import { Get } from '../decorators/http-method';
+import { queryParam, queryParams } from './query-param';
+
+describe('queryParam', () => {
+  it('returns query parameter value', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/search')
+      search(q = queryParam('q')) {
+        return { q };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/search?q=hello'));
+    expect(await res.json()).toEqual({ q: 'hello' });
+  });
+
+  it('returns undefined for missing parameter', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/search')
+      search(q = queryParam('q')) {
+        return { q: q ?? 'default' };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/search'));
+    expect(await res.json()).toEqual({ q: 'default' });
+  });
+});
+
+describe('queryParams', () => {
+  it('returns multiple values for same parameter', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/filter')
+      filter(tags = queryParams('tag')) {
+        return { tags };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/filter?tag=a&tag=b&tag=c'));
+    expect(await res.json()).toEqual({ tags: ['a', 'b', 'c'] });
+  });
+
+  it('returns empty array for missing parameter', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/filter')
+      filter(tags = queryParams('tag')) {
+        return { tags };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/filter'));
+    expect(await res.json()).toEqual({ tags: [] });
+  });
+});

--- a/packages/core/src/primitives/query-param.test.ts
+++ b/packages/core/src/primitives/query-param.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { createHttpApp } from '../http/app';
 import { Controller } from '../decorators/controller';
 import { Get } from '../decorators/http-method';
+import { createHttpApp } from '../http/app';
+
 import { queryParam, queryParams } from './query-param';
 
 describe('queryParam', () => {

--- a/packages/core/src/primitives/query-param.ts
+++ b/packages/core/src/primitives/query-param.ts
@@ -1,0 +1,9 @@
+import { getEntryContext } from '../internal/entry-context';
+
+export const queryParam = (name: string): string | undefined => {
+  return getEntryContext().honoContext.req.query(name);
+};
+
+export const queryParams = (name: string): string[] => {
+  return getEntryContext().honoContext.req.queries(name) ?? [];
+};

--- a/packages/core/src/primitives/response-cookie.test.ts
+++ b/packages/core/src/primitives/response-cookie.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { createHttpApp } from '../http/app';
+import { Controller } from '../decorators/controller';
+import { Post } from '../decorators/http-method';
+import { response } from './response';
+
+describe('response.setCookie', () => {
+  it('sets a cookie', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/login')
+      login(res = response()) {
+        return res.setCookie('session', 'abc123').json({ ok: true });
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/login', { method: 'POST' }));
+
+    expect(res.headers.get('Set-Cookie')).toBe('session=abc123; Path=/');
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('sets a cookie with options', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/login')
+      login(res = response()) {
+        return res
+          .setCookie('session', 'abc123', {
+            httpOnly: true,
+            secure: true,
+            maxAge: 3600,
+            path: '/',
+          })
+          .json({ ok: true });
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/login', { method: 'POST' }));
+
+    const cookie = res.headers.get('Set-Cookie');
+    expect(cookie).toContain('session=abc123');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('Max-Age=3600');
+  });
+});
+
+describe('response.deleteCookie', () => {
+  it('deletes a cookie', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/logout')
+      logout(res = response()) {
+        return res.deleteCookie('session').json({ ok: true });
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/logout', { method: 'POST' }));
+
+    const cookie = res.headers.get('Set-Cookie');
+    expect(cookie).toContain('session=');
+    expect(cookie).toContain('Max-Age=0');
+  });
+});

--- a/packages/core/src/primitives/response-cookie.test.ts
+++ b/packages/core/src/primitives/response-cookie.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { createHttpApp } from '../http/app';
 import { Controller } from '../decorators/controller';
 import { Post } from '../decorators/http-method';
+import { createHttpApp } from '../http/app';
+
 import { response } from './response';
 
 describe('response.setCookie', () => {

--- a/packages/core/src/primitives/response.ts
+++ b/packages/core/src/primitives/response.ts
@@ -1,6 +1,6 @@
 import type { Context, TypedResponse } from 'hono';
 import { deleteCookie, setCookie } from 'hono/cookie';
-import type { CookieOptions } from 'hono/utils/cookie';
+import type { CookieOptions as HonoCookieOptions } from 'hono/utils/cookie';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 import { getEntryContext } from '../internal/entry-context';
@@ -8,6 +8,16 @@ import { getEntryContext } from '../internal/entry-context';
 // zelt は 300 multi-choice / 304 not-modified / 305-306 deprecated を除外し、
 // AppType / OpenAPI consumer 向けに本物の redirect 3xx だけに narrow する。
 type KoyaRedirectStatusCode = 301 | 302 | 303 | 307 | 308;
+
+export type CookieOptions = {
+  domain?: string;
+  expires?: Date;
+  httpOnly?: boolean;
+  maxAge?: number;
+  path?: string;
+  secure?: boolean;
+  sameSite?: 'Strict' | 'Lax' | 'None';
+};
 
 export type ResponseBuilder = {
   json<T, S extends ContentfulStatusCode = 200>(
@@ -37,8 +47,6 @@ export type ResponseBuilder = {
 
   deleteCookie(name: string, options?: CookieOptions): ResponseBuilder;
 };
-
-export type { CookieOptions };
 
 // Minimal structural view of hono Context for building responses.
 type ResponseContext = Pick<Context, 'json' | 'redirect' | 'text' | 'body' | 'header'>;
@@ -102,11 +110,13 @@ const buildResponseBuilder = (c: Context): ResponseBuilder => {
       return builder;
     },
     setCookie: (name, value, options) => {
-      setCookie(c, name, value, options);
+      const honoOptions: HonoCookieOptions | undefined = options;
+      setCookie(c, name, value, honoOptions);
       return builder;
     },
     deleteCookie: (name, options) => {
-      deleteCookie(c, name, options);
+      const honoOptions: HonoCookieOptions | undefined = options;
+      deleteCookie(c, name, honoOptions);
       return builder;
     },
   };

--- a/packages/core/src/primitives/response.ts
+++ b/packages/core/src/primitives/response.ts
@@ -1,4 +1,6 @@
 import type { Context, TypedResponse } from 'hono';
+import { deleteCookie, setCookie } from 'hono/cookie';
+import type { CookieOptions } from 'hono/utils/cookie';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 import { getEntryContext } from '../internal/entry-context';
@@ -30,7 +32,13 @@ export type ResponseBuilder = {
   ): TypedResponse<T, S, 'body'>;
 
   header(name: string, value: string): ResponseBuilder;
+
+  setCookie(name: string, value: string, options?: CookieOptions): ResponseBuilder;
+
+  deleteCookie(name: string, options?: CookieOptions): ResponseBuilder;
 };
+
+export type { CookieOptions };
 
 // Minimal structural view of hono Context for building responses.
 type ResponseContext = Pick<Context, 'json' | 'redirect' | 'text' | 'body' | 'header'>;
@@ -83,7 +91,7 @@ function makeBody(c: ResponseContext): ResponseBuilder['body'] {
   return body;
 }
 
-const buildResponseBuilder = (c: ResponseContext): ResponseBuilder => {
+const buildResponseBuilder = (c: Context): ResponseBuilder => {
   const builder: ResponseBuilder = {
     json: makeJson(c),
     redirect: makeRedirect(c),
@@ -91,6 +99,14 @@ const buildResponseBuilder = (c: ResponseContext): ResponseBuilder => {
     body: makeBody(c),
     header: (name, value) => {
       c.header(name, value);
+      return builder;
+    },
+    setCookie: (name, value, options) => {
+      setCookie(c, name, value, options);
+      return builder;
+    },
+    deleteCookie: (name, options) => {
+      deleteCookie(c, name, options);
       return builder;
     },
   };

--- a/packages/core/src/primitives/response.ts
+++ b/packages/core/src/primitives/response.ts
@@ -1,6 +1,5 @@
 import type { Context, TypedResponse } from 'hono';
 import { deleteCookie, setCookie } from 'hono/cookie';
-import type { CookieOptions as HonoCookieOptions } from 'hono/utils/cookie';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 import { getEntryContext } from '../internal/entry-context';
@@ -110,13 +109,11 @@ const buildResponseBuilder = (c: Context): ResponseBuilder => {
       return builder;
     },
     setCookie: (name, value, options) => {
-      const honoOptions: HonoCookieOptions | undefined = options;
-      setCookie(c, name, value, honoOptions);
+      setCookie(c, name, value, options);
       return builder;
     },
     deleteCookie: (name, options) => {
-      const honoOptions: HonoCookieOptions | undefined = options;
-      deleteCookie(c, name, honoOptions);
+      deleteCookie(c, name, options);
       return builder;
     },
   };

--- a/packages/core/src/primitives/url.test.ts
+++ b/packages/core/src/primitives/url.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { createHttpApp } from '../http/app';
+import { Controller } from '../decorators/controller';
+import { Get, Post } from '../decorators/http-method';
+import { url, path, method } from './url';
+
+describe('url', () => {
+  it('returns full request URL', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/info')
+      info(u = url()) {
+        return { url: u };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/info?foo=bar'));
+    expect(await res.json()).toEqual({ url: 'http://localhost/info?foo=bar' });
+  });
+});
+
+describe('path', () => {
+  it('returns request path', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/users/:id')
+      user(p = path()) {
+        return { path: p };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+    const res = await app.fetch(new Request('http://localhost/users/123?include=profile'));
+    expect(await res.json()).toEqual({ path: '/users/123' });
+  });
+});
+
+describe('method', () => {
+  it('returns HTTP method', async () => {
+    @Controller('/')
+    class TestController {
+      @Get('/test')
+      getTest(m = method()) {
+        return { method: m };
+      }
+
+      @Post('/test')
+      postTest(m = method()) {
+        return { method: m };
+      }
+    }
+
+    const app = await createHttpApp({ controllers: [TestController] });
+
+    const getRes = await app.fetch(new Request('http://localhost/test'));
+    expect(await getRes.json()).toEqual({ method: 'GET' });
+
+    const postRes = await app.fetch(new Request('http://localhost/test', { method: 'POST' }));
+    expect(await postRes.json()).toEqual({ method: 'POST' });
+  });
+});

--- a/packages/core/src/primitives/url.test.ts
+++ b/packages/core/src/primitives/url.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { createHttpApp } from '../http/app';
 import { Controller } from '../decorators/controller';
 import { Get, Post } from '../decorators/http-method';
-import { url, path, method } from './url';
+import { createHttpApp } from '../http/app';
+
+import { method, path, url } from './url';
 
 describe('url', () => {
   it('returns full request URL', async () => {

--- a/packages/core/src/primitives/url.ts
+++ b/packages/core/src/primitives/url.ts
@@ -1,0 +1,13 @@
+import { getEntryContext } from '../internal/entry-context';
+
+export const url = (): string => {
+  return getEntryContext().honoContext.req.url;
+};
+
+export const path = (): string => {
+  return getEntryContext().honoContext.req.path;
+};
+
+export const method = (): string => {
+  return getEntryContext().honoContext.req.method;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       hono:
         specifier: 4.12.16
         version: 4.12.16
+      ts-pattern:
+        specifier: 5.6.2
+        version: 5.6.2
       valibot:
         specifier: 1.3.1
         version: 1.3.1(typescript@6.0.2)
@@ -8590,6 +8593,9 @@ packages:
 
   ts-morph@28.0.0:
     resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
+
+  ts-pattern@5.6.2:
+    resolution: {integrity: sha512-d4IxJUXROL5NCa3amvMg6VQW2HVtZYmUTPfvVtO7zJWGYLJ+mry9v2OmYm+z67aniQoQ8/yFNadiEwtNS9qQiw==}
 
   ts-pattern@5.7.1:
     resolution: {integrity: sha512-EGs8PguQqAAUIcQfK4E9xdXxB6s2GK4sJfT/vcc9V1ELIvC4LH/zXu2t/5fajtv6oiRCxdv7BgtVK3vWgROxag==}
@@ -18373,6 +18379,8 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
+
+  ts-pattern@5.6.2: {}
 
   ts-pattern@5.7.1: {}
 


### PR DESCRIPTION
## Summary

- Add request helpers: `queryParam()`, `queryParams()`, `header()`, `cookie()`, `url()`, `path()`, `method()`, `body()`
- Add response helpers: `response().setCookie()`, `response().deleteCookie()`
- Wrap Hono's context API with Zelt's functional primitive pattern

## Test plan

- [x] Unit tests for all new primitives (19 new tests)
- [x] All 183 tests passing