### PR TITLE
refactor: move Node.js-specific env configs to adapter-node

### DIFF
--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "@hono/node-server": "2.0.1",
-    "@zeltjs/core": "workspace:*"
+    "@zeltjs/core": "workspace:*",
+    "dotenv": "17.4.2"
   },
   "devDependencies": {
     "@types/node": "22.19.17"

--- a/packages/adapter-node/src/dotenv.config.ts
+++ b/packages/adapter-node/src/dotenv.config.ts
@@ -1,8 +1,6 @@
 import { config } from 'dotenv';
 
-import { Config } from '../../config';
-
-import { EnvConfig } from './env.config';
+import { Config, EnvConfig } from '@zeltjs/core';
 
 @Config
 export class DotEnvConfig extends EnvConfig {

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -4,4 +4,7 @@ export type { ServeOptions, AddressInfo } from './serve';
 export { onNode } from './on-node';
 export type { ServerHandle } from './on-node';
 
+export { ProcessEnvConfig } from './process-env.config';
+export { DotEnvConfig } from './dotenv.config';
+
 export { createAdaptorServer } from '@hono/node-server';

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createHttpApp, Controller, Get, EnvConfig, ProcessEnvConfig } from '@zeltjs/core';
+import { createHttpApp, Controller, Get, EnvConfig } from '@zeltjs/core';
 
 import { onNode, type ServerHandle } from './on-node';
+import { ProcessEnvConfig } from './process-env.config';
 
 describe('onNode', () => {
   let handle: ServerHandle | undefined;

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -1,6 +1,8 @@
 import { serve } from '@hono/node-server';
 import type { ServerType } from '@hono/node-server';
-import { EnvConfig, ProcessEnvConfig, type HttpApp } from '@zeltjs/core';
+import { EnvConfig, type HttpApp } from '@zeltjs/core';
+
+import { ProcessEnvConfig } from './process-env.config';
 
 type ListenOptions = {
   readonly port?: number;

--- a/packages/adapter-node/src/process-env.config.ts
+++ b/packages/adapter-node/src/process-env.config.ts
@@ -1,0 +1,8 @@
+import { Config, EnvConfig } from '@zeltjs/core';
+
+@Config
+export class ProcessEnvConfig extends EnvConfig {
+  override get(key: string): string | undefined {
+    return process.env[key];
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "croner": "9.1.0",
-    "dotenv": "17.4.2",
     "hono": "4.12.16",
     "ts-pattern": "5.6.2",
     "valibot": "1.3.1"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,4 +69,4 @@ export type { Lifecycle, Disposable } from './lifecycle';
 
 export { Logger } from './modules/logger';
 
-export { EnvConfig, ProcessEnvConfig, DotEnvConfig, EnvService } from './modules/env';
+export { EnvConfig, EnvService } from './modules/env';

--- a/packages/core/src/modules/env/env.config.ts
+++ b/packages/core/src/modules/env/env.config.ts
@@ -8,10 +8,3 @@ export class EnvConfig {
     return undefined;
   }
 }
-
-@Config
-export class ProcessEnvConfig extends EnvConfig {
-  override get(key: string): string | undefined {
-    return process.env[key];
-  }
-}

--- a/packages/core/src/modules/env/env.service.test.ts
+++ b/packages/core/src/modules/env/env.service.test.ts
@@ -1,15 +1,24 @@
+/// <reference types="node" />
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { Config } from '../../config';
 import { createTestTargetBase } from '../../internal/container';
 
-import { ProcessEnvConfig } from './env.config';
+import { EnvConfig } from './env.config';
 import { EnvService } from './env.service';
+
+@Config
+class TestProcessEnvConfig extends EnvConfig {
+  override get(key: string): string | undefined {
+    return process.env[key];
+  }
+}
 
 let service: EnvService;
 
 const setupEnvService = async () => {
   const result = await createTestTargetBase(EnvService, {
-    configs: [ProcessEnvConfig],
+    configs: [TestProcessEnvConfig],
   });
   service = result.target;
   return result;

--- a/packages/core/src/modules/env/index.ts
+++ b/packages/core/src/modules/env/index.ts
@@ -1,3 +1,2 @@
-export { EnvConfig, ProcessEnvConfig } from './env.config';
-export { DotEnvConfig } from './dotenv.config';
+export { EnvConfig } from './env.config';
 export { EnvService } from './env.service';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,8 +9,7 @@
     "sourceMap": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "experimentalDecorators": true,
-    "erasableSyntaxOnly": false,
-    "types": ["node"]
+    "erasableSyntaxOnly": false
   },
   "include": ["src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
+      dotenv:
+        specifier: 17.4.2
+        version: 17.4.2
     devDependencies:
       '@types/node':
         specifier: 22.19.17
@@ -286,9 +289,6 @@ importers:
       croner:
         specifier: 9.1.0
         version: 9.1.0
-      dotenv:
-        specifier: 17.4.2
-        version: 17.4.2
       hono:
         specifier: 4.12.16
         version: 4.12.16


### PR DESCRIPTION
## Summary

- Move `ProcessEnvConfig` and `DotEnvConfig` from `@zeltjs/core` to `@zeltjs/adapter-node`
- Remove `dotenv` dependency from core, add to adapter-node
- Remove `types: ["node"]` from core tsconfig.json
- Core package is now runtime-agnostic (no Node.js dependency)

## Changes

| File | Change |
|------|--------|
| `adapter-node/src/process-env.config.ts` | New file - moved from core |
| `adapter-node/src/dotenv.config.ts` | New file - moved from core |
| `core/src/modules/env/env.config.ts` | Removed `ProcessEnvConfig` |
| `core/src/modules/env/dotenv.config.ts` | Deleted |
| `core/tsconfig.json` | Removed `types: ["node"]` |

## Test plan

- [x] `pnpm --filter @zeltjs/core test` passes
- [x] `pnpm --filter @zeltjs/adapter-node test` passes
- [x] `pnpm build` succeeds
- [x] `pnpm typecheck` succeeds