### PR TITLE
docs: sync documentation with recent API changes

### DIFF
--- a/website/docs/authentication.md
+++ b/website/docs/authentication.md
@@ -311,6 +311,120 @@ const app = createHttpApp({
 | `verify(token)` | Verify and decode a token (throws on invalid) |
 | `decode(token)` | Decode without verification (returns `null` on error) |
 
+## Using @zeltjs/auth-session
+
+For session-based authentication with cookies, Zelt provides the `@zeltjs/auth-session` package.
+
+### Installation
+
+```bash
+pnpm add @zeltjs/auth-session @zeltjs/kv
+```
+
+### Basic Setup
+
+1. Set the `SESSION_SECRET` environment variable
+2. Create a custom config that provides a KV store
+3. Register the middleware:
+
+```typescript
+import { createHttpApp } from '@zeltjs/core';
+import { MemoryKV } from '@zeltjs/kv';
+import { SessionMiddleware, SessionConfig } from '@zeltjs/auth-session';
+import { Config, injectConfig } from '@zeltjs/core';
+
+@Config
+class MySessionConfig extends SessionConfig {
+  private kv = inject(MemoryKV);
+
+  override get store() {
+    return this.kv.namespace('sessions');
+  }
+}
+
+const app = createHttpApp({
+  controllers: [UserController],
+  middlewares: [SessionMiddleware],
+  configs: [MySessionConfig],
+  injectables: [MemoryKV],
+});
+```
+
+### Session Functions
+
+Use the session functions in your handlers:
+
+```typescript
+import { Controller, Get, Post, bodyParam } from '@zeltjs/core';
+import { getSession, setSession, updateSession, destroySession } from '@zeltjs/auth-session';
+
+interface UserSession {
+  userId: string;
+  name: string;
+}
+
+@Controller('/auth')
+class AuthController {
+  @Post('/login')
+  login(body = bodyParam(LoginSchema)) {
+    setSession<UserSession>({ userId: '123', name: body.name });
+    return { success: true };
+  }
+
+  @Get('/me')
+  me() {
+    const session = getSession<UserSession>();
+    if (!session) {
+      throw new HTTPException(401, { message: 'Not logged in' });
+    }
+    return session;
+  }
+
+  @Post('/logout')
+  logout() {
+    destroySession();
+    return { success: true };
+  }
+}
+```
+
+### Session API
+
+| Function | Description |
+|----------|-------------|
+| `getSession<T>()` | Get current session data (returns `undefined` if not logged in) |
+| `setSession<T>(data)` | Set session data (replaces existing) |
+| `updateSession<T>(updater)` | Update session data with a function |
+| `destroySession()` | Destroy the session and clear the cookie |
+| `isNewSession()` | Check if this is a newly created session |
+| `getSessionId()` | Get the current session ID |
+
+### Custom Configuration
+
+Extend `SessionConfig` to customize behavior:
+
+```typescript
+@Config
+class MySessionConfig extends SessionConfig {
+  override get cookieName() {
+    return 'my_session';
+  }
+
+  override get ttlSec() {
+    return 86400 * 7; // 7 days
+  }
+
+  override get cookieOptions() {
+    return {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Strict' as const,
+      path: '/',
+    };
+  }
+}
+```
+
 ## Best Practices
 
 1. **Set authentication early** — Register auth middleware globally so it runs before route handlers

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -93,14 +93,19 @@ The `Token` property is inherited from the parent class, so `injectConfig(Databa
 
 ## Environment-Based Configuration
 
-Zelt provides built-in config classes for environment variables:
+Zelt provides environment configuration through platform-specific adapters.
 
-### ProcessEnvConfig
+### Node.js Environment
+
+For Node.js applications, use the configs from `@zeltjs/adapter-node`:
+
+#### ProcessEnvConfig
 
 Reads from `process.env` directly:
 
 ```typescript
-import { Config, ProcessEnvConfig, injectConfig } from '@zeltjs/core';
+import { Config, injectConfig } from '@zeltjs/core';
+import { ProcessEnvConfig } from '@zeltjs/adapter-node';
 
 @Config
 export class DatabaseConfig {
@@ -128,12 +133,13 @@ const app = createHttpApp({
 });
 ```
 
-### DotEnvConfig
+#### DotEnvConfig
 
 Loads `.env` files using [dotenv](https://github.com/motdotla/dotenv), then reads from `process.env`:
 
 ```typescript
-import { Config, DotEnvConfig, injectConfig } from '@zeltjs/core';
+import { Config, injectConfig } from '@zeltjs/core';
+import { DotEnvConfig } from '@zeltjs/adapter-node';
 
 @Config
 export class DatabaseConfig {
@@ -153,16 +159,61 @@ const app = createHttpApp({
 });
 ```
 
-### Custom Env Paths
+#### Custom Env Paths
 
 Extend `DotEnvConfig` to load from custom paths:
 
 ```typescript
-import { Config, DotEnvConfig } from '@zeltjs/core';
+import { Config } from '@zeltjs/core';
+import { DotEnvConfig } from '@zeltjs/adapter-node';
 
 @Config
 export class MyEnvConfig extends DotEnvConfig {
   protected override readonly paths = ['.env', '.env.local'];
 }
 ```
+
+### Cloudflare Workers Environment
+
+For Cloudflare Workers, environment configuration is handled automatically by `onCloudflareWorkers()`. See the [Cloudflare Workers Getting Started guide](/getting-started/cloudflare-workers) for details.
+
+## TypeScript Decorator Configuration
+
+Zelt supports both TC39 standard decorators and legacy TypeScript decorators. The framework automatically detects which mode is being used at runtime.
+
+### TC39 Standard Decorators (Recommended)
+
+For new projects, use TC39 standard decorators. No special TypeScript configuration is needed:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext"
+  }
+}
+```
+
+### Legacy Decorators
+
+For compatibility with existing codebases, enable legacy decorators:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "experimentalDecorators": true
+  }
+}
+```
+
+### Detection Behavior
+
+Zelt automatically detects the decorator mode based on the runtime context:
+
+- **TC39 mode**: Decorator receives a context object with `kind`, `name`, and `metadata` properties
+- **Legacy mode**: Decorator receives `target`, `propertyKey`, and `descriptor` arguments
+
+Both modes work identically from an API perspective—you don't need to change your code when switching between them.
 

--- a/website/docs/getting-started/cloudflare-workers.md
+++ b/website/docs/getting-started/cloudflare-workers.md
@@ -78,10 +78,10 @@ Create `src/index.ts` as the Cloudflare Workers entry point:
 import { onCloudflareWorkers } from '@zeltjs/adapter-cloudflare-workers';
 import { app } from './app';
 
-export default onCloudflareWorkers(app);
+export default await onCloudflareWorkers(app);
 ```
 
-The `onCloudflareWorkers()` function wraps your app for the Workers runtime. By default, it uses **lazy initialization** — controllers are resolved on the first request rather than at startup. This optimizes cold start times in serverless environments.
+The `onCloudflareWorkers()` function is async and prepares your app for the Workers runtime. By default, it uses **lazy initialization** (`warmup: false`) — controllers are resolved on the first request rather than at startup. This optimizes cold start times in serverless environments.
 
 ### Step 4: Configure Wrangler
 
@@ -224,7 +224,7 @@ By default, `onCloudflareWorkers()` uses lazy initialization (`warmup: false`) t
 If you prefer to resolve all controllers at initialization (useful for debugging or when cold start time is less critical), set `warmup: true`:
 
 ```typescript
-export default onCloudflareWorkers(app, { warmup: true });
+export default await onCloudflareWorkers(app, { warmup: true });
 ```
 
 | Option | Behavior | Use Case |

--- a/website/docs/getting-started/node.md
+++ b/website/docs/getting-started/node.md
@@ -56,28 +56,31 @@ export class HelloController {
 
 ### Step 2: Create the Application
 
-Create `src/app.ts` to wire up your controllers:
+Create `src/app.ts` to wire up your controllers and prepare for the Node.js runtime:
 
 ```typescript
 import { createHttpApp } from '@zeltjs/core';
+import { onNode } from '@zeltjs/adapter-node';
 import { HelloController } from './controllers/hello.controller';
 
 export const app = createHttpApp({
   controllers: [HelloController],
 });
+
+export default await onNode(app);
 ```
+
+The `onNode()` function prepares your app for the Node.js runtime, returning a `NodeApp` with `listen()` and `get()` methods.
 
 ### Step 3: Start the Server
 
-Create `src/main.ts` for the Node.js entry point:
+Create `src/main.ts` to start the server:
 
 ```typescript
-import { serve } from '@zeltjs/adapter-node';
-import { app } from './app';
+import nodeApp from './app';
 
-serve(app, { port: 3000 }, (info) => {
-  console.log(`Server running at http://localhost:${info.port}`);
-});
+const server = await nodeApp.listen({ port: 3000 });
+console.log(`Server running at http://localhost:${server.address.port}`);
 ```
 
 ### Step 4: Configure TypeScript

--- a/website/docs/rate-limiting.md
+++ b/website/docs/rate-limiting.md
@@ -67,7 +67,7 @@ export class AuthController {
       windowSec: 300,
     });
 
-    if (result.isErr()) {
+    if (!result.ok) {
       return res.json({ error: 'Service unavailable' }, 503);
     }
     if (!result.value.allowed) {
@@ -126,9 +126,13 @@ Use `'open'` for non-critical rate limiting where availability is prioritized. U
 
 ## RateLimitResult Type
 
-The `hit()` method returns a `ResultAsync<RateLimitResult, RateLimitError>`:
+The `hit()` method returns `Promise<RateLimiterHitResult>`:
 
 ```typescript
+type RateLimiterHitResult =
+  | { ok: true; value: RateLimitResult }
+  | { ok: false; error: RateLimitError };
+
 type RateLimitResult = {
   allowed: boolean;      // Whether the request is permitted
   remaining: number;     // Requests remaining in current window

--- a/website/docs/validation.md
+++ b/website/docs/validation.md
@@ -5,12 +5,19 @@
 
 Zelt uses [Valibot](https://valibot.dev/) for request validation, providing a type-safe and lightweight validation solution.
 
+## Installation
+
+```bash
+pnpm add @zeltjs/validate-valibot valibot
+```
+
 ## Basic Usage
 
 Use `validated()` with a Valibot schema to validate request bodies:
 
 ```typescript
-import { Controller, Post, validated, response } from '@zeltjs/core';
+import { Controller, Post, response } from '@zeltjs/core';
+import { validated } from '@zeltjs/validate-valibot';
 import * as v from 'valibot';
 
 const CreateUserSchema = v.object({
@@ -34,7 +41,8 @@ export class UserController {
 Use `validated(schema, 'form')` to validate `multipart/form-data` requests, including file uploads:
 
 ```typescript
-import { Controller, Post, validated, response } from '@zeltjs/core';
+import { Controller, Post, response } from '@zeltjs/core';
+import { validated } from '@zeltjs/validate-valibot';
 import * as v from 'valibot';
 
 const UploadSchema = v.object({


### PR DESCRIPTION
## Summary

Update website documentation to reflect changes from recent PRs (#55-#72):

- **validation.md**: Add `@zeltjs/validate-valibot` installation instructions and update import paths
- **authentication.md**: Add `@zeltjs/auth-session` package documentation with session functions API
- **getting-started/node.md**: Update to use async `onNode()` API with `listen()` method
- **getting-started/cloudflare-workers.md**: Update to use async `await onCloudflareWorkers()`
- **rate-limiting.md**: Update for neverthrow removal (`result.ok` instead of `result.isErr()`)
- **configuration.md**: Move `ProcessEnvConfig`/`DotEnvConfig` imports to `@zeltjs/adapter-node`, add TC39/legacy decorator configuration section

## Related PRs

- #66 validate-valibot separation
- #55 auth-session package
- #61 async adapter (onNode, onCloudflareWorkers)
- #63 TC39 decorator dual-mode
- #70, #67, #64 neverthrow removal
- #58 env config move to adapter-node

## Test plan

- [x] Build passes (`pnpm build`)
- [x] All tests pass (`pnpm test`)
- [ ] Review documentation accuracy against actual package APIs