### PR TITLE
feat(ci): add file links to infra change alert comments

### DIFF
--- a/.github/workflows/infra-change-alert.yml
+++ b/.github/workflows/infra-change-alert.yml
@@ -75,8 +75,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const crypto = require('crypto');
             const files = `${{ steps.check.outputs.files }}`.trim().split('\n').filter(f => f);
-            const fileList = files.map(f => `- \`${f}\``).join('\n');
+            const prFilesUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}/files`;
+            const fileList = files.map(f => {
+              const hash = crypto.createHash('sha256').update(f, 'utf8').digest('hex');
+              return `- [\`${f}\`](${prFilesUrl}#diff-${hash})`;
+            }).join('\n');
 
             const body = `## ⚠️ Infrastructure File Changes Detected
 


### PR DESCRIPTION
## Summary

- Link each infrastructure file in the alert comment to its diff anchor in the PR Files changed tab
- Uses SHA256 hash of file path for GitHub's diff anchor format (`#diff-{hash}`)

## Test plan

- [ ] Create a PR that modifies an infrastructure file (e.g., `tsconfig.json`)
- [ ] Verify the infra change alert comment shows clickable links
- [ ] Verify clicking a link navigates to the correct file in Files changed tab