### PR TITLE
refactor(eslint): restrict @needle-di/core imports to core/command/cli

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -290,4 +290,26 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: ['packages/**/*.{ts,tsx}'],
+    ignores: [
+      'packages/core/**/*.{ts,tsx}',
+      'packages/command/**/*.{ts,tsx}',
+      'packages/cli/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@needle-di/core',
+              message:
+                'Import from @zeltjs/core or @zeltjs/testing instead. Direct @needle-di/core imports are only allowed in packages/core, packages/command, and packages/cli.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -34,9 +34,9 @@
     "neverthrow": "8.2.0"
   },
   "devDependencies": {
-    "@needle-di/core": "1.1.2",
     "@types/node": "22.19.17",
     "@zeltjs/core": "workspace:*",
+    "@zeltjs/testing": "workspace:*",
     "hono": "4.12.16"
   }
 }

--- a/packages/auth-jwt/src/jwt.middleware.test.ts
+++ b/packages/auth-jwt/src/jwt.middleware.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Container } from '@needle-di/core';
+import { createTestTarget } from '@zeltjs/testing';
 import {
   Controller,
   Get,
@@ -51,10 +51,11 @@ class JwtServiceTestConfig extends JwtConfig {
   }
 }
 
-const buildJwtService = () => {
-  const container = new Container();
-  container.bind({ provide: JwtConfig, useValue: new JwtServiceTestConfig() });
-  return container.get(JwtService);
+const buildJwtService = async () => {
+  const testTarget = await createTestTarget(JwtService, {
+    configs: [JwtServiceTestConfig],
+  });
+  return { jwtService: testTarget.target, shutdown: testTarget.shutdown };
 };
 
 describe('JwtMiddleware', () => {
@@ -81,7 +82,7 @@ describe('JwtMiddleware', () => {
   });
 
   it('should allow request with valid token', async () => {
-    const jwtService = buildJwtService();
+    const { jwtService, shutdown } = await buildJwtService();
     const token = await jwtService.sign({ sub: 'user-123' });
     const res = await (await buildApp()).request('/protected/', {
       headers: { Authorization: `Bearer ${token}` },
@@ -90,10 +91,10 @@ describe('JwtMiddleware', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { message: string };
     expect(body.message).toBe('success');
+    await shutdown();
   });
 
   it('should return 401 for expired token', async () => {
-    const expiredContainer = new Container();
     class ExpiredConfig extends JwtConfig {
       override get secret(): string {
         return 'test-secret-key-for-testing-only';
@@ -102,9 +103,10 @@ describe('JwtMiddleware', () => {
         return '0s';
       }
     }
-    expiredContainer.bind({ provide: JwtConfig, useValue: new ExpiredConfig() });
-    const expiredJwtService = expiredContainer.get(JwtService);
-    const token = await expiredJwtService.sign({ sub: 'user-123' });
+    const expiredTarget = await createTestTarget(JwtService, {
+      configs: [ExpiredConfig],
+    });
+    const token = await expiredTarget.target.sign({ sub: 'user-123' });
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -113,6 +115,7 @@ describe('JwtMiddleware', () => {
     });
 
     expect(res.status).toBe(401);
+    await expiredTarget.shutdown();
   });
 });
 
@@ -138,7 +141,7 @@ describe('JwtMiddleware — setUser integration', () => {
     });
     await httpApp.ready();
 
-    const jwtService = buildJwtService();
+    const { jwtService, shutdown } = await buildJwtService();
     const token = await jwtService.sign({ sub: 'user-42' });
 
     const res = await httpApp.request('/user-check/', {
@@ -148,6 +151,7 @@ describe('JwtMiddleware — setUser integration', () => {
     expect(res.status).toBe(200);
     expect(capturedUser).toBe('user-42');
     expect(capturedRoles).toEqual(['user', 'admin']);
+    await shutdown();
   });
 });
 
@@ -191,10 +195,11 @@ describe('JwtMiddleware — cookie driver', () => {
     return app;
   };
 
-  const buildCookieJwtService = () => {
-    const container = new Container();
-    container.bind({ provide: JwtConfig, useClass: CookieDriverConfig });
-    return container.get(JwtService);
+  const buildCookieJwtService = async () => {
+    const testTarget = await createTestTarget(JwtService, {
+      configs: [CookieDriverConfig],
+    });
+    return { jwtService: testTarget.target, shutdown: testTarget.shutdown };
   };
 
   it('should return 401 when no cookie is present', async () => {
@@ -204,17 +209,18 @@ describe('JwtMiddleware — cookie driver', () => {
   });
 
   it('should return 401 when Authorization header is used instead of cookie', async () => {
-    const jwtService = buildCookieJwtService();
+    const { jwtService, shutdown } = await buildCookieJwtService();
     const token = await jwtService.sign({ sub: 'user-123' });
     const res = await (await buildCookieApp()).request('/cookie-protected/', {
       headers: { Authorization: `Bearer ${token}` },
     });
 
     expect(res.status).toBe(401);
+    await shutdown();
   });
 
   it('should allow request with valid cookie', async () => {
-    const jwtService = buildCookieJwtService();
+    const { jwtService, shutdown } = await buildCookieJwtService();
     const token = await jwtService.sign({ sub: 'user-123' });
     const res = await (await buildCookieApp()).request('/cookie-protected/', {
       headers: { Cookie: `auth_token=${token}` },
@@ -223,6 +229,7 @@ describe('JwtMiddleware — cookie driver', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { message: string };
     expect(body.message).toBe('cookie-success');
+    await shutdown();
   });
 
   it('should return 401 for invalid cookie token', async () => {
@@ -252,7 +259,7 @@ describe('JwtMiddleware — cookie driver', () => {
     });
     await httpApp.ready();
 
-    const jwtService = buildCookieJwtService();
+    const { jwtService, shutdown } = await buildCookieJwtService();
     const token = await jwtService.sign({ sub: 'cookie-user-99' });
 
     const res = await httpApp.request('/cookie-user-check/', {
@@ -261,5 +268,6 @@ describe('JwtMiddleware — cookie driver', () => {
 
     expect(res.status).toBe(200);
     expect(capturedUser).toBe('cookie-user-99');
+    await shutdown();
   });
 });

--- a/packages/auth-jwt/src/jwt.service.test.ts
+++ b/packages/auth-jwt/src/jwt.service.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { Container } from '@needle-di/core';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestTarget, type TestTargetResult } from '@zeltjs/testing';
 
 import { JwtService } from './jwt.service';
 import { JwtConfig } from './jwt.config';
@@ -15,12 +15,18 @@ class TestJwtConfig extends JwtConfig {
 }
 
 describe('JwtService', () => {
+  let testTarget: TestTargetResult<JwtService>;
   let jwtService: JwtService;
 
-  beforeEach(() => {
-    const container = new Container();
-    container.bind({ provide: JwtConfig, useValue: new TestJwtConfig() });
-    jwtService = container.get(JwtService);
+  beforeEach(async () => {
+    testTarget = await createTestTarget(JwtService, {
+      configs: [TestJwtConfig],
+    });
+    jwtService = testTarget.target;
+  });
+
+  afterEach(async () => {
+    await testTarget.shutdown();
   });
 
   describe('sign', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,15 +179,15 @@ importers:
         specifier: 8.2.0
         version: 8.2.0
     devDependencies:
-      '@needle-di/core':
-        specifier: 1.1.2
-        version: 1.1.2
       '@types/node':
         specifier: 22.19.17
         version: 22.19.17
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
+      '@zeltjs/testing':
+        specifier: workspace:*
+        version: link:../testing
       hono:
         specifier: 4.12.16
         version: 4.12.16


### PR DESCRIPTION
## Summary

- Add ESLint `no-restricted-imports` rule to prohibit direct `@needle-di/core` imports outside `packages/core`, `packages/command`, and `packages/cli`
- Migrate `packages/auth-jwt` tests from `Container` to `createTestTarget` from `@zeltjs/testing`

## Motivation

DI implementation details (`@needle-di/core`) should be encapsulated within core packages. Other packages should use the public APIs from `@zeltjs/core` or `@zeltjs/testing`.

## Test plan

- [x] All tests pass (`pnpm test`)
- [x] ESLint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)