### PR TITLE
refactor(auth-session): introduce SessionSchema for type-safe session access

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -299,17 +299,6 @@ export default tseslint.config(
     },
   },
   {
-    // Session context uses generic type narrowing at AsyncLocalStorage boundary.
-    // Type assertions are needed for user-facing generic session data APIs.
-    files: [
-      'packages/auth-session/src/session.context.lib.ts',
-      'packages/auth-session/src/session.functions.lib.ts',
-    ],
-    rules: {
-      '@9wick/strict-type-rules/no-as-assertion': 'off',
-    },
-  },
-  {
     // Command module uses AsyncLocalStorage and generic type inference at runtime boundaries.
     // Type assertions are needed for inferred schema types. Throws for developer errors (calling
     // args() outside command context) which should crash immediately during development.

--- a/packages/auth-session/src/index.ts
+++ b/packages/auth-session/src/index.ts
@@ -8,4 +8,4 @@ export {
   isNewSession,
   getSessionId,
 } from './session.functions.lib';
-export type { SessionData, SessionMetadata, StoredSession } from './session.types';
+export type { SessionData, SessionMetadata, SessionSchema, StoredSession } from './session.types';

--- a/packages/auth-session/src/session.context.lib.ts
+++ b/packages/auth-session/src/session.context.lib.ts
@@ -1,10 +1,13 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import type { SessionData, StoredSession } from './session.types';
+import type { SessionMetadata, SessionSchema } from './session.types';
 
-export interface SessionContext<T extends SessionData = SessionData> {
+export interface SessionContext {
   sessionId: string;
-  session: StoredSession<T>;
+  session: {
+    data: SessionSchema;
+    meta: SessionMetadata;
+  };
   isNew: boolean;
   isDestroyed: boolean;
   isDirty: boolean;
@@ -12,17 +15,12 @@ export interface SessionContext<T extends SessionData = SessionData> {
 
 const sessionStorage = new AsyncLocalStorage<SessionContext>();
 
-export const getSessionContext = <T extends SessionData = SessionData>():
-  | SessionContext<T>
-  | undefined => {
-  return sessionStorage.getStore() as SessionContext<T> | undefined;
+export const getSessionContext = (): SessionContext | undefined => {
+  return sessionStorage.getStore();
 };
 
-export const runWithSessionContext = <T extends SessionData, R>(
-  context: SessionContext<T>,
-  fn: () => R,
-): R => {
-  return sessionStorage.run(context as SessionContext, fn);
+export const runWithSessionContext = <R>(context: SessionContext, fn: () => R): R => {
+  return sessionStorage.run(context, fn);
 };
 
 export const markSessionDirty = (): void => {

--- a/packages/auth-session/src/session.functions.lib.ts
+++ b/packages/auth-session/src/session.functions.lib.ts
@@ -1,28 +1,26 @@
 import { getSessionContext, markSessionDestroyed, markSessionDirty } from './session.context.lib';
-import type { SessionData } from './session.types';
+import type { SessionSchema } from './session.types';
 
-export const getSession = <T extends SessionData = SessionData>(): T | undefined => {
-  const ctx = getSessionContext<T>();
+export const getSession = (): SessionSchema | undefined => {
+  const ctx = getSessionContext();
   if (!ctx || ctx.isDestroyed) {
     return undefined;
   }
-  return ctx.session.data as T;
+  return ctx.session.data;
 };
 
-export const setSession = <T extends SessionData = SessionData>(data: T): void => {
-  const ctx = getSessionContext<T>();
+export const setSession = (data: SessionSchema): void => {
+  const ctx = getSessionContext();
   if (ctx) {
     ctx.session.data = data;
     markSessionDirty();
   }
 };
 
-export const updateSession = <T extends SessionData = SessionData>(
-  updater: (current: T) => T,
-): void => {
-  const ctx = getSessionContext<T>();
+export const updateSession = (updater: (current: SessionSchema) => SessionSchema): void => {
+  const ctx = getSessionContext();
   if (ctx) {
-    ctx.session.data = updater(ctx.session.data as T);
+    ctx.session.data = updater(ctx.session.data);
     markSessionDirty();
   }
 };

--- a/packages/auth-session/src/session.middleware.test.ts
+++ b/packages/auth-session/src/session.middleware.test.ts
@@ -6,11 +6,13 @@ import type { KVStore } from '@zeltjs/kv';
 import { SessionMiddleware } from './session.middleware';
 import { SessionConfig } from './session.config';
 import { getSession, setSession, destroySession, isNewSession } from './session.functions.lib';
-import type { SessionData } from './session.types';
+import type { SessionSchema } from './session.types';
 
-interface TestSession extends SessionData {
-  userId?: string;
-  count?: number;
+declare module '@zeltjs/auth-session' {
+  interface SessionSchema {
+    userId?: string;
+    count?: number;
+  }
 }
 
 class TestSessionConfig extends SessionConfig {
@@ -43,23 +45,23 @@ class TestSessionConfig extends SessionConfig {
 class SessionTestController {
   @Get('/')
   get() {
-    const session = getSession<TestSession>();
+    const session = getSession();
     return { session, isNew: isNewSession() };
   }
 
   @Post('/login')
   login() {
-    setSession<TestSession>({ userId: 'user-123', count: 1 });
+    setSession({ userId: 'user-123', count: 1 });
     return { success: true };
   }
 
   @Post('/increment')
   increment() {
-    const session = getSession<TestSession>();
+    const session = getSession();
     if (session) {
-      setSession<TestSession>({ ...session, count: (session.count ?? 0) + 1 });
+      setSession({ ...session, count: (session.count ?? 0) + 1 });
     }
-    return { count: getSession<TestSession>()?.count };
+    return { count: getSession()?.count };
   }
 
   @Post('/logout')
@@ -91,7 +93,7 @@ describe('SessionMiddleware', () => {
     const res = await app.request('/session/');
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { session: TestSession | undefined; isNew: boolean };
+    const body = (await res.json()) as { session: SessionSchema | undefined; isNew: boolean };
     expect(body.isNew).toBe(true);
     expect(body.session).toEqual({});
   });
@@ -107,7 +109,7 @@ describe('SessionMiddleware', () => {
     const getRes = await app.request('/session/', {
       headers: { Cookie: `sid=${cookie}` },
     });
-    const body = (await getRes.json()) as { session: TestSession };
+    const body = (await getRes.json()) as { session: SessionSchema };
     expect(body.session.userId).toBe('user-123');
     expect(body.session.count).toBe(1);
   });
@@ -131,7 +133,7 @@ describe('SessionMiddleware', () => {
     const getRes = await app.request('/session/', {
       headers: { Cookie: `sid=${cookie}` },
     });
-    const body = (await getRes.json()) as { session: TestSession };
+    const body = (await getRes.json()) as { session: SessionSchema };
     expect(body.session.count).toBe(3);
   });
 
@@ -150,7 +152,7 @@ describe('SessionMiddleware', () => {
     const getRes = await app.request('/session/', {
       headers: { Cookie: `sid=${cookie}` },
     });
-    const body = (await getRes.json()) as { session: TestSession | undefined; isNew: boolean };
+    const body = (await getRes.json()) as { session: SessionSchema | undefined; isNew: boolean };
     expect(body.isNew).toBe(true);
     expect(body.session).toEqual({});
   });

--- a/packages/auth-session/src/session.types.ts
+++ b/packages/auth-session/src/session.types.ts
@@ -1,3 +1,7 @@
+export interface SessionSchema {
+  [key: string]: unknown;
+}
+
 export interface SessionData {
   [key: string]: unknown;
 }
@@ -7,7 +11,7 @@ export interface SessionMetadata {
   expiresAt: number;
 }
 
-export interface StoredSession<T extends SessionData = SessionData> {
-  data: T;
+export interface StoredSession {
+  data: SessionSchema;
   meta: SessionMetadata;
 }


### PR DESCRIPTION
## Summary

- Introduce `SessionSchema` interface with declaration merging support
- Remove all `as` type assertions from session context and functions
- Remove eslint `no-as-assertion` exception for auth-session files

## Changes

Users can now extend `SessionSchema` via declaration merging:

```ts
declare module '@zeltjs/auth-session' {
  interface SessionSchema {
    userId?: string;
    cart?: CartItem[];
  }
}
```

## Test plan

- [x] Type check passes
- [x] All existing tests pass
- [x] Lint passes without exceptions