### PR TITLE
feat(core): add lazy controller resolution for serverless cold start optimization

### DIFF
--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -1,10 +1,11 @@
 import { serve } from '@hono/node-server';
 import type { ServerType } from '@hono/node-server';
-import { EnvConfig, ProcessEnvConfig, type HttpApp } from '@zeltjs/core';
+import { EnvConfig, ProcessEnvConfig, type HttpApp, type ReadyOptions } from '@zeltjs/core';
 
 type ListenOptions = {
   readonly port?: number;
   readonly hostname?: string;
+  readonly warmup?: boolean;
 };
 
 export type ServerHandle = {
@@ -21,12 +22,12 @@ export const onNode = (app: HttpApp): OnNodeHandle => {
     const options: ListenOptions =
       typeof portOrOptions === 'number' ? { port: portOrOptions } : (portOrOptions ?? {});
 
-    // Auto-inject ProcessEnvConfig if EnvConfig is registered
     if (app.hasConfig(EnvConfig)) {
       app.replaceConfig(EnvConfig, ProcessEnvConfig);
     }
 
-    await app.ready();
+    const readyOptions: ReadyOptions = { warmup: options.warmup ?? true };
+    await app.ready(readyOptions);
 
     const port = options.port ?? 3000;
     const hostname = options.hostname ?? '0.0.0.0';

--- a/packages/core/src/http/app.test.ts
+++ b/packages/core/src/http/app.test.ts
@@ -9,6 +9,7 @@ import { Get, Post } from '../decorators/http-method';
 import { Middleware } from '../decorators/middleware';
 import { SkipMiddleware } from '../decorators/skip-middleware';
 import { UseMiddleware } from '../decorators/use-middleware';
+import { LifecycleManager, type Lifecycle } from '../lifecycle';
 import { inject } from '../primitives/inject';
 import { getContext } from '../primitives/get-context';
 import { pathParam } from '../primitives/path-param';
@@ -716,5 +717,121 @@ describe('replaceConfig', () => {
     const app = createHttpApp({ controllers: [TestController] });
     await app.shutdown();
     expect(() => app.replaceConfig(SomeConfig2, SomeConfig2)).toThrow(/after shutdown\(\)/);
+  });
+});
+
+describe('warmup option', () => {
+  it('lazy mode (default): lifecycle starts on first request', async () => {
+    const events: string[] = [];
+
+    @injectable()
+    class LazyService {
+      constructor(lifecycle = inject(LifecycleManager)) {
+        const lc: Lifecycle = {
+          startup: async () => {
+            events.push('LazyService:startup');
+          },
+          shutdown: async () => {
+            events.push('LazyService:shutdown');
+          },
+        };
+        lifecycle.register(lc);
+      }
+
+      getValue() {
+        return 'lazy';
+      }
+    }
+
+    @Controller('/lazy')
+    class LazyController {
+      constructor(private svc = inject(LazyService)) {}
+
+      @Get('/')
+      get() {
+        return { value: this.svc.getValue() };
+      }
+    }
+
+    const app = createHttpApp({ controllers: [LazyController] });
+    await app.ready();
+
+    expect(events).toEqual([]);
+
+    const res = await app.request('/lazy/');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ value: 'lazy' });
+
+    expect(events).toEqual(['LazyService:startup']);
+    await app.shutdown();
+  });
+
+  it('warmup: true - lifecycle starts during ready()', async () => {
+    const events: string[] = [];
+
+    @injectable()
+    class EagerService {
+      constructor(lifecycle = inject(LifecycleManager)) {
+        const lc: Lifecycle = {
+          startup: async () => {
+            events.push('EagerService:startup');
+          },
+          shutdown: async () => {
+            events.push('EagerService:shutdown');
+          },
+        };
+        lifecycle.register(lc);
+      }
+
+      getValue() {
+        return 'eager';
+      }
+    }
+
+    @Controller('/eager')
+    class EagerController {
+      constructor(private svc = inject(EagerService)) {}
+
+      @Get('/')
+      get() {
+        return { value: this.svc.getValue() };
+      }
+    }
+
+    const app = createHttpApp({ controllers: [EagerController] });
+    await app.ready({ warmup: true });
+
+    expect(events).toEqual(['EagerService:startup']);
+
+    const res = await app.request('/eager/');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ value: 'eager' });
+    await app.shutdown();
+  });
+
+  it('controller instance is cached per request', async () => {
+    let instantiationCount = 0;
+
+    @Controller('/cached')
+    class CachedController {
+      constructor() {
+        instantiationCount++;
+      }
+
+      @Get('/')
+      get() {
+        return { count: instantiationCount };
+      }
+    }
+
+    const app = createHttpApp({ controllers: [CachedController] });
+    await app.ready();
+
+    await app.request('/cached/');
+    await app.request('/cached/');
+    await app.request('/cached/');
+
+    expect(instantiationCount).toBe(1);
+    await app.shutdown();
   });
 });

