### PR TITLE
refactor(cli,contract): remove neverthrow from public API

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -126,15 +126,20 @@ export default tseslint.config(
     ],
     rules: {
       '@9wick/strict-type-rules/no-throw': 'off',
+      '@9wick/strict-type-rules/no-try-catch': 'off',
+      '@9wick/strict-type-rules/no-type-predicate': 'off',
     },
   },
   {
     // CLI tool entry points: console output is the user-visible UX, watch loop must catch
     // regeneration errors to keep watching after a failure rather than crashing the process.
+    // Type predicate and in operator needed for ContractError type guard.
     files: ['packages/contract/src/watch.ts', 'packages/contract/src/cli.ts'],
     rules: {
       'no-console': 'off',
       '@9wick/strict-type-rules/no-try-catch': 'off',
+      '@9wick/strict-type-rules/no-type-predicate': 'off',
+      '@9wick/strict-type-rules/no-in-operator': 'off',
     },
   },
   {
@@ -207,6 +212,25 @@ export default tseslint.config(
     rules: {
       '@9wick/strict-type-rules/no-as-assertion': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
+    },
+  },
+  {
+    // CLI entry points: throw/catch at user-facing boundaries for error reporting.
+    // Public API returns Promise (not ResultAsync) to avoid neverthrow leak.
+    // Type predicate needed for error type guard.
+    files: [
+      'packages/cli/src/config/loader.ts',
+      'packages/cli/src/builders/tsdown.ts',
+      'packages/cli/src/commands/run/runner.ts',
+      'packages/cli/src/commands/run/loader.ts',
+      'packages/cli/src/commands/run.ts',
+      'packages/cli/src/commands/dev.ts',
+      'packages/cli/src/commands/build.ts',
+    ],
+    rules: {
+      '@9wick/strict-type-rules/no-throw': 'off',
+      '@9wick/strict-type-rules/no-try-catch': 'off',
+      '@9wick/strict-type-rules/no-type-predicate': 'off',
     },
   },
   {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,6 @@
     "chokidar": "5.0.0",
     "citty": "0.1.6",
     "consola": "3.4.2",
-    "neverthrow": "8.2.0",
     "tinyglobby": "0.2.14",
     "ts-pattern": "5.7.1"
   },

--- a/packages/cli/src/builders/tsdown.ts
+++ b/packages/cli/src/builders/tsdown.ts
@@ -2,7 +2,6 @@ import { spawn } from 'node:child_process';
 import { resolve } from 'node:path';
 
 import consola from 'consola';
-import { errAsync, okAsync, ResultAsync } from 'neverthrow';
 
 import type { BuildConfig } from '../config/schema';
 
@@ -11,7 +10,15 @@ export type BuildOptions = {
   readonly config: BuildConfig;
 };
 
-export type BuildError = { type: 'BUILD_FAILED'; exitCode: number };
+export class BuildError extends Error {
+  readonly type = 'BUILD_FAILED' as const;
+  readonly exitCode: number;
+  constructor(exitCode: number) {
+    super(`Build failed with exit code ${exitCode}`);
+    this.name = 'BuildError';
+    this.exitCode = exitCode;
+  }
+}
 
 const buildArgs = (config: BuildConfig): string[] => {
   const args: string[] = [];
@@ -42,7 +49,7 @@ const buildArgs = (config: BuildConfig): string[] => {
   return args;
 };
 
-export const runTsdownBuild = (options: BuildOptions): ResultAsync<void, BuildError> => {
+export const runTsdownBuild = async (options: BuildOptions): Promise<void> => {
   const { cwd, config } = options;
   const args = buildArgs(config);
 
@@ -51,26 +58,22 @@ export const runTsdownBuild = (options: BuildOptions): ResultAsync<void, BuildEr
 
   const tsdownBin = resolve(cwd, 'node_modules/.bin/tsdown');
 
-  return ResultAsync.fromPromise(
-    new Promise<number>((resolvePromise, rejectPromise) => {
-      const child = spawn(tsdownBin, args, {
-        cwd,
-        stdio: 'inherit',
-      });
+  const exitCode = await new Promise<number>((resolvePromise, rejectPromise) => {
+    const child = spawn(tsdownBin, args, {
+      cwd,
+      stdio: 'inherit',
+    });
 
-      child.on('close', (code) => {
-        resolvePromise(code ?? 0);
-      });
+    child.on('close', (code) => {
+      resolvePromise(code ?? 0);
+    });
 
-      child.on('error', (err) => {
-        rejectPromise(err);
-      });
-    }),
-    () => ({ type: 'BUILD_FAILED' as const, exitCode: 1 }),
-  ).andThen((exitCode) => {
-    if (exitCode !== 0) {
-      return errAsync({ type: 'BUILD_FAILED' as const, exitCode });
-    }
-    return okAsync(undefined);
+    child.on('error', (err) => {
+      rejectPromise(err);
+    });
   });
+
+  if (exitCode !== 0) {
+    throw new BuildError(exitCode);
+  }
 };

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,10 +1,9 @@
 import { defineCommand } from 'citty';
 import consola from 'consola';
-import { errAsync, type ResultAsync } from 'neverthrow';
 import { match } from 'ts-pattern';
 
-import { type BuildError, runTsdownBuild } from '../builders/tsdown';
-import { type ConfigLoadError, loadZeltConfig } from '../config/loader';
+import { BuildError, runTsdownBuild } from '../builders/tsdown';
+import { ConfigLoadError, loadZeltConfig } from '../config/loader';
 import type { BuildConfig } from '../config/schema';
 
 type BuildArgs = {
@@ -13,7 +12,11 @@ type BuildArgs = {
   readonly outDir?: string;
 };
 
-type RunBuildError = ConfigLoadError | BuildError | { type: 'NO_ENTRY' };
+class NoEntryError extends Error {
+  readonly type = 'NO_ENTRY' as const;
+}
+
+type RunBuildError = ConfigLoadError | BuildError | NoEntryError;
 
 const resolveBuildConfig = (args: BuildArgs, buildConfig: BuildConfig | undefined) => ({
   ...buildConfig,
@@ -21,25 +24,32 @@ const resolveBuildConfig = (args: BuildArgs, buildConfig: BuildConfig | undefine
   outDir: args.outDir ?? buildConfig?.outDir,
 });
 
-const runBuild = (cwd: string, typedArgs: BuildArgs): ResultAsync<void, RunBuildError> => {
+const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
   const configFile = typedArgs.config;
+  const config = await loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd });
+  const buildConfig = resolveBuildConfig(typedArgs, config.build);
 
-  return loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd }).andThen(
-    (config) => {
-      const buildConfig = resolveBuildConfig(typedArgs, config.build);
+  if (buildConfig.entry === undefined) {
+    throw new NoEntryError();
+  }
 
-      if (buildConfig.entry === undefined) {
-        return errAsync({ type: 'NO_ENTRY' as const });
-      }
+  consola.start('Building...');
+  await runTsdownBuild({ cwd, config: buildConfig });
+  consola.success('Build completed');
+};
 
-      consola.start('Building...');
-
-      return runTsdownBuild({ cwd, config: buildConfig }).map(() => {
-        consola.success('Build completed');
-        return undefined;
-      });
-    },
-  );
+const handleError = (error: RunBuildError): void => {
+  match(error)
+    .with({ type: 'CONFIG_LOAD_FAILED' }, () => {
+      consola.error('Failed to load config');
+    })
+    .with({ type: 'NO_ENTRY' }, () => {
+      consola.error('No entry file specified. Use --entry or set build.entry in zelt.config.ts');
+    })
+    .with({ type: 'BUILD_FAILED' }, () => {
+      consola.error('Build failed');
+    })
+    .exhaustive();
 };
 
 export const buildCommand = defineCommand({
@@ -68,24 +78,18 @@ export const buildCommand = defineCommand({
     const cwd = globalThis.process.cwd();
     const typedArgs: BuildArgs = args;
 
-    const result = await runBuild(cwd, typedArgs);
-
-    result.match(
-      () => {},
-      (error) =>
-        match(error)
-          .with({ type: 'CONFIG_LOAD_FAILED' }, () => {
-            consola.error('Failed to load config');
-          })
-          .with({ type: 'NO_ENTRY' }, () => {
-            consola.error(
-              'No entry file specified. Use --entry or set build.entry in zelt.config.ts',
-            );
-          })
-          .with({ type: 'BUILD_FAILED' }, () => {
-            consola.error('Build failed');
-          })
-          .exhaustive(),
-    );
+    try {
+      await runBuild(cwd, typedArgs);
+    } catch (error) {
+      if (
+        error instanceof ConfigLoadError ||
+        error instanceof BuildError ||
+        error instanceof NoEntryError
+      ) {
+        handleError(error);
+      } else {
+        throw error;
+      }
+    }
   },
 });

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,9 +1,8 @@
 import { defineCommand } from 'citty';
 import consola from 'consola';
-import { errAsync, ResultAsync } from 'neverthrow';
 import { match } from 'ts-pattern';
 
-import { type ConfigLoadError, loadZeltConfig } from '../config/loader';
+import { ConfigLoadError, loadZeltConfig } from '../config/loader';
 import type { DevConfig } from '../config/schema';
 import { startDevServer } from '../dev-server/server';
 
@@ -13,7 +12,11 @@ type DevArgs = {
   readonly port?: string;
 };
 
-type DevError = ConfigLoadError | { type: 'NO_ENTRY' };
+class NoEntryError extends Error {
+  readonly type = 'NO_ENTRY' as const;
+}
+
+type DevError = ConfigLoadError | NoEntryError;
 
 const resolveDevConfig = (args: DevArgs, devConfig: DevConfig | undefined) => {
   const entry = args.entry ?? devConfig?.entry;
@@ -26,22 +29,27 @@ const resolveDevConfig = (args: DevArgs, devConfig: DevConfig | undefined) => {
   };
 };
 
-const runDev = (cwd: string, typedArgs: DevArgs): ResultAsync<void, DevError> => {
+const runDev = async (cwd: string, typedArgs: DevArgs): Promise<void> => {
   const configFile = typedArgs.config;
+  const config = await loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd });
+  const devConfig = resolveDevConfig(typedArgs, config.dev);
 
-  return loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd }).andThen(
-    (config) => {
-      const devConfig = resolveDevConfig(typedArgs, config.dev);
+  if (devConfig.entry === undefined) {
+    throw new NoEntryError();
+  }
 
-      if (devConfig.entry === undefined) {
-        return errAsync({ type: 'NO_ENTRY' as const });
-      }
+  await startDevServer({ cwd, config: { ...devConfig, entry: devConfig.entry } });
+};
 
-      return ResultAsync.fromSafePromise(
-        startDevServer({ cwd, config: { ...devConfig, entry: devConfig.entry } }),
-      );
-    },
-  );
+const handleError = (error: DevError): void => {
+  match(error)
+    .with({ type: 'CONFIG_LOAD_FAILED' }, () => {
+      consola.error('Failed to load config');
+    })
+    .with({ type: 'NO_ENTRY' }, () => {
+      consola.error('No entry file specified. Use --entry or set dev.entry in zelt.config.ts');
+    })
+    .exhaustive();
 };
 
 export const devCommand = defineCommand({
@@ -70,21 +78,14 @@ export const devCommand = defineCommand({
     const cwd = globalThis.process.cwd();
     const typedArgs: DevArgs = args;
 
-    const result = await runDev(cwd, typedArgs);
-
-    result.match(
-      () => {},
-      (error) =>
-        match(error)
-          .with({ type: 'CONFIG_LOAD_FAILED' }, () => {
-            consola.error('Failed to load config');
-          })
-          .with({ type: 'NO_ENTRY' }, () => {
-            consola.error(
-              'No entry file specified. Use --entry or set dev.entry in zelt.config.ts',
-            );
-          })
-          .exhaustive(),
-    );
+    try {
+      await runDev(cwd, typedArgs);
+    } catch (error) {
+      if (error instanceof ConfigLoadError || error instanceof NoEntryError) {
+        handleError(error);
+      } else {
+        throw error;
+      }
+    }
   },
 });

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,49 +1,57 @@
 import type { CommandClass } from '@zeltjs/command';
 import { defineCommand } from 'citty';
 import consola from 'consola';
-import { err, ok, type Result, type ResultAsync } from 'neverthrow';
 import { match } from 'ts-pattern';
 
-import { type ConfigLoadError, loadZeltConfig } from '../config/loader';
+import { ConfigLoadError, loadZeltConfig } from '../config/loader';
 
-import { type LoadCommandsError, loadCommands } from './run/loader';
-import { type RunCommandError, runCommand } from './run/runner';
+import { type LoadCommandsError, GlobError, ImportError, loadCommands } from './run/loader';
+import { CommandExecutionError, runCommand } from './run/runner';
+
+class NoCommandsConfigError extends Error {
+  readonly type = 'NO_COMMANDS_CONFIG' as const;
+}
+
+class CommandNotFoundError extends Error {
+  readonly type = 'COMMAND_NOT_FOUND' as const;
+  readonly commandName: string;
+  readonly available: string[];
+  constructor(name: string, available: string[]) {
+    super(`Command not found: ${name}`);
+    this.name = 'CommandNotFoundError';
+    this.commandName = name;
+    this.available = available;
+  }
+}
 
 type RunError =
   | ConfigLoadError
   | LoadCommandsError
-  | RunCommandError
-  | { type: 'NO_COMMANDS_CONFIG' }
-  | { type: 'COMMAND_NOT_FOUND'; name: string; available: string[] };
+  | CommandExecutionError
+  | NoCommandsConfigError
+  | CommandNotFoundError;
 
-const findCommand = (
-  commands: Map<string, CommandClass>,
-  name: string,
-): Result<CommandClass, RunError> => {
+const findCommand = (commands: Map<string, CommandClass>, name: string): CommandClass => {
   const commandClass = commands.get(name);
   if (!commandClass) {
-    return err({
-      type: 'COMMAND_NOT_FOUND',
-      name,
-      available: [...commands.keys()],
-    });
+    throw new CommandNotFoundError(name, [...commands.keys()]);
   }
-  return ok(commandClass);
+  return commandClass;
 };
 
-const executeCommand = (
+const executeCommand = async (
   cwd: string,
   commandsPattern: string | undefined,
   commandName: string,
   commandArgs: string[],
-): ResultAsync<void, RunError> => {
+): Promise<void> => {
   if (!commandsPattern) {
-    return err({ type: 'NO_COMMANDS_CONFIG' } as const) as unknown as ResultAsync<void, RunError>;
+    throw new NoCommandsConfigError();
   }
 
-  return loadCommands(cwd, commandsPattern)
-    .andThen((commands) => findCommand(commands, commandName))
-    .andThen((commandClass) => runCommand(commandClass, commandArgs));
+  const commands = await loadCommands(cwd, commandsPattern);
+  const commandClass = findCommand(commands, commandName);
+  await runCommand(commandClass, commandArgs);
 };
 
 const handleError = (error: RunError): void => {
@@ -61,7 +69,7 @@ const handleError = (error: RunError): void => {
       consola.error(`Failed to import command file: ${e.file}`, e.cause);
     })
     .with({ type: 'COMMAND_NOT_FOUND' }, (e) => {
-      consola.error(`Command not found: ${e.name}`);
+      consola.error(`Command not found: ${e.commandName}`);
       consola.info('Available commands:');
       for (const name of e.available) {
         consola.info(`  - ${name}`);
@@ -71,6 +79,24 @@ const handleError = (error: RunError): void => {
       consola.error('Command execution failed:', e.cause);
     })
     .exhaustive();
+};
+
+const isRunError = (error: unknown): error is RunError =>
+  error instanceof ConfigLoadError ||
+  error instanceof GlobError ||
+  error instanceof ImportError ||
+  error instanceof CommandExecutionError ||
+  error instanceof NoCommandsConfigError ||
+  error instanceof CommandNotFoundError;
+
+const runMain = async (
+  cwd: string,
+  configFile: string | undefined,
+  commandName: string,
+  commandArgs: string[],
+): Promise<void> => {
+  const config = await loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd });
+  await executeCommand(cwd, config.commands, commandName, commandArgs);
 };
 
 export const runCommandDef = defineCommand({
@@ -96,12 +122,14 @@ export const runCommandDef = defineCommand({
     const commandName = args.command as string;
     const commandArgs = rawArgs.slice(rawArgs.indexOf(commandName) + 1);
 
-    const result = await loadZeltConfig(
-      configFile !== undefined ? { cwd, configFile } : { cwd },
-    ).andThen((config) => executeCommand(cwd, config.commands, commandName, commandArgs));
-
-    if (result.isErr()) {
-      handleError(result.error);
+    try {
+      await runMain(cwd, configFile, commandName, commandArgs);
+    } catch (error) {
+      if (isRunError(error)) {
+        handleError(error);
+      } else {
+        throw error;
+      }
     }
   },
 });

--- a/packages/cli/src/commands/run/loader.test.ts
+++ b/packages/cli/src/commands/run/loader.test.ts
@@ -32,20 +32,14 @@ describe('loadCommands', () => {
 
     const result = await loadCommands(testDir, '*.mjs');
 
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value.size).toBe(1);
-      expect(result.value.has('greet')).toBe(true);
-    }
+    expect(result.size).toBe(1);
+    expect(result.has('greet')).toBe(true);
   });
 
   it('returns empty map when no commands found', async () => {
     const result = await loadCommands(testDir, '*.mjs');
 
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value.size).toBe(0);
-    }
+    expect(result.size).toBe(0);
   });
 
   it('handles multiple commands in one file', async () => {
@@ -65,11 +59,8 @@ describe('loadCommands', () => {
 
     const result = await loadCommands(testDir, '*.mjs');
 
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value.size).toBe(2);
-      expect(result.value.has('foo')).toBe(true);
-      expect(result.value.has('bar')).toBe(true);
-    }
+    expect(result.size).toBe(2);
+    expect(result.has('foo')).toBe(true);
+    expect(result.has('bar')).toBe(true);
   });
 });

