### PR TITLE
feat(adapters)!: make onNode and onCloudflareWorkers async with get() support

### DIFF
--- a/examples/drizzle-todo/src/app.ts
+++ b/examples/drizzle-todo/src/app.ts
@@ -7,4 +7,4 @@ export const app = createHttpApp({
   controllers,
 });
 
-export default onNode(app);
+export default await onNode(app);

--- a/examples/hello/src/app.ts
+++ b/examples/hello/src/app.ts
@@ -9,4 +9,4 @@ export const app = createHttpApp({
   middlewares: [loggingMiddleware],
 });
 
-export default onNode(app);
+export default await onNode(app);

--- a/packages/adapter-cloudflare-workers/src/index.ts
+++ b/packages/adapter-cloudflare-workers/src/index.ts
@@ -1,3 +1,3 @@
 export { onCloudflareWorkers } from './on-cloudflare-workers';
-export type { CloudflareWorkersHandle, CloudflareWorkersOptions } from './on-cloudflare-workers';
+export type { CloudflareWorkersApp, CloudflareWorkersOptions } from './on-cloudflare-workers';
 export { CloudflareWorkersEnvConfig } from './cloudflare-workers-env.config';

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
@@ -20,20 +20,22 @@ const createMockExecutionContext = () =>
   }) as unknown as ExecutionContext;
 
 describe('onCloudflareWorkers', () => {
-  it('returns a fetch handler', () => {
+  it('returns CloudflareWorkersApp with get and fetch', async () => {
     const app = createHttpApp({ controllers: [HelloController] });
-    const handle = onCloudflareWorkers(app);
+    const workersApp = await onCloudflareWorkers(app);
 
-    expect(handle.fetch).toBeDefined();
-    expect(typeof handle.fetch).toBe('function');
+    expect(workersApp.fetch).toBeDefined();
+    expect(typeof workersApp.fetch).toBe('function');
+    expect(workersApp.get).toBeDefined();
+    expect(typeof workersApp.get).toBe('function');
   });
 
   it('handles requests and returns responses', async () => {
     const app = createHttpApp({ controllers: [HelloController] });
-    const handle = onCloudflareWorkers(app);
+    const workersApp = await onCloudflareWorkers(app);
     const ctx = createMockExecutionContext();
 
-    const res = await handle.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    const res = await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ message: 'hello from workers' });
@@ -42,10 +44,8 @@ describe('onCloudflareWorkers', () => {
   it('defaults to lazy mode (warmup: false)', async () => {
     const app = createHttpApp({ controllers: [HelloController] });
     const readySpy = vi.spyOn(app, 'ready');
-    const handle = onCloudflareWorkers(app);
-    const ctx = createMockExecutionContext();
 
-    await handle.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    await onCloudflareWorkers(app);
 
     expect(readySpy).toHaveBeenCalledWith({ warmup: false });
   });
@@ -53,33 +53,31 @@ describe('onCloudflareWorkers', () => {
   it('respects warmup: true option', async () => {
     const app = createHttpApp({ controllers: [HelloController] });
     const readySpy = vi.spyOn(app, 'ready');
-    const handle = onCloudflareWorkers(app, { warmup: true });
-    const ctx = createMockExecutionContext();
 
-    await handle.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    await onCloudflareWorkers(app, { warmup: true });
 
     expect(readySpy).toHaveBeenCalledWith({ warmup: true });
   });
 
-  it('calls ready() only once across multiple requests', async () => {
+  it('ready() is called once during onCloudflareWorkers', async () => {
     const app = createHttpApp({ controllers: [HelloController] });
     const readySpy = vi.spyOn(app, 'ready');
-    const handle = onCloudflareWorkers(app);
     const ctx = createMockExecutionContext();
 
-    await handle.fetch(new Request('https://example.com/hello/'), {}, ctx);
-    await handle.fetch(new Request('https://example.com/hello/'), {}, ctx);
-    await handle.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    const workersApp = await onCloudflareWorkers(app);
+    await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
 
     expect(readySpy).toHaveBeenCalledTimes(1);
   });
 
   it('calls waitUntil on ExecutionContext', async () => {
     const app = createHttpApp({ controllers: [HelloController] });
-    const handle = onCloudflareWorkers(app);
+    const workersApp = await onCloudflareWorkers(app);
     const ctx = createMockExecutionContext();
 
-    await handle.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
 
     expect(ctx.waitUntil).toHaveBeenCalled();
   });
@@ -90,10 +88,8 @@ describe('onCloudflareWorkers', () => {
       configs: [EnvConfig],
     });
     const replaceConfigSpy = vi.spyOn(app, 'replaceConfig');
-    const handle = onCloudflareWorkers(app);
-    const ctx = createMockExecutionContext();
 
-    await handle.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    await onCloudflareWorkers(app);
 
     expect(replaceConfigSpy).toHaveBeenCalledWith(EnvConfig, CloudflareWorkersEnvConfig);
   });
@@ -101,11 +97,20 @@ describe('onCloudflareWorkers', () => {
   it('does not call replaceConfig when EnvConfig is not registered', async () => {
     const app = createHttpApp({ controllers: [HelloController] });
     const replaceConfigSpy = vi.spyOn(app, 'replaceConfig');
-    const handle = onCloudflareWorkers(app);
-    const ctx = createMockExecutionContext();
 
-    await handle.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    await onCloudflareWorkers(app);
 
     expect(replaceConfigSpy).not.toHaveBeenCalled();
+  });
+
+  it('provides get() to retrieve dependencies from container', async () => {
+    const app = createHttpApp({
+      controllers: [HelloController],
+      configs: [EnvConfig],
+    });
+    const workersApp = await onCloudflareWorkers(app);
+
+    const env = workersApp.get(EnvConfig);
+    expect(env.get).toBeTypeOf('function');
   });
 });

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.ts
@@ -6,37 +6,32 @@ export type CloudflareWorkersOptions = {
   readonly warmup?: boolean;
 };
 
-export type CloudflareWorkersHandle = {
+export type CloudflareWorkersApp = {
+  readonly get: <T extends object>(cls: new (...args: never[]) => T) => T;
   readonly fetch: (request: Request, env: unknown, ctx: ExecutionContext) => Promise<Response>;
+  readonly shutdown: () => Promise<void>;
 };
 
-export const onCloudflareWorkers = (
+export const onCloudflareWorkers = async (
   app: HttpApp,
   options: CloudflareWorkersOptions = {},
-): CloudflareWorkersHandle => {
-  let readyPromise: Promise<void> | undefined;
+): Promise<CloudflareWorkersApp> => {
+  if (app.hasConfig(EnvConfig)) {
+    app.replaceConfig(EnvConfig, CloudflareWorkersEnvConfig);
+  }
 
-  const ensureReady = (): Promise<void> => {
-    if (!readyPromise) {
-      if (app.hasConfig(EnvConfig)) {
-        app.replaceConfig(EnvConfig, CloudflareWorkersEnvConfig);
-      }
-      const readyOptions: ReadyOptions = { warmup: options.warmup ?? false };
-      readyPromise = app.ready(readyOptions);
-    }
-    return readyPromise;
-  };
+  const readyOptions: ReadyOptions = { warmup: options.warmup ?? false };
+  const { get } = await app.ready(readyOptions);
 
   const fetch = async (
     request: Request,
     _env: unknown,
     ctx: ExecutionContext,
   ): Promise<Response> => {
-    await ensureReady();
     const response = app.fetch(request);
     ctx.waitUntil(response.then(() => {}));
     return response;
   };
 
-  return { fetch };
+  return { get, fetch, shutdown: app.shutdown };
 };

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -1,18 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createHttpApp, Controller, Get, EnvConfig } from '@zeltjs/core';
 
-import { onNode, type ServerHandle } from './on-node';
+import { onNode, type ServerHandle, type NodeApp } from './on-node';
 import { ProcessEnvConfig } from './process-env.config';
 
 describe('onNode', () => {
+  let nodeApp: NodeApp | undefined;
   let handle: ServerHandle | undefined;
 
   afterEach(async () => {
     await handle?.shutdown();
     handle = undefined;
+    nodeApp = undefined;
   });
 
-  it('calls ready and returns server handle', async () => {
+  it('calls ready and returns NodeApp with get and listen', async () => {
     @Controller('/')
     class TestController {
       @Get('/')
@@ -22,7 +24,8 @@ describe('onNode', () => {
     }
 
     const app = createHttpApp({ controllers: [TestController] });
-    handle = await onNode(app).listen(0);
+    nodeApp = await onNode(app);
+    handle = await nodeApp.listen(0);
 
     expect(handle.address.port).toBeGreaterThan(0);
     expect(handle.shutdown).toBeTypeOf('function');
@@ -42,14 +45,15 @@ describe('onNode', () => {
     }
 
     const app = createHttpApp({ controllers: [PingController] });
-    handle = await onNode(app).listen(0);
+    nodeApp = await onNode(app);
+    handle = await nodeApp.listen(0);
 
     expect(handle.address.port).toBeGreaterThan(0);
     const res = await fetch(`http://localhost:${handle.address.port}/`);
     expect(res.status).toBe(200);
   });
 
-  it('calls app.ready() before serving', async () => {
+  it('calls app.ready() during onNode', async () => {
     @Controller('/health')
     class HealthController {
       @Get('/')
@@ -61,10 +65,11 @@ describe('onNode', () => {
     const app = createHttpApp({ controllers: [HealthController] });
     const readySpy = vi.spyOn(app, 'ready');
 
-    handle = await onNode(app).listen(0);
+    nodeApp = await onNode(app);
 
     expect(readySpy).toHaveBeenCalledOnce();
 
+    handle = await nodeApp.listen(0);
     const res = await fetch(`http://localhost:${handle.address.port}/health/`);
     const body: { status: string } = await res.json();
     expect(body.status).toBe('ok');
@@ -77,7 +82,7 @@ describe('onNode', () => {
     });
     const replaceConfigSpy = vi.spyOn(app, 'replaceConfig');
 
-    handle = await onNode(app).listen(0);
+    nodeApp = await onNode(app);
 
     expect(replaceConfigSpy).toHaveBeenCalledWith(EnvConfig, ProcessEnvConfig);
   });
@@ -92,7 +97,8 @@ describe('onNode', () => {
     }
 
     const app = createHttpApp({ controllers: [SimpleController] });
-    handle = await onNode(app).listen(0);
+    nodeApp = await onNode(app);
+    handle = await nodeApp.listen(0);
 
     const res = await fetch(`http://localhost:${handle.address.port}/`);
     expect(res.status).toBe(200);
@@ -108,12 +114,32 @@ describe('onNode', () => {
     }
 
     const app = createHttpApp({ controllers: [ShutdownController] });
-    handle = await onNode(app).listen(0);
+    nodeApp = await onNode(app);
+    handle = await nodeApp.listen(0);
     const { port } = handle.address;
 
     await handle.shutdown();
     handle = undefined;
 
     await expect(fetch(`http://localhost:${port}/`)).rejects.toThrow();
+  });
+
+  it('provides get() to retrieve dependencies from container', async () => {
+    @Controller('/')
+    class ServiceController {
+      @Get('/')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    const app = createHttpApp({
+      controllers: [ServiceController],
+      configs: [EnvConfig],
+    });
+    nodeApp = await onNode(app);
+
+    const env = nodeApp.get(EnvConfig);
+    expect(env.get).toBeTypeOf('function');
   });
 });

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -7,7 +7,6 @@ import { ProcessEnvConfig } from './process-env.config';
 type ListenOptions = {
   readonly port?: number;
   readonly hostname?: string;
-  readonly warmup?: boolean;
 };
 
 export type ServerHandle = {
@@ -15,24 +14,30 @@ export type ServerHandle = {
   readonly shutdown: () => Promise<void>;
 };
 
-type OnNodeHandle = {
-  readonly listen: (portOrOptions?: number | ListenOptions) => Promise<ServerHandle>;
+export type NodeAppOptions = {
+  readonly warmup?: boolean;
 };
 
-export const onNode = (app: HttpApp): OnNodeHandle => {
+export type NodeApp = {
+  readonly get: <T extends object>(cls: new (...args: never[]) => T) => T;
+  readonly listen: (portOrOptions?: number | ListenOptions) => Promise<ServerHandle>;
+  readonly shutdown: () => Promise<void>;
+};
+
+export const onNode = async (app: HttpApp, options: NodeAppOptions = {}): Promise<NodeApp> => {
+  if (app.hasConfig(EnvConfig)) {
+    app.replaceConfig(EnvConfig, ProcessEnvConfig);
+  }
+
+  const readyOptions: ReadyOptions = { warmup: options.warmup ?? true };
+  const { get } = await app.ready(readyOptions);
+
   const listen = async (portOrOptions?: number | ListenOptions): Promise<ServerHandle> => {
-    const options: ListenOptions =
+    const listenOptions: ListenOptions =
       typeof portOrOptions === 'number' ? { port: portOrOptions } : (portOrOptions ?? {});
 
-    if (app.hasConfig(EnvConfig)) {
-      app.replaceConfig(EnvConfig, ProcessEnvConfig);
-    }
-
-    const readyOptions: ReadyOptions = { warmup: options.warmup ?? true };
-    await app.ready(readyOptions);
-
-    const port = options.port ?? 3000;
-    const hostname = options.hostname ?? '0.0.0.0';
+    const port = listenOptions.port ?? 3000;
+    const hostname = listenOptions.hostname ?? '0.0.0.0';
 
     let server!: ServerType;
     const serverReady = new Promise<{ port: number; address: string }>((resolve) => {
@@ -53,5 +58,5 @@ export const onNode = (app: HttpApp): OnNodeHandle => {
     return { address, shutdown };
   };
 
-  return { listen };
+  return { get, listen, shutdown: app.shutdown };
 };

--- a/packages/core/src/http/app.test.ts
+++ b/packages/core/src/http/app.test.ts
@@ -613,9 +613,11 @@ describe('createHttpApp 2-phase initialization', () => {
     }
 
     const app = createHttpApp({ controllers: [TestController] });
-    await app.ready();
-    // Second call must not throw and must not re-initialize
-    await expect(app.ready()).resolves.toBeUndefined();
+    const result1 = await app.ready();
+    // Second call must not throw and must return same result
+    const result2 = await app.ready();
+    expect(result1.get).toBeDefined();
+    expect(result2.get).toBeDefined();
     await app.shutdown();
   });
 

--- a/packages/core/src/http/app.ts
+++ b/packages/core/src/http/app.ts
@@ -34,11 +34,15 @@ export type ReadyOptions = {
   readonly warmup?: boolean;
 };
 
+export type ReadyResult = {
+  readonly get: <T extends object>(cls: new (...args: never[]) => T) => T;
+};
+
 export type HttpApp = {
   readonly fetch: (request: Request) => Promise<Response>;
   readonly request: (input: string | Request, init?: RequestInit) => Promise<Response>;
   readonly shutdown: () => Promise<void>;
-  readonly ready: (options?: ReadyOptions) => Promise<void>;
+  readonly ready: (options?: ReadyOptions) => Promise<ReadyResult>;
   readonly hasConfig: (token: AnyConfigClass) => boolean;
   readonly replaceConfig: (token: AnyConfigClass, replacement: AnyConfigClass) => void;
   /** @deprecated Scheduler now starts automatically. Use shutdown() to stop. */
@@ -173,7 +177,7 @@ const assertConfigToken = (
   }
 };
 
-const awaitSafe = async (p: Promise<void>): Promise<void> => {
+const awaitSafe = async (p: Promise<unknown>): Promise<void> => {
   try {
     await p;
   } catch {
@@ -187,7 +191,7 @@ const configHasToken = (configs: readonly AnyConstructorClass[], token: AnyConfi
 type AppState = {
   built: BuiltApp | undefined;
   disposed: boolean;
-  readyPromise: Promise<void> | undefined;
+  readyPromise: Promise<ReadyResult> | undefined;
   readonly configOverrides: Map<AnyConfigClass, AnyConfigClass>;
 };
 
@@ -200,11 +204,14 @@ const createReplaceConfig =
     state.configOverrides.set(token, replacement);
   };
 
+const createReadyResult = (resolver: Resolver): ReadyResult => ({
+  get: <T extends object>(cls: new (...args: never[]) => T): T => resolver.get(cls),
+});
+
 const createReady =
   (options: CreateHttpAppOptions, state: AppState) =>
-  async (readyOptions?: ReadyOptions): Promise<void> => {
+  async (readyOptions?: ReadyOptions): Promise<ReadyResult> => {
     if (state.disposed) throw new Error('Cannot ready() after shutdown()');
-    if (state.built) return;
     if (state.readyPromise) return state.readyPromise;
 
     const warmup = readyOptions?.warmup ?? false;
@@ -214,6 +221,7 @@ const createReady =
       warmup,
     }).then((b) => {
       state.built = b;
+      return createReadyResult(b.resolver);
     });
     return state.readyPromise;
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { createHttpApp } from './http/app';
-export type { CreateHttpAppOptions, HttpApp, ReadyOptions } from './http/app';
+export type { CreateHttpAppOptions, HttpApp, ReadyOptions, ReadyResult } from './http/app';
 
 export { validationErrorBodySchema } from './http/error-schema';
 export type { ValidationErrorBody } from './http/error-schema';


### PR DESCRIPTION
## Summary

- `HttpApp.ready()` now returns `ReadyResult` with `get()` method for DI container access
- `onNode(app)` returns `Promise<NodeApp>` with `get`, `listen`, `shutdown`
- `onCloudflareWorkers(app)` returns `Promise<CloudflareWorkersApp>` with `get`, `fetch`, `shutdown`

## Motivation

Enable pre-listen operations like database migrations:

```ts
const app = await onNode(createHttpApp({ ... }));
await app.get(Database).migrate();
await app.listen(3000);
```

Makes `onNode` and `onCloudflareWorkers` symmetric - both call `ready()` internally and return an app handle with `get()`.

## Breaking Changes

- `onNode()` now returns `Promise<NodeApp>` instead of `OnNodeHandle`
- `onCloudflareWorkers()` now returns `Promise<CloudflareWorkersApp>` instead of `CloudflareWorkersHandle`

## Test plan

- [x] All existing tests updated and passing
- [x] New test for `get()` method on both adapters