--- a/packages/core/src/http/app.ts
+++ b/packages/core/src/http/app.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 
 import { createContainer } from '../internal/container';
 import { LifecycleManager } from '../lifecycle';
-import { buildRoutes } from '../internal/route-builder';
+import { buildRoutes, warmupControllers } from '../internal/route-builder';
 import type {
   ErrorHandlerClass,
   ErrorHandlerInstance,
@@ -30,11 +30,15 @@ export type CreateHttpAppOptions = {
   readonly configs?: readonly (new (...args: never[]) => object)[];
 };
 
+export type ReadyOptions = {
+  readonly warmup?: boolean;
+};
+
 export type HttpApp = {
   readonly fetch: (request: Request) => Promise<Response>;
   readonly request: (input: string | Request, init?: RequestInit) => Promise<Response>;
   readonly shutdown: () => Promise<void>;
-  readonly ready: () => Promise<void>;
+  readonly ready: (options?: ReadyOptions) => Promise<void>;
   readonly hasConfig: (token: AnyConfigClass) => boolean;
   readonly replaceConfig: (token: AnyConfigClass, replacement: AnyConfigClass) => void;
   /** @deprecated Scheduler now starts automatically. Use shutdown() to stop. */
@@ -83,13 +87,21 @@ const registerScheduler = (
   return runner;
 };
 
-const setupHono = (options: CreateHttpAppOptions, resolver: Resolver): Hono => {
-  // strict:false で `/echo` と `/echo/` を同一視する。joinPath が末尾スラッシュを正規化するため、
-  // 利用者が `@Post('/')` と書いた場合でも `/echo/` リクエストにマッチさせる必要がある。
+const setupHono = (
+  options: CreateHttpAppOptions,
+  resolver: Resolver,
+  lifecycle: LifecycleManager,
+): Hono => {
   const hono = new Hono({ strict: false });
   const errorHandlers = resolveErrorHandlers(options.errorHandlers ?? [], resolver);
   hono.onError(createErrorHandler(errorHandlers));
-  buildRoutes(hono, options.controllers, resolver, options.middlewares ?? []);
+  buildRoutes({
+    hono,
+    controllers: options.controllers,
+    resolver,
+    lifecycle,
+    globalMiddlewares: options.middlewares ?? [],
+  });
   return hono;
 };
 
@@ -97,21 +109,27 @@ type BuiltApp = {
   readonly hono: Hono;
   readonly lifecycle: LifecycleManager;
   readonly schedulerRunner: SchedulerRunner | undefined;
+  readonly resolver: Resolver;
+  readonly controllers: readonly ControllerClass[];
 };
 
-const buildApp = async (
-  options: CreateHttpAppOptions,
-  configOverrides: ReadonlyMap<AnyConstructorClass, AnyConstructorClass>,
-): Promise<BuiltApp> => {
-  const effectiveConfigs = applyOverrides(options.configs ?? [], configOverrides);
+type BuildAppOptions = {
+  readonly appOptions: CreateHttpAppOptions;
+  readonly configOverrides: ReadonlyMap<AnyConstructorClass, AnyConstructorClass>;
+  readonly warmup: boolean;
+};
+
+const buildApp = async (buildOptions: BuildAppOptions): Promise<BuiltApp> => {
+  const { appOptions, configOverrides, warmup } = buildOptions;
+  const effectiveConfigs = applyOverrides(appOptions.configs ?? [], configOverrides);
   const resolver = createContainer({ configs: effectiveConfigs });
   const lifecycle = resolver.get(LifecycleManager);
 
   instantiateConfigs(effectiveConfigs, resolver);
-  const schedulerRunner = registerScheduler(options.schedulers, resolver, lifecycle);
+  const schedulerRunner = registerScheduler(appOptions.schedulers, resolver, lifecycle);
 
   try {
-    await lifecycle.startup();
+    await lifecycle.startupPending();
   } catch (error) {
     await lifecycle.shutdown();
     throw error;
@@ -119,13 +137,22 @@ const buildApp = async (
 
   let hono: Hono;
   try {
-    hono = setupHono(options, resolver);
+    hono = setupHono(appOptions, resolver, lifecycle);
   } catch (error) {
     await lifecycle.shutdown();
     throw error;
   }
 
-  return { hono, lifecycle, schedulerRunner };
+  if (warmup) {
+    try {
+      await warmupControllers(appOptions.controllers, resolver, lifecycle);
+    } catch (error) {
+      await lifecycle.shutdown();
+      throw error;
+    }
+  }
+
+  return { hono, lifecycle, schedulerRunner, resolver, controllers: appOptions.controllers };
 };
 
 const applyOverrides = (
@@ -173,15 +200,23 @@ const createReplaceConfig =
     state.configOverrides.set(token, replacement);
   };
 
-const createReady = (options: CreateHttpAppOptions, state: AppState) => async (): Promise<void> => {
-  if (state.disposed) throw new Error('Cannot ready() after shutdown()');
-  if (state.built) return;
-  if (state.readyPromise) return state.readyPromise;
-  state.readyPromise = buildApp(options, state.configOverrides).then((b) => {
-    state.built = b;
-  });
-  return state.readyPromise;
-};
+const createReady =
+  (options: CreateHttpAppOptions, state: AppState) =>
+  async (readyOptions?: ReadyOptions): Promise<void> => {
+    if (state.disposed) throw new Error('Cannot ready() after shutdown()');
+    if (state.built) return;
+    if (state.readyPromise) return state.readyPromise;
+
+    const warmup = readyOptions?.warmup ?? false;
+    state.readyPromise = buildApp({
+      appOptions: options,
+      configOverrides: state.configOverrides,
+      warmup,
+    }).then((b) => {
+      state.built = b;
+    });
+    return state.readyPromise;
+  };
 
 const createShutdown = (state: AppState) => async (): Promise<void> => {
   if (state.disposed) return;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { createHttpApp } from './http/app';
-export type { CreateHttpAppOptions, HttpApp } from './http/app';
+export type { CreateHttpAppOptions, HttpApp, ReadyOptions } from './http/app';
 
 export { validationErrorBodySchema } from './http/error-schema';
 export type { ValidationErrorBody } from './http/error-schema';

--- a/packages/core/src/internal/route-builder.test.ts
+++ b/packages/core/src/internal/route-builder.test.ts
@@ -5,6 +5,7 @@ import * as v from 'valibot';
 
 import { Controller } from '../decorators/controller';
 import { Get, Post } from '../decorators/http-method';
+import { LifecycleManager } from '../lifecycle';
 import { validated } from '../primitives/validated';
 
 import { createContainer } from './container';
@@ -68,7 +69,14 @@ class PassthroughController {
 describe('buildRoutes (instanceof Response branch)', () => {
   it('returns a hand-built Response as-is (instanceof Response branch)', async () => {
     const hono = new Hono({ strict: false });
-    buildRoutes(hono, [PassthroughController], createContainer());
+    const resolver = createContainer();
+    const lifecycle = resolver.get(LifecycleManager);
+    buildRoutes({
+      hono,
+      controllers: [PassthroughController],
+      resolver,
+      lifecycle,
+    });
     const res = await hono.fetch(new Request('http://x/passthrough/teapot'));
     expect(res.status).toBe(418);
     expect(res.headers.get('X-Custom')).toBe('yes');
@@ -113,7 +121,14 @@ describe('route-builder — error path integration', () => {
 
   const hono = new Hono({ strict: false });
   hono.onError(createOnError());
-  buildRoutes(hono, [ErrController], createContainer());
+  const resolver = createContainer();
+  const lifecycle = resolver.get(LifecycleManager);
+  buildRoutes({
+    hono,
+    controllers: [ErrController],
+    resolver,
+    lifecycle,
+  });
 
   it('serializes HTTPException to status + custom body via getResponse()', async () => {
     const res = await hono.fetch(new Request('http://x/err/not-found'));

--- a/packages/core/src/internal/route-builder.ts
+++ b/packages/core/src/internal/route-builder.ts
@@ -1,6 +1,7 @@
 import type { Context, Env, Hono, Input } from 'hono';
 import * as v from 'valibot';
 
+import type { LifecycleManager } from '../lifecycle';
 import type { FunctionMiddleware, MiddlewareClass, MiddlewareInput } from '../middleware/types';
 import { currentRoles, currentUser } from '../primitives/auth';
 
@@ -213,31 +214,50 @@ const composeHandler = (
   };
 };
 
+type RouteBuilderContext = {
+  readonly resolver: ResolverHandle;
+  readonly lifecycle: LifecycleManager;
+  readonly instanceCache: Map<ControllerClass, object>;
+};
+
+const getOrCreateInstance = (
+  ctx: RouteBuilderContext,
+  controllerClass: ControllerClass,
+): object => {
+  const cached = ctx.instanceCache.get(controllerClass);
+  if (cached) return cached;
+  const instance = ctx.resolver.get(controllerClass);
+  ctx.instanceCache.set(controllerClass, instance);
+  return instance;
+};
+
 const registerRoute = (
   hono: Hono,
-  resolver: ResolverHandle,
+  ctx: RouteBuilderContext,
   route: Route,
   globalMiddlewares: readonly MiddlewareInput[],
 ): void => {
-  const instance = resolver.get(route.controllerClass);
-  const invoke = resolveHandler(instance, route.methodName);
-
   const middlewares = collectRouteMiddlewares(
     globalMiddlewares,
     route.controllerClass,
     route.methodName,
-    resolver,
+    ctx.resolver,
   );
 
-  const finalHandler = async (c: MiddlewareContext): Promise<Response> => {
-    const result = await invoke();
-    if (result instanceof Response) return result;
-    return c.json(result);
-  };
-
-  const composedHandler = composeHandler(middlewares, finalHandler);
-
   const handler = async (c: MiddlewareContext): Promise<Response> => {
+    const instance = getOrCreateInstance(ctx, route.controllerClass);
+    await ctx.lifecycle.startupPending();
+
+    const invoke = resolveHandler(instance, route.methodName);
+
+    const finalHandler = async (ctx: MiddlewareContext): Promise<Response> => {
+      const result = await invoke();
+      if (result instanceof Response) return result;
+      return ctx.json(result);
+    };
+
+    const composedHandler = composeHandler(middlewares, finalHandler);
+
     const { jsonBody, formBody } = await parseRequestBodies(c);
     const pathParams: Readonly<Record<string, string>> = c.req.param();
     return runInEntryContext({ input: { jsonBody, formBody, pathParams }, honoContext: c }, () =>
@@ -256,13 +276,33 @@ const registerRoute = (
   methods[route.method]();
 };
 
-export const buildRoutes = (
-  hono: Hono,
+export type BuildRoutesOptions = {
+  readonly hono: Hono;
+  readonly controllers: readonly ControllerClass[];
+  readonly resolver: ResolverHandle;
+  readonly lifecycle: LifecycleManager;
+  readonly globalMiddlewares?: readonly MiddlewareInput[];
+};
+
+export const buildRoutes = (options: BuildRoutesOptions): void => {
+  const ctx: RouteBuilderContext = {
+    resolver: options.resolver,
+    lifecycle: options.lifecycle,
+    instanceCache: new Map(),
+  };
+
+  for (const route of collectRoutes(options.controllers)) {
+    registerRoute(options.hono, ctx, route, options.globalMiddlewares ?? []);
+  }
+};
+
+export const warmupControllers = async (
   controllers: readonly ControllerClass[],
   resolver: ResolverHandle,
-  globalMiddlewares: readonly MiddlewareInput[] = [],
-): void => {
-  for (const route of collectRoutes(controllers)) {
-    registerRoute(hono, resolver, route, globalMiddlewares);
+  lifecycle: LifecycleManager,
+): Promise<void> => {
+  for (const cls of controllers) {
+    resolver.get(cls);
   }
+  await lifecycle.startupPending();
 };

--- a/packages/core/src/lifecycle.test.ts
+++ b/packages/core/src/lifecycle.test.ts
@@ -102,4 +102,58 @@ describe('LifecycleManager', () => {
 
     expect(maxConcurrent).toBe(1);
   });
+
+  it('startupPending only starts newly registered lifecycles', async () => {
+    const manager = new LifecycleManager();
+    const events: string[] = [];
+
+    const first: Lifecycle = {
+      startup: async () => {
+        events.push('first:start');
+      },
+      shutdown: async () => {},
+    };
+    const second: Lifecycle = {
+      startup: async () => {
+        events.push('second:start');
+      },
+      shutdown: async () => {},
+    };
+    const third: Lifecycle = {
+      startup: async () => {
+        events.push('third:start');
+      },
+      shutdown: async () => {},
+    };
+
+    manager.register(first);
+    manager.register(second);
+    await manager.startupPending();
+
+    expect(events).toEqual(['first:start', 'second:start']);
+
+    manager.register(third);
+    await manager.startupPending();
+
+    expect(events).toEqual(['first:start', 'second:start', 'third:start']);
+  });
+
+  it('startupPending is idempotent when no new lifecycles registered', async () => {
+    const manager = new LifecycleManager();
+    let callCount = 0;
+
+    const lifecycle: Lifecycle = {
+      startup: async () => {
+        callCount++;
+      },
+      shutdown: async () => {},
+    };
+
+    manager.register(lifecycle);
+    await manager.startupPending();
+    await manager.startupPending();
+    await manager.startupPending();
+
+    expect(callCount).toBe(1);
+  });
 });

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -11,20 +11,29 @@ export interface Lifecycle extends Disposable {
 @injectable()
 export class LifecycleManager {
   private readonly lifecycles: Lifecycle[] = [];
+  private startedIndex = 0;
 
   register(lifecycle: Lifecycle): void {
     this.lifecycles.push(lifecycle);
   }
 
   async startup(): Promise<void> {
-    for (const lc of this.lifecycles) {
-      await lc.startup();
+    await this.startupPending();
+  }
+
+  async startupPending(): Promise<void> {
+    while (this.startedIndex < this.lifecycles.length) {
+      const lc = this.lifecycles[this.startedIndex];
+      if (lc) await lc.startup();
+      this.startedIndex++;
     }
   }
 
   async shutdown(): Promise<void> {
-    for (const lc of [...this.lifecycles].reverse()) {
-      await lc.shutdown();
+    const stopAt = Math.max(this.startedIndex, this.lifecycles.length);
+    for (let i = stopAt - 1; i >= 0; i--) {
+      const lc = this.lifecycles[i];
+      if (lc) await lc.shutdown();
     }
   }
 }

--- a/packages/core/src/primitives/response.test.ts
+++ b/packages/core/src/primitives/response.test.ts
@@ -5,6 +5,7 @@ import { Controller } from '../decorators/controller';
 import { Get, Post } from '../decorators/http-method';
 import { createContainer } from '../internal/container';
 import { buildRoutes } from '../internal/route-builder';
+import { LifecycleManager } from '../lifecycle';
 
 import { response } from './response';
 
@@ -38,7 +39,14 @@ class ResponseTestController {
 
 describe('response()', () => {
   const hono = new Hono({ strict: false });
-  buildRoutes(hono, [ResponseTestController], createContainer());
+  const resolver = createContainer();
+  const lifecycle = resolver.get(LifecycleManager);
+  buildRoutes({
+    hono,
+    controllers: [ResponseTestController],
+    resolver,
+    lifecycle,
+  });
 
   it('json status code', async () => {
     const res = await hono.fetch(new Request('http://x/r/json'));


### PR DESCRIPTION
## Summary

- Add `LifecycleManager.startupPending()` for incremental lifecycle startup - only starts newly registered lifecycles
- Move controller resolution from `buildRoutes()` to request time, enabling lazy instantiation
- Add `warmup` option to `ready()` (default: `false` for lazy mode)
- Update `adapter-node` to use `warmup: true` by default for Node.js servers

## Motivation

Serverless environments (Lambda/Cloudflare Workers) benefit from lazy controller resolution. With this change:
- `HelloController` (no DB dependency) responds immediately
- `UserController` (depends on `DBService`) initializes its lifecycle only on first request

## Breaking Changes

- `ready()` default behavior changed to lazy mode
- Node.js users via `onNode()` are unaffected (defaults to eager via `warmup: true`)

## Test plan

- [x] `LifecycleManager.startupPending()` tests added
- [x] Lazy vs eager resolution behavior tests added
- [x] `warmup` option tests added
- [x] All existing tests pass