### PR TITLE
refactor(contract): replace console.log with CLI output utility

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -132,15 +132,21 @@ export default tseslint.config(
     },
   },
   {
-    // CLI tool entry points: console output is the user-visible UX, watch loop must catch
-    // regeneration errors to keep watching after a failure rather than crashing the process.
+    // CLI tool entry points: watch loop must catch regeneration errors to keep watching
+    // after a failure rather than crashing the process.
     // Type predicate and in operator needed for ContractError type guard.
     files: ['packages/contract/src/watch.ts', 'packages/contract/src/cli.ts'],
     rules: {
-      'no-console': 'off',
       '@9wick/strict-type-rules/no-try-catch': 'off',
       '@9wick/strict-type-rules/no-type-predicate': 'off',
       '@9wick/strict-type-rules/no-in-operator': 'off',
+    },
+  },
+  {
+    // CLI output utility wraps console methods for centralized output control.
+    files: ['packages/contract/src/cli-output.ts'],
+    rules: {
+      'no-console': 'off',
     },
   },
   {

--- a/packages/contract/src/cli-output.ts
+++ b/packages/contract/src/cli-output.ts
@@ -7,7 +7,3 @@ export const cliPrint = (message: string): void => {
 export const cliError = (message: string): void => {
   console.error(message);
 };
-
-export const cliWarn = (message: string): void => {
-  console.warn(message);
-};

--- a/packages/contract/src/cli-output.ts
+++ b/packages/contract/src/cli-output.ts
@@ -1,0 +1,13 @@
+// packages/contract/src/cli-output.ts
+
+export const cliPrint = (message: string): void => {
+  console.log(message);
+};
+
+export const cliError = (message: string): void => {
+  console.error(message);
+};
+
+export const cliWarn = (message: string): void => {
+  console.warn(message);
+};

--- a/packages/contract/src/cli.ts
+++ b/packages/contract/src/cli.ts
@@ -8,6 +8,7 @@ import { generateClient } from './generate-client';
 import type { GenerateClientOptions } from './config/options';
 import { findConfigFile, loadConfig, isLoadConfigError } from './load-config';
 import { watchClient } from './watch';
+import { cliPrint, cliError } from './cli-output';
 
 const formatAnalyzerError = (e: ContractError & { type: string }): string =>
   match(e)
@@ -113,18 +114,18 @@ const isConfigError = (result: GenerateClientOptions | ConfigError): result is C
 const buildAction = async (opts: { config?: string }): Promise<void> => {
   const configOrError = await resolveConfig(opts.config);
   if (isConfigError(configOrError)) {
-    console.error(formatError(configOrError));
+    cliError(formatError(configOrError));
     process.exit(1);
   }
 
   try {
     const success = await generateClient(configOrError);
-    console.log(
+    cliPrint(
       `[zelt-openapi] built (app.gen.ts ${success.appGenChanged ? 'changed' : 'unchanged'}, openapi.json ${success.openApiChanged ? 'changed' : 'unchanged'})`,
     );
   } catch (error) {
     if (isContractError(error)) {
-      console.error(formatError(error));
+      cliError(formatError(error));
       process.exit(1);
     }
     throw error;
@@ -134,12 +135,12 @@ const buildAction = async (opts: { config?: string }): Promise<void> => {
 const watchAction = async (opts: { config?: string }): Promise<void> => {
   const configOrError = await resolveConfig(opts.config);
   if (isConfigError(configOrError)) {
-    console.error(formatError(configOrError));
+    cliError(formatError(configOrError));
     process.exit(1);
   }
 
   await watchClient({ ...configOrError, watch: true });
-  console.log('[zelt-openapi] watching ...');
+  cliPrint('[zelt-openapi] watching ...');
 };
 
 const cli = cac('zelt-openapi');

--- a/packages/contract/src/watch.ts
+++ b/packages/contract/src/watch.ts
@@ -6,6 +6,7 @@ import { match } from 'ts-pattern';
 import type { ContractError } from './errors';
 import type { GenerateClientOptions } from './config/options';
 import { generateClient } from './generate-client';
+import { cliPrint, cliError } from './cli-output';
 
 const formatError = (error: ContractError): string =>
   match(error)
@@ -67,7 +68,7 @@ export const watchClient = async (options: GenerateClientOptions): Promise<() =>
     await generateClient(options);
   } catch (error) {
     if (isContractError(error)) {
-      console.error('[zelt-openapi] initial generation failed:', formatError(error));
+      cliError(`[zelt-openapi] initial generation failed: ${formatError(error)}`);
     } else {
       throw error;
     }
@@ -78,12 +79,12 @@ export const watchClient = async (options: GenerateClientOptions): Promise<() =>
     void (async (): Promise<void> => {
       try {
         const success = await generateClient(options);
-        console.log(
+        cliPrint(
           `[zelt-openapi] regenerated (app.gen.ts ${success.appGenChanged ? 'changed' : 'unchanged'}, openapi.json ${success.openApiChanged ? 'changed' : 'unchanged'}) — trigger: ${path}`,
         );
       } catch (error) {
         if (isContractError(error)) {
-          console.error('[zelt-openapi] regeneration failed:', formatError(error));
+          cliError(`[zelt-openapi] regeneration failed: ${formatError(error)}`);
         } else {
           throw error;
         }


### PR DESCRIPTION
## Summary

- CLI専用出力ユーティリティ (`cli-output.ts`) を追加
- `cli.ts` と `watch.ts` の `console.log/error` を `cliPrint/cliError` に置換
- ESLint `no-console` 例外を `cli-output.ts` のみに限定

## Motivation

- テスト時のモック化を容易にする
- 将来の出力レベル制御（verbose/quiet モード）の基盤

## Test plan

- [x] ESLint pass
- [x] TypeScript pass  
- [x] Unit tests pass (40/40)