### PR TITLE
feat(rate-limit)!: remove neverthrow from public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "nx run-many -t build",
+    "check:no-neverthrow-leak": "grep -r 'neverthrow' packages/*/dist/*.d.ts 2>/dev/null && echo 'WARN: neverthrow leaked to public API' || true",
     "format": "biome format --write .",
     "format:check": "biome check .",
     "lint": "eslint . && oxlint .",
@@ -16,7 +17,7 @@
     "codepolicy": "codepolicy",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "precommit": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm build && pnpm test && npx precommit-verify save",
+    "precommit": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm build && pnpm check:no-neverthrow-leak && pnpm test && npx precommit-verify save",
     "prepare": "npx lefthook install"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Adapt rate-limit package to new KV API (Promise/throw pattern)
- Remove neverthrow dependency from kv, kv-driver-redis, rate-limit packages
- Add `check:no-neverthrow-leak` script to precommit (warn only)

## BREAKING CHANGE

`RateLimiter.hit()` and `reset()` now return `Promise<{ ok: true, value } | { ok: false, error }>` instead of `ResultAsync`.

## Test plan

- [x] All rate-limit tests pass
- [x] Knip passes (no unused neverthrow deps)
- [x] precommit passes