--- a/packages/cli/src/commands/run/loader.ts
+++ b/packages/cli/src/commands/run/loader.ts
@@ -1,18 +1,37 @@
 import { pathToFileURL } from 'node:url';
 
 import { getCommandMetadata, type CommandClass } from '@zeltjs/command';
-import { fromPromise, okAsync, type ResultAsync } from 'neverthrow';
 import { glob } from 'tinyglobby';
 
-export type LoadCommandsError =
-  | { type: 'GLOB_FAILED'; cause: unknown }
-  | { type: 'IMPORT_FAILED'; file: string; cause: unknown };
+export class GlobError extends Error {
+  readonly type = 'GLOB_FAILED' as const;
+  constructor(cause: unknown) {
+    super('Failed to scan command files');
+    this.name = 'GlobError';
+    this.cause = cause;
+  }
+}
 
-const importModule = (file: string): ResultAsync<Record<string, unknown>, LoadCommandsError> =>
-  fromPromise(
-    import(pathToFileURL(file).href) as Promise<Record<string, unknown>>,
-    (cause) => ({ type: 'IMPORT_FAILED', file, cause }) as const,
-  );
+export class ImportError extends Error {
+  readonly type = 'IMPORT_FAILED' as const;
+  readonly file: string;
+  constructor(file: string, cause: unknown) {
+    super(`Failed to import command file: ${file}`);
+    this.name = 'ImportError';
+    this.file = file;
+    this.cause = cause;
+  }
+}
+
+export type LoadCommandsError = GlobError | ImportError;
+
+const importModule = async (file: string): Promise<Record<string, unknown>> => {
+  try {
+    return (await import(pathToFileURL(file).href)) as Record<string, unknown>;
+  } catch (cause) {
+    throw new ImportError(file, cause);
+  }
+};
 
 const extractCommands = (module: Record<string, unknown>): Map<string, CommandClass> => {
   const commandMap = new Map<string, CommandClass>();
@@ -27,34 +46,30 @@ const extractCommands = (module: Record<string, unknown>): Map<string, CommandCl
   return commandMap;
 };
 
