### PR TITLE
feat(core): add CliConfig for CLI environment abstraction

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -144,14 +144,6 @@ export default tseslint.config(
     },
   },
   {
-    // CLI and config loader need process.argv / process.cwd() — these are build-time tools
-    // that run in Node.js directly, not inside an application container.
-    files: ['packages/contract/src/cli.ts', 'packages/contract/src/load-config.ts'],
-    rules: {
-      '@9wick/strict-type-rules/no-process-access': 'off',
-    },
-  },
-  {
     // error-handler reads NODE_ENV to decide whether to expose internal error messages.
     // process.env.NODE_ENV is the de-facto standard for this guard; edge/serverless runtimes
     // inline or polyfill it at build time. typeof process guard prevents crashes where process

--- a/packages/adapter-node/src/cli.config.ts
+++ b/packages/adapter-node/src/cli.config.ts
@@ -1,0 +1,16 @@
+import { CliConfig, Config } from '@zeltjs/core';
+
+@Config
+export class NodeCliConfig extends CliConfig {
+  override cwd(): string {
+    return process.cwd();
+  }
+
+  override argv(): readonly string[] {
+    return process.argv;
+  }
+
+  override exit(code: number): never {
+    process.exit(code);
+  }
+}

--- a/packages/adapter-node/src/cli.config.ts
+++ b/packages/adapter-node/src/cli.config.ts
@@ -1,4 +1,4 @@
-import { CliConfig, Config } from '@zeltjs/core';
+import { CliConfig, Config, type Signal, type SignalHandler } from '@zeltjs/core';
 
 @Config
 export class NodeCliConfig extends CliConfig {
@@ -12,5 +12,13 @@ export class NodeCliConfig extends CliConfig {
 
   override exit(code: number): never {
     process.exit(code);
+  }
+
+  override onSignal(signal: Signal, handler: SignalHandler): void {
+    process.on(signal, handler);
+  }
+
+  override offSignal(signal: Signal, handler: SignalHandler): void {
+    process.off(signal, handler);
   }
 }

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -4,6 +4,7 @@ export type { ServeOptions, AddressInfo } from './serve';
 export { onNode } from './on-node';
 export type { ServerHandle } from './on-node';
 
+export { NodeCliConfig } from './cli.config';
 export { ProcessEnvConfig } from './process-env.config';
 export { DotEnvConfig } from './dotenv.config';
 

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createApp, Controller, Get, EnvConfig, Command } from '@zeltjs/core';
+import { createApp, Controller, Get, EnvConfig, CliConfig, Command } from '@zeltjs/core';
 
+import { NodeCliConfig } from './cli.config';
 import { onNode, type ServerHandle, type HttpNodeApp, type CommandNodeApp } from './on-node';
 import { ProcessEnvConfig } from './process-env.config';
 
@@ -85,6 +86,18 @@ describe('onNode with HTTP', () => {
     nodeApp = await onNode(app);
 
     expect(replaceConfigSpy).toHaveBeenCalledWith(EnvConfig, ProcessEnvConfig);
+  });
+
+  it('auto-injects NodeCliConfig when CliConfig token is in configs', async () => {
+    const app = createApp({
+      http: { controllers: [] },
+      configs: [CliConfig],
+    });
+    const replaceConfigSpy = vi.spyOn(app, 'replaceConfig');
+
+    nodeApp = await onNode(app);
+
+    expect(replaceConfigSpy).toHaveBeenCalledWith(CliConfig, NodeCliConfig);
   });
 
   it('silently skips ProcessEnvConfig injection when EnvConfig is not in configs', async () => {

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -1,6 +1,7 @@
 import { serve } from '@hono/node-server';
 import type { ServerType } from '@hono/node-server';
 import {
+  CliConfig,
   EnvConfig,
   type HttpApp,
   type CommandApp,
@@ -8,6 +9,7 @@ import {
   type CommandClass,
 } from '@zeltjs/core';
 
+import { NodeCliConfig } from './cli.config';
 import { ProcessEnvConfig } from './process-env.config';
 
 type ListenOptions = {
@@ -195,6 +197,9 @@ export async function onNode(
   app: HttpApp | CommandApp | (HttpApp & CommandApp),
   options: NodeAppOptions = {},
 ): Promise<NodeApp> {
+  if (app.hasConfig(CliConfig)) {
+    app.replaceConfig(CliConfig, NodeCliConfig);
+  }
   if (app.hasConfig(EnvConfig)) {
     app.replaceConfig(EnvConfig, ProcessEnvConfig);
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@needle-di/core": "1.1.2",
+    "@zeltjs/adapter-node": "workspace:*",
     "@zeltjs/core": "workspace:*",
     "c12": "3.0.4",
     "chokidar": "5.0.0",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,3 +1,4 @@
+import { NodeCliConfig } from '@zeltjs/adapter-node';
 import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
@@ -5,6 +6,8 @@ import { match } from 'ts-pattern';
 import { BuildError, runTsdownBuild } from '../builders/tsdown';
 import { ConfigLoadError, loadZeltConfig } from '../config/loader';
 import type { BuildConfig } from '../config/schema';
+
+const cliConfig = new NodeCliConfig();
 
 type BuildArgs = {
   readonly config?: string;
@@ -75,7 +78,7 @@ export const buildCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cwd = globalThis.process.cwd();
+    const cwd = cliConfig.cwd();
     const typedArgs: BuildArgs = args;
 
     try {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,3 +1,4 @@
+import { NodeCliConfig } from '@zeltjs/adapter-node';
 import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
@@ -5,6 +6,8 @@ import { match } from 'ts-pattern';
 import { ConfigLoadError, loadZeltConfig } from '../config/loader';
 import type { DevConfig } from '../config/schema';
 import { startDevServer } from '../dev-server/server';
+
+const cliConfig = new NodeCliConfig();
 
 type DevArgs = {
   readonly config?: string;
@@ -75,7 +78,7 @@ export const devCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cwd = globalThis.process.cwd();
+    const cwd = cliConfig.cwd();
     const typedArgs: DevArgs = args;
 
     try {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,3 +1,4 @@
+import { NodeCliConfig } from '@zeltjs/adapter-node';
 import type { CommandClass } from '@zeltjs/core';
 import { defineCommand } from 'citty';
 import consola from 'consola';
@@ -12,6 +13,8 @@ import {
   runCommand,
   SchemaValidationError,
 } from './run/runner';
+
+const cliConfig = new NodeCliConfig();
 
 class NoCommandsConfigError extends Error {
   readonly type = 'NO_COMMANDS_CONFIG' as const;
@@ -152,7 +155,7 @@ export const runCommandDef = defineCommand({
     },
   },
   async run({ args, rawArgs }) {
-    const cwd = globalThis.process.cwd();
+    const cwd = cliConfig.cwd();
     const configFile = args.config as string | undefined;
     const commandName = args.command as string;
     const commandArgs = rawArgs.slice(rawArgs.indexOf(commandName) + 1);

--- a/packages/cli/src/dev-server/server.ts
+++ b/packages/cli/src/dev-server/server.ts
@@ -1,10 +1,14 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 
+import { NodeCliConfig } from '@zeltjs/adapter-node';
+import type { SignalHandler } from '@zeltjs/core';
 import consola from 'consola';
 
 import type { DevConfig } from '../config/schema';
 
 import { createWatcher, type WatcherHandle } from './watcher';
+
+const cliConfig = new NodeCliConfig();
 
 export type DevServerOptions = {
   readonly cwd: string;
@@ -107,19 +111,17 @@ const createRestartHandler = (state: DevServerState, cwd: string, entry: string)
   };
 };
 
-type SignalHandler = () => void;
-
 const registerSignalHandlers = (onSignal: () => Promise<void>): SignalHandler => {
   const handler = (): void => {
     void onSignal();
   };
 
-  globalThis.process.on('SIGINT', handler);
-  globalThis.process.on('SIGTERM', handler);
+  cliConfig.onSignal('SIGINT', handler);
+  cliConfig.onSignal('SIGTERM', handler);
 
   return () => {
-    globalThis.process.off('SIGINT', handler);
-    globalThis.process.off('SIGTERM', handler);
+    cliConfig.offSignal('SIGINT', handler);
+    cliConfig.offSignal('SIGTERM', handler);
   };
 };
 

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -12,5 +12,5 @@
     "erasableSyntaxOnly": false
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../adapter-node" }]
 }

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -33,6 +33,7 @@
     "hono": "4.12.16"
   },
   "dependencies": {
+    "@zeltjs/adapter-node": "workspace:*",
     "cac": "7.0.0",
     "chokidar": "5.0.0",
     "fast-glob": "3.3.3",

--- a/packages/contract/src/cli.ts
+++ b/packages/contract/src/cli.ts
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
 // packages/contract/src/cli.ts
+import { NodeCliConfig } from '@zeltjs/adapter-node';
 import { cac } from 'cac';
 import { match } from 'ts-pattern';
 
+import type { GenerateClientOptions } from './config/options';
 import type { ContractError, ConfigError } from './errors';
 import { generateClient } from './generate-client';
-import type { GenerateClientOptions } from './config/options';
 import { findConfigFile, loadConfig, isLoadConfigError } from './load-config';
 import { watchClient } from './watch';
+
+const cliConfig = new NodeCliConfig();
 
 const formatAnalyzerError = (e: ContractError & { type: string }): string =>
   match(e)
@@ -92,13 +95,13 @@ const isContractError = (error: unknown): error is ContractError =>
 const resolveConfig = async (
   configPath: string | undefined,
 ): Promise<GenerateClientOptions | ConfigError> => {
-  const cfgPath = configPath ?? (await findConfigFile(process.cwd()));
+  const cfgPath = configPath ?? (await findConfigFile(cliConfig.cwd()));
   if (cfgPath === undefined) {
     return { type: 'CONFIG_NOT_FOUND' };
   }
 
   try {
-    return await loadConfig(cfgPath);
+    return await loadConfig(cfgPath, cliConfig);
   } catch (error) {
     if (isLoadConfigError(error)) {
       return error;
@@ -114,7 +117,7 @@ const buildAction = async (opts: { config?: string }): Promise<void> => {
   const configOrError = await resolveConfig(opts.config);
   if (isConfigError(configOrError)) {
     console.error(formatError(configOrError));
-    process.exit(1);
+    return cliConfig.exit(1);
   }
 
   try {
@@ -125,7 +128,7 @@ const buildAction = async (opts: { config?: string }): Promise<void> => {
   } catch (error) {
     if (isContractError(error)) {
       console.error(formatError(error));
-      process.exit(1);
+      return cliConfig.exit(1);
     }
     throw error;
   }
@@ -135,7 +138,7 @@ const watchAction = async (opts: { config?: string }): Promise<void> => {
   const configOrError = await resolveConfig(opts.config);
   if (isConfigError(configOrError)) {
     console.error(formatError(configOrError));
-    process.exit(1);
+    return cliConfig.exit(1);
   }
 
   await watchClient({ ...configOrError, watch: true });
@@ -156,5 +159,5 @@ cli
 
 cli.help();
 cli.version('0.0.0');
-cli.parse(process.argv, { run: false });
+cli.parse([...cliConfig.argv()], { run: false });
 await cli.runMatchedCommand();

--- a/packages/contract/src/load-config.ts
+++ b/packages/contract/src/load-config.ts
@@ -3,6 +3,8 @@ import { access } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import type { CliConfig } from '@zeltjs/core';
+
 import type { ConfigError } from './errors';
 import type { GenerateClientOptions } from './config/options';
 
@@ -42,8 +44,11 @@ class InvalidConfigExportError extends Error {
   }
 }
 
-export const loadConfig = async (path: string): Promise<GenerateClientOptions> => {
-  const abs = isAbsolute(path) ? path : resolve(process.cwd(), path);
+export const loadConfig = async (
+  path: string,
+  cliConfig: CliConfig,
+): Promise<GenerateClientOptions> => {
+  const abs = isAbsolute(path) ? path : resolve(cliConfig.cwd(), path);
   const url = pathToFileURL(abs).href;
 
   let mod: unknown;

--- a/packages/contract/tsconfig.json
+++ b/packages/contract/tsconfig.json
@@ -12,5 +12,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../adapter-node" }]
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,4 +119,5 @@ export type {
   LoggerTransport,
 } from './modules/logger';
 
+export { CliConfig } from './modules/cli';
 export { EnvConfig, EnvService } from './modules/env';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,4 +120,5 @@ export type {
 } from './modules/logger';
 
 export { CliConfig } from './modules/cli';
+export type { Signal, SignalHandler } from './modules/cli';
 export { EnvConfig, EnvService } from './modules/env';

--- a/packages/core/src/modules/cli/cli.config.ts
+++ b/packages/core/src/modules/cli/cli.config.ts
@@ -1,0 +1,16 @@
+import { Config } from '../../config';
+
+@Config
+export class CliConfig {
+  cwd(): string {
+    throw new Error('CliConfig.cwd() not implemented');
+  }
+
+  argv(): readonly string[] {
+    throw new Error('CliConfig.argv() not implemented');
+  }
+
+  exit(_code: number): never {
+    throw new Error('CliConfig.exit() not implemented');
+  }
+}

--- a/packages/core/src/modules/cli/cli.config.ts
+++ b/packages/core/src/modules/cli/cli.config.ts
@@ -1,5 +1,8 @@
 import { Config } from '../../config';
 
+export type Signal = 'SIGINT' | 'SIGTERM';
+export type SignalHandler = () => void;
+
 @Config
 export class CliConfig {
   cwd(): string {
@@ -12,5 +15,13 @@ export class CliConfig {
 
   exit(_code: number): never {
     throw new Error('CliConfig.exit() not implemented');
+  }
+
+  onSignal(_signal: Signal, _handler: SignalHandler): void {
+    throw new Error('CliConfig.onSignal() not implemented');
+  }
+
+  offSignal(_signal: Signal, _handler: SignalHandler): void {
+    throw new Error('CliConfig.offSignal() not implemented');
   }
 }

--- a/packages/core/src/modules/cli/index.ts
+++ b/packages/core/src/modules/cli/index.ts
@@ -1,0 +1,1 @@
+export { CliConfig } from './cli.config';

--- a/packages/core/src/modules/cli/index.ts
+++ b/packages/core/src/modules/cli/index.ts
@@ -1,1 +1,2 @@
 export { CliConfig } from './cli.config';
+export type { Signal, SignalHandler } from './cli.config';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       '@needle-di/core':
         specifier: 1.1.2
         version: 1.1.2
+      '@zeltjs/adapter-node':
+        specifier: workspace:*
+        version: link:../adapter-node
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
@@ -261,6 +264,9 @@ importers:
 
   packages/contract:
     dependencies:
+      '@zeltjs/adapter-node':
+        specifier: workspace:*
+        version: link:../adapter-node
       cac:
         specifier: 7.0.0
         version: 7.0.0


### PR DESCRIPTION
## Summary

- Add `CliConfig` base class with `cwd()`, `argv()`, `exit()` methods for CLI environment abstraction
- Add `NodeCliConfig` implementation using Node.js `process.*` APIs
- Auto-inject `NodeCliConfig` in `onNode()` when `CliConfig` is registered
- Refactor CLI packages to use `CliConfig` instead of direct `process.*` access
- Remove `no-process-access` eslint exception for CLI files

## Motivation

- Enable testability by allowing mock injection of CLI environment
- Improve portability to other runtimes (Deno, Bun)
- Maintain consistency with `EnvConfig` / `ProcessEnvConfig` pattern

## Test plan

- [x] `pnpm test` - All tests pass (431 passed)
- [x] `pnpm lint` - No errors
- [x] New test added for `NodeCliConfig` auto-injection in `onNode()`