-const importAndExtract = (
+const importAndExtract = async (
   file: string,
   commandMap: Map<string, CommandClass>,
-): ResultAsync<void, LoadCommandsError> =>
-  importModule(file).map((module) => {
-    for (const [name, cls] of extractCommands(module)) {
-      commandMap.set(name, cls);
-    }
-    return undefined;
-  });
+): Promise<void> => {
+  const module = await importModule(file);
+  for (const [name, cls] of extractCommands(module)) {
+    commandMap.set(name, cls);
+  }
+};
 
-const importAllFiles = (
-  files: string[],
-  commandMap: Map<string, CommandClass>,
-): ResultAsync<void, LoadCommandsError> =>
-  files.reduce<ResultAsync<void, LoadCommandsError>>(
-    (acc, file) => acc.andThen(() => importAndExtract(file, commandMap)),
-    okAsync(undefined),
-  );
-
-export const loadCommands = (
+export const loadCommands = async (
   cwd: string,
   pattern: string,
-): ResultAsync<Map<string, CommandClass>, LoadCommandsError> =>
-  fromPromise(
-    glob(pattern, { cwd, absolute: true }),
-    (cause) => ({ type: 'GLOB_FAILED', cause }) as const,
-  ).andThen((files) => {
-    const commandMap = new Map<string, CommandClass>();
-    return importAllFiles(files, commandMap).map(() => commandMap);
-  });
+): Promise<Map<string, CommandClass>> => {
+  let files: string[];
+  try {
+    files = await glob(pattern, { cwd, absolute: true });
+  } catch (cause) {
+    throw new GlobError(cause);
+  }
+
+  const commandMap = new Map<string, CommandClass>();
+  for (const file of files) {
+    await importAndExtract(file, commandMap);
+  }
+  return commandMap;
+};

--- a/packages/cli/src/commands/run/runner.test.ts
+++ b/packages/cli/src/commands/run/runner.test.ts
@@ -1,7 +1,7 @@
 import { Command } from '@zeltjs/command';
 import { describe, expect, it } from 'vitest';
 
-import { runCommand } from './runner';
+import { CommandExecutionError, runCommand } from './runner';
 
 describe('runCommand', () => {
   it('executes command with parsed args and options', async () => {
@@ -23,9 +23,8 @@ describe('runCommand', () => {
 
     const GreetCommand = Command({ name: 'greet' })(GreetCommandBase);
 
-    const result = await runCommand(GreetCommand, ['Alice', '--verbose']);
+    await runCommand(GreetCommand, ['Alice', '--verbose']);
 
-    expect(result.isOk()).toBe(true);
     expect(received.name).toBe('Alice');
     expect(received.verbose).toBe(true);
   });
@@ -45,13 +44,12 @@ describe('runCommand', () => {
 
     const DeployCommand = Command({ name: 'deploy' })(DeployCommandBase);
 
-    const result = await runCommand(DeployCommand, []);
+    await runCommand(DeployCommand, []);
 
-    expect(result.isOk()).toBe(true);
     expect(received.env).toBe('production');
   });
 
-  it('returns error when command throws', async () => {
+  it('throws CommandExecutionError when command throws', async () => {
     class FailingCommandBase {
       run() {
         throw new Error('Command failed');
@@ -60,11 +58,6 @@ describe('runCommand', () => {
 
     const FailingCommand = Command({ name: 'fail' })(FailingCommandBase);
 
-    const result = await runCommand(FailingCommand, []);
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.type).toBe('COMMAND_EXECUTION_FAILED');
-    }
+    await expect(runCommand(FailingCommand, [])).rejects.toThrow(CommandExecutionError);
   });
 });

--- a/packages/cli/src/commands/run/runner.ts
+++ b/packages/cli/src/commands/run/runner.ts
@@ -2,9 +2,15 @@ import type { CommandClass, CommandContext } from '@zeltjs/command';
 import { Container } from '@needle-di/core';
 import type { ArgsDef, BooleanArgDef, StringArgDef } from 'citty';
 import { parseArgs } from 'citty';
-import { fromPromise, fromThrowable, ok, type Result, type ResultAsync } from 'neverthrow';
 
-export type RunCommandError = { type: 'COMMAND_EXECUTION_FAILED'; cause: unknown };
+export class CommandExecutionError extends Error {
+  readonly type = 'COMMAND_EXECUTION_FAILED' as const;
+  constructor(cause: unknown) {
+    super('Command execution failed');
+    this.name = 'CommandExecutionError';
+    this.cause = cause;
+  }
+}
 
 type InstanceShape = {
   args?: Record<string, { type: string; default?: string }>;
@@ -75,7 +81,7 @@ const buildOptions = (instance: InstanceShape, parsed: ParsedArgs): Record<strin
 const parseAndResolve = (
   commandClass: CommandClass,
   argv: string[],
-): Result<{ instance: InstanceShape; ctx: CommandContext }, never> => {
+): { instance: InstanceShape; ctx: CommandContext } => {
   const cittyArgs = buildCittyArgs(commandClass);
   const parsed = parseArgs(argv, cittyArgs) as ParsedArgs;
 
@@ -87,30 +93,14 @@ const parseAndResolve = (
     options: buildOptions(instance, parsed),
   } as CommandContext;
 
-  return ok({ instance, ctx });
+  return { instance, ctx };
 };
 
-const executeRun = (
-  instance: InstanceShape,
-  ctx: CommandContext,
-): ResultAsync<void, RunCommandError> => {
-  const safeRun = fromThrowable(
-    () => instance.run(ctx),
-    (cause) => ({ type: 'COMMAND_EXECUTION_FAILED' as const, cause }),
-  );
-
-  return safeRun().asyncAndThen((maybePromise) =>
-    fromPromise(Promise.resolve(maybePromise), (cause) => ({
-      type: 'COMMAND_EXECUTION_FAILED' as const,
-      cause,
-    })),
-  );
+export const runCommand = async (commandClass: CommandClass, argv: string[]): Promise<void> => {
+  const { instance, ctx } = parseAndResolve(commandClass, argv);
+  try {
+    await Promise.resolve(instance.run(ctx));
+  } catch (cause) {
+    throw new CommandExecutionError(cause);
+  }
 };
-
-export const runCommand = (
-  commandClass: CommandClass,
-  argv: string[],
-): ResultAsync<void, RunCommandError> =>
-  parseAndResolve(commandClass, argv).asyncAndThen(({ instance, ctx }) =>
-    executeRun(instance, ctx),
-  );

--- a/packages/cli/src/config/index.test.ts
+++ b/packages/cli/src/config/index.test.ts
@@ -48,19 +48,15 @@ describe('loadZeltConfig', () => {
     `;
     await writeFile(join(testDir, 'zelt.config.ts'), configContent);
 
-    const result = await loadZeltConfig({ cwd: testDir });
+    const config = await loadZeltConfig({ cwd: testDir });
 
-    expect(result.isOk()).toBe(true);
-    const config = result._unsafeUnwrap();
     expect(config.build?.entry).toBe('./src/app.ts');
     expect(config.build?.outDir).toBe('./build');
   });
 
   it('returns defaults when no config file exists', async () => {
-    const result = await loadZeltConfig({ cwd: testDir });
+    const config = await loadZeltConfig({ cwd: testDir });
 
-    expect(result.isOk()).toBe(true);
-    const config = result._unsafeUnwrap();
     expect(config.build?.outDir).toBe('./dist');
     expect(config.build?.platform).toBe('node');
     expect(config.build?.format).toBe('esm');
@@ -81,10 +77,8 @@ describe('loadZeltConfig', () => {
     `;
     await writeFile(join(testDir, 'zelt.config.ts'), configContent);
 
-    const result = await loadZeltConfig({ cwd: testDir });
+    const config = await loadZeltConfig({ cwd: testDir });
 
-    expect(result.isOk()).toBe(true);
-    const config = result._unsafeUnwrap();
     expect(config.build?.entry).toBe('./src/main.ts');
     expect(config.build?.outDir).toBe('./dist');
     expect(config.dev?.port).toBe(8080);
@@ -97,12 +91,9 @@ describe('loadZeltConfig', () => {
       `export default { commands: 'src/commands/**/*.ts' }`,
     );
 
-    const result = await loadZeltConfig({ cwd: testDir });
+    const config = await loadZeltConfig({ cwd: testDir });
 
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value.commands).toBe('src/commands/**/*.ts');
-    }
+    expect(config.commands).toBe('src/commands/**/*.ts');
   });
 
   it('loads legacy top-level fields for backward compatibility', async () => {
@@ -115,10 +106,8 @@ describe('loadZeltConfig', () => {
     `;
     await writeFile(join(testDir, 'zelt.config.ts'), configContent);
 
-    const result = await loadZeltConfig({ cwd: testDir });
+    const config = await loadZeltConfig({ cwd: testDir });
 
-    expect(result.isOk()).toBe(true);
-    const config = result._unsafeUnwrap();
     expect(config.controllers).toEqual(['./src/**/*.controller.ts']);
     expect(config.dist).toBe('./generated');
     expect(config.tsconfig).toBe('./tsconfig.json');

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,3 +1,3 @@
 export { defineConfig } from './define-config';
-export { loadZeltConfig, type LoadConfigOptions } from './loader';
+export { loadZeltConfig, ConfigLoadError, type LoadConfigOptions } from './loader';
 export type { ZeltConfig, BuildConfig, DevConfig, OpenApiConfig } from './schema';

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -1,5 +1,4 @@
 import { loadConfig } from 'c12';
-import { ResultAsync } from 'neverthrow';
 
 import type { ZeltConfig } from './schema';
 
@@ -8,7 +7,14 @@ export type LoadConfigOptions = {
   readonly configFile?: string;
 };
 
-export type ConfigLoadError = { type: 'CONFIG_LOAD_FAILED' };
+export class ConfigLoadError extends Error {
+  readonly type = 'CONFIG_LOAD_FAILED' as const;
+  constructor(cause?: unknown) {
+    super('Failed to load config');
+    this.name = 'ConfigLoadError';
+    this.cause = cause;
+  }
+}
 
 const DEFAULT_BUILD_CONFIG = {
   outDir: './dist',
@@ -22,9 +28,7 @@ const DEFAULT_DEV_CONFIG = {
   debounceMs: 300,
 } as const;
 
-export const loadZeltConfig = (
-  options: LoadConfigOptions = {},
-): ResultAsync<ZeltConfig, ConfigLoadError> => {
+export const loadZeltConfig = async (options: LoadConfigOptions = {}): Promise<ZeltConfig> => {
   const c12Options: Parameters<typeof loadConfig<ZeltConfig>>[0] = {
     name: 'zelt',
     defaults: {
@@ -40,7 +44,10 @@ export const loadZeltConfig = (
     c12Options.configFile = options.configFile;
   }
 
-  return ResultAsync.fromPromise(loadConfig<ZeltConfig>(c12Options), () => ({
-    type: 'CONFIG_LOAD_FAILED' as const,
-  })).map((result) => result.config);
+  try {
+    const result = await loadConfig<ZeltConfig>(c12Options);
+    return result.config;
+  } catch (cause) {
+    throw new ConfigLoadError(cause);
+  }
 };

--- a/packages/contract/src/cli.ts
+++ b/packages/contract/src/cli.ts
@@ -3,9 +3,10 @@
 import { cac } from 'cac';
 import { match } from 'ts-pattern';
 
-import type { ContractError } from './errors';
+import type { ContractError, ConfigError } from './errors';
 import { generateClient } from './generate-client';
-import { findConfigFile, loadConfig } from './load-config';
+import type { GenerateClientOptions } from './config/options';
+import { findConfigFile, loadConfig, isLoadConfigError } from './load-config';
 import { watchClient } from './watch';
 
 const formatAnalyzerError = (e: ContractError & { type: string }): string =>
@@ -75,57 +76,73 @@ const formatError = (error: ContractError): string =>
   formatConfigError(error) ||
   'zelt/openapi: unknown error';
 
+const isContractError = (error: unknown): error is ContractError =>
+  typeof error === 'object' && error !== null && 'type' in error;
+
+const resolveConfig = async (
+  configPath: string | undefined,
+): Promise<GenerateClientOptions | ConfigError> => {
+  const cfgPath = configPath ?? (await findConfigFile(process.cwd()));
+  if (cfgPath === undefined) {
+    return { type: 'CONFIG_NOT_FOUND' };
+  }
+
+  try {
+    return await loadConfig(cfgPath);
+  } catch (error) {
+    if (isLoadConfigError(error)) {
+      return error;
+    }
+    throw error;
+  }
+};
+
+const isConfigError = (result: GenerateClientOptions | ConfigError): result is ConfigError =>
+  'type' in result;
+
+const buildAction = async (opts: { config?: string }): Promise<void> => {
+  const configOrError = await resolveConfig(opts.config);
+  if (isConfigError(configOrError)) {
+    console.error(formatError(configOrError));
+    process.exit(1);
+  }
+
+  try {
+    const success = await generateClient(configOrError);
+    console.log(
+      `[zelt-openapi] built (app.gen.ts ${success.appGenChanged ? 'changed' : 'unchanged'}, openapi.json ${success.openApiChanged ? 'changed' : 'unchanged'})`,
+    );
+  } catch (error) {
+    if (isContractError(error)) {
+      console.error(formatError(error));
+      process.exit(1);
+    }
+    throw error;
+  }
+};
+
+const watchAction = async (opts: { config?: string }): Promise<void> => {
+  const configOrError = await resolveConfig(opts.config);
+  if (isConfigError(configOrError)) {
+    console.error(formatError(configOrError));
+    process.exit(1);
+  }
+
+  await watchClient({ ...configOrError, watch: true });
+  console.log('[zelt-openapi] watching ...');
+};
+
 const cli = cac('zelt-openapi');
 
 cli
   .command('build', 'Generate AppType + OpenAPI once')
   .option('-c, --config <path>', 'Path to zelt.config file')
-  .action(async (opts: { config?: string }) => {
-    const cfgPath = opts.config ?? (await findConfigFile(process.cwd()));
-    if (cfgPath === undefined) {
-      console.error(formatError({ type: 'CONFIG_NOT_FOUND' }));
-      process.exit(1);
-    }
-
-    const cfgResult = await loadConfig(cfgPath);
-    if (cfgResult.isErr()) {
-      console.error(formatError(cfgResult.error));
-      process.exit(1);
-    }
-
-    const result = await generateClient(cfgResult.value);
-    result.match(
-      (success) => {
-        console.log(
-          `[zelt-openapi] built (app.gen.ts ${success.appGenChanged ? 'changed' : 'unchanged'}, openapi.json ${success.openApiChanged ? 'changed' : 'unchanged'})`,
-        );
-      },
-      (error) => {
-        console.error(formatError(error));
-        process.exit(1);
-      },
-    );
-  });
+  .action(buildAction);
 
 cli
   .command('watch', 'Generate AppType + OpenAPI continuously')
   .option('-c, --config <path>', 'Path to zelt.config file')
-  .action(async (opts: { config?: string }) => {
-    const cfgPath = opts.config ?? (await findConfigFile(process.cwd()));
-    if (cfgPath === undefined) {
-      console.error(formatError({ type: 'CONFIG_NOT_FOUND' }));
-      process.exit(1);
-    }
-
-    const cfgResult = await loadConfig(cfgPath);
-    if (cfgResult.isErr()) {
-      console.error(formatError(cfgResult.error));
-      process.exit(1);
-    }
-
-    await watchClient({ ...cfgResult.value, watch: true });
-    console.log('[zelt-openapi] watching ...');
-  });
+  .action(watchAction);
 
 cli.help();
 cli.version('0.0.0');

--- a/packages/contract/src/generate-client.ts
+++ b/packages/contract/src/generate-client.ts
@@ -3,9 +3,6 @@ import { existsSync } from 'node:fs';
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import { errAsync, ResultAsync } from 'neverthrow';
-
-import type { ContractError } from './errors';
 import { discoverControllers } from './analyzer/discover-controllers';
 import { analyzeControllers } from './analyzer/internal-representation';
 import { createProject } from './analyzer/project';
@@ -27,9 +24,9 @@ export type GenerateClientResult = {
   readonly openApiChanged: boolean;
 };
 
-export const generateClient = (
+export const generateClient = async (
   options: GenerateClientOptions,
-): ResultAsync<GenerateClientResult, ContractError> => {
+): Promise<GenerateClientResult> => {
   const distDir = resolve(options.dist);
   const tsconfigPath = options.tsconfig ? resolve(options.tsconfig) : resolve('tsconfig.json');
 
@@ -38,26 +35,27 @@ export const generateClient = (
 
   const irResult = analyzeControllers(project, specs);
   if (irResult.isErr()) {
-    return errAsync(irResult.error);
+    throw irResult.error;
   }
   const ir = irResult.value;
 
-  return ResultAsync.fromPromise(mkdir(distDir, { recursive: true }), () => ({
-    type: 'CONFIG_NOT_FOUND' as const,
-  }))
-    .andThen(() => emitOpenApi(ir, { distDir, tsconfigPath }))
-    .andThen((openApiDoc) => {
-      const appGenContent = emitAppGen(ir, { distDir });
-      const appGenPath = resolve(distDir, 'app.gen.ts');
-      const openApiContent = `${JSON.stringify(openApiDoc, null, 2)}\n`;
-      const openApiPath = resolve(distDir, 'openapi.json');
+  await mkdir(distDir, { recursive: true });
 
-      return ResultAsync.fromPromise(
-        Promise.all([
-          writeIfChanged(appGenPath, appGenContent),
-          writeIfChanged(openApiPath, openApiContent),
-        ]),
-        () => ({ type: 'CONFIG_NOT_FOUND' as const }),
-      ).map(([appGenChanged, openApiChanged]) => ({ appGenChanged, openApiChanged }));
-    });
+  const openApiResult = await emitOpenApi(ir, { distDir, tsconfigPath });
+  if (openApiResult.isErr()) {
+    throw openApiResult.error;
+  }
+  const openApiDoc = openApiResult.value;
+
+  const appGenContent = emitAppGen(ir, { distDir });
+  const appGenPath = resolve(distDir, 'app.gen.ts');
+  const openApiContent = `${JSON.stringify(openApiDoc, null, 2)}\n`;
+  const openApiPath = resolve(distDir, 'openapi.json');
+
+  const [appGenChanged, openApiChanged] = await Promise.all([
+    writeIfChanged(appGenPath, appGenContent),
+    writeIfChanged(openApiPath, openApiContent),
+  ]);
+
+  return { appGenChanged, openApiChanged };
 };

--- a/packages/contract/src/load-config.ts
+++ b/packages/contract/src/load-config.ts
@@ -3,8 +3,6 @@ import { access } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { okAsync, errAsync, ResultAsync } from 'neverthrow';
-
 import type { ConfigError } from './errors';
 import type { GenerateClientOptions } from './config/options';
 
@@ -34,26 +32,40 @@ function narrowConfig(value: unknown): unknown {
   return value;
 }
 
-const dynamicImport = (url: string, path: string): ResultAsync<unknown, ConfigError> =>
-  ResultAsync.fromSafePromise(import(url)).mapErr(() => ({
-    type: 'INVALID_CONFIG_EXPORT' as const,
-    path,
-  }));
+class InvalidConfigExportError extends Error {
+  readonly type = 'INVALID_CONFIG_EXPORT' as const;
+  readonly path: string;
+  constructor(path: string) {
+    super(`Invalid config export: ${path}`);
+    this.name = 'InvalidConfigExportError';
+    this.path = path;
+  }
+}
 
-export const loadConfig = (path: string): ResultAsync<GenerateClientOptions, ConfigError> => {
+export const loadConfig = async (path: string): Promise<GenerateClientOptions> => {
   const abs = isAbsolute(path) ? path : resolve(process.cwd(), path);
   const url = pathToFileURL(abs).href;
 
-  return dynamicImport(url, path).andThen((mod) => {
-    if (typeof mod !== 'object' || mod === null) {
-      return errAsync({ type: 'INVALID_CONFIG_EXPORT' as const, path });
-    }
-    const namespace: Record<string, unknown> = { ...mod };
-    const defaultKey = 'default';
-    const cfg = namespace[defaultKey];
-    if (cfg === undefined) {
-      return errAsync({ type: 'INVALID_CONFIG_EXPORT' as const, path });
-    }
-    return okAsync(narrowConfig(cfg));
-  });
+  let mod: unknown;
+  try {
+    mod = await import(url);
+  } catch {
+    throw new InvalidConfigExportError(path);
+  }
+
+  if (typeof mod !== 'object' || mod === null) {
+    throw new InvalidConfigExportError(path);
+  }
+
+  const namespace: Record<string, unknown> = { ...mod };
+  const defaultKey = 'default';
+  const cfg = namespace[defaultKey];
+  if (cfg === undefined) {
+    throw new InvalidConfigExportError(path);
+  }
+
+  return narrowConfig(cfg);
 };
+
+export const isLoadConfigError = (error: unknown): error is ConfigError =>
+  error instanceof InvalidConfigExportError;

--- a/packages/contract/src/test/generate-client.test.ts
+++ b/packages/contract/src/test/generate-client.test.ts
@@ -19,11 +19,8 @@ describe('generateClient', () => {
       tsconfig: tsconfigPath,
     });
 
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) return;
-
-    expect(result.value.appGenChanged).toBe(true);
-    expect(result.value.openApiChanged).toBe(true);
+    expect(result.appGenChanged).toBe(true);
+    expect(result.openApiChanged).toBe(true);
 
     const appGen = await readFile(join(dist, 'app.gen.ts'), 'utf8');
     expect(appGen).toContain('export type AppType = BuildAppType<[');
@@ -34,12 +31,11 @@ describe('generateClient', () => {
 
   it('returns changed=false on second run with no changes', async () => {
     const dist = await mkdtemp(join(tmpdir(), 'zelt-openapi-'));
-    const firstResult = await generateClient({
+    await generateClient({
       controllers: [fixtureGlob],
       dist,
       tsconfig: tsconfigPath,
     });
-    expect(firstResult.isOk()).toBe(true);
 
     const secondResult = await generateClient({
       controllers: [fixtureGlob],
@@ -47,10 +43,7 @@ describe('generateClient', () => {
       tsconfig: tsconfigPath,
     });
 
-    expect(secondResult.isOk()).toBe(true);
-    if (secondResult.isErr()) return;
-
-    expect(secondResult.value.appGenChanged).toBe(false);
-    expect(secondResult.value.openApiChanged).toBe(false);
+    expect(secondResult.appGenChanged).toBe(false);
+    expect(secondResult.openApiChanged).toBe(false);
   });
 });

--- a/packages/contract/src/watch.ts
+++ b/packages/contract/src/watch.ts
@@ -48,28 +48,37 @@ const formatError = (error: ContractError): string =>
     )
     .exhaustive();
 
+const isContractError = (error: unknown): error is ContractError =>
+  typeof error === 'object' && error !== null && 'type' in error;
+
 export const watchClient = async (options: GenerateClientOptions): Promise<() => Promise<void>> => {
   const watchedPaths = fg.sync([...options.controllers], { absolute: true });
 
-  const initialResult = await generateClient(options);
-  if (initialResult.isErr()) {
-    console.error('[zelt-openapi] initial generation failed:', formatError(initialResult.error));
+  try {
+    await generateClient(options);
+  } catch (error) {
+    if (isContractError(error)) {
+      console.error('[zelt-openapi] initial generation failed:', formatError(error));
+    } else {
+      throw error;
+    }
   }
 
   const watcher = chokidar.watch(watchedPaths, { ignoreInitial: true });
   watcher.on('change', (path) => {
     void (async (): Promise<void> => {
-      const result = await generateClient(options);
-      result.match(
-        (success) => {
-          console.log(
-            `[zelt-openapi] regenerated (app.gen.ts ${success.appGenChanged ? 'changed' : 'unchanged'}, openapi.json ${success.openApiChanged ? 'changed' : 'unchanged'}) — trigger: ${path}`,
-          );
-        },
-        (error) => {
+      try {
+        const success = await generateClient(options);
+        console.log(
+          `[zelt-openapi] regenerated (app.gen.ts ${success.appGenChanged ? 'changed' : 'unchanged'}, openapi.json ${success.openApiChanged ? 'changed' : 'unchanged'}) — trigger: ${path}`,
+        );
+      } catch (error) {
+        if (isContractError(error)) {
           console.error('[zelt-openapi] regeneration failed:', formatError(error));
-        },
-      );
+        } else {
+          throw error;
+        }
+      }
     })();
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,9 +227,6 @@ importers:
       consola:
         specifier: 3.4.2
         version: 3.4.2
-      neverthrow:
-        specifier: 8.2.0
-        version: 8.2.0
       tinyglobby:
         specifier: 0.2.14
         version: 0.2.14


### PR DESCRIPTION
## Summary

- Replace `ResultAsync` returns with `Promise`/throw pattern in `loadZeltConfig` and `generateClient`
- Add typed Error classes with `type` discriminant for exhaustive `ts-pattern` matching
- Update ESLint config to allow `no-throw`/`no-try-catch` in affected CLI entry points

## Breaking Changes

`loadZeltConfig` and `generateClient` now return `Promise` instead of `ResultAsync`. Errors are thrown instead of returned as `Err`.

## Test plan

- [x] `pnpm run check:no-neverthrow-leak` passes (no neverthrow types in `.d.ts` files)
- [x] All 399 tests pass
- [x] Full precommit (format, typecheck, lint, build, test) verified