### PR TITLE
refactor(command): remove Legacy Command API

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -216,8 +216,8 @@ export default tseslint.config(
     },
   },
   {
-    // CLI command runner uses DI container.get() at dynamic module boundaries
-    // where type assertions are unavoidable.
+    // CLI command runner uses citty parseArgs which returns loosely typed object.
+    // Type assertions are needed at this library boundary.
     files: [
       'packages/cli/src/commands/run/runner.ts',
       'packages/cli/src/commands/run/loader.ts',
@@ -225,11 +225,6 @@ export default tseslint.config(
     ],
     rules: {
       '@9wick/strict-type-rules/no-as-assertion': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -216,8 +216,8 @@ export default tseslint.config(
     },
   },
   {
-    // CLI command runner uses Object.create and DI container.get() at dynamic module
-    // boundaries where type assertions are unavoidable.
+    // CLI command runner uses DI container.get() at dynamic module boundaries
+    // where type assertions are unavoidable.
     files: [
       'packages/cli/src/commands/run/runner.ts',
       'packages/cli/src/commands/run/loader.ts',
@@ -226,6 +226,10 @@ export default tseslint.config(
     rules: {
       '@9wick/strict-type-rules/no-as-assertion': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
   {

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createApp, Controller, Get, EnvConfig, Command } from '@zeltjs/core';
+import { createApp, Controller, Get, EnvConfig, Command, cliSchema } from '@zeltjs/core';
 
 import { onNode, type ServerHandle, type HttpNodeApp, type CommandNodeApp } from './on-node';
 import { ProcessEnvConfig } from './process-env.config';
@@ -155,12 +155,14 @@ describe('onNode with commands', () => {
   it('executes a command and returns exitCode 0 on success', async () => {
     const runFn = vi.fn();
 
-    @Command({ name: 'test-cmd' })
     class TestCommand {
+      static schema = cliSchema({});
+
       run() {
         runFn();
       }
     }
+    Command({ name: 'test-cmd' })(TestCommand);
 
     const app = createApp({ commands: [TestCommand] });
     nodeApp = await onNode(app);
@@ -172,10 +174,12 @@ describe('onNode with commands', () => {
   });
 
   it('returns exitCode 1 when command not found', async () => {
-    @Command({ name: 'existing' })
     class ExistingCommand {
+      static schema = cliSchema({});
+
       run() {}
     }
+    Command({ name: 'existing' })(ExistingCommand);
 
     const app = createApp({ commands: [ExistingCommand] });
     nodeApp = await onNode(app);
@@ -186,10 +190,12 @@ describe('onNode with commands', () => {
   });
 
   it('returns exitCode 1 when no command specified', async () => {
-    @Command({ name: 'test' })
     class TestCommand {
+      static schema = cliSchema({});
+
       run() {}
     }
+    Command({ name: 'test' })(TestCommand);
 
     const app = createApp({ commands: [TestCommand] });
     nodeApp = await onNode(app);
@@ -200,12 +206,14 @@ describe('onNode with commands', () => {
   });
 
   it('returns exitCode 1 when command throws', async () => {
-    @Command({ name: 'failing' })
     class FailingCommand {
+      static schema = cliSchema({});
+
       run() {
         throw new Error('Command failed');
       }
     }
+    Command({ name: 'failing' })(FailingCommand);
 
     const app = createApp({ commands: [FailingCommand] });
     nodeApp = await onNode(app);

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -86,7 +86,7 @@ const runCommand = (
 ): Promise<ExecResult> => {
   const instance = get(CommandClass);
   return Promise.resolve()
-    .then(() => instance.run({ args: {}, options: {} }))
+    .then(() => instance.run())
     .then(() => successResult)
     .catch(() => failureResult);
 };

--- a/packages/cli/src/commands/run/runner.test.ts
+++ b/packages/cli/src/commands/run/runner.test.ts
@@ -18,62 +18,6 @@ const getArgsFromContext = (cmd: unknown): unknown => {
 };
 
 describe('runCommand', () => {
-  it('executes command with parsed args and options', async () => {
-    const received: { name: string; verbose: boolean } = { name: '', verbose: false };
-
-    @Command({ name: 'greet' })
-    class GreetCommand {
-      readonly args = {
-        name: { type: 'positional' as const, required: true as const },
-      };
-      readonly options = {
-        verbose: { type: 'boolean' as const, default: false },
-      };
-
-      run(ctx: { args: Record<string, string | undefined>; options: Record<string, unknown> }) {
-        received.name = ctx.args['name'] ?? '';
-        received.verbose = ctx.options['verbose'] as boolean;
-      }
-    }
-
-    await runCommand(GreetCommand, ['Alice', '--verbose']);
-
-    expect(received.name).toBe('Alice');
-    expect(received.verbose).toBe(true);
-  });
-
-  it('uses default values when args not provided', async () => {
-    const received: { env: string } = { env: '' };
-
-    @Command({ name: 'deploy' })
-    class DeployCommand {
-      readonly options = {
-        env: { type: 'string' as const, default: 'production' },
-      };
-
-      run(ctx: { args: Record<string, string | undefined>; options: Record<string, unknown> }) {
-        received.env = ctx.options['env'] as string;
-      }
-    }
-
-    await runCommand(DeployCommand, []);
-
-    expect(received.env).toBe('production');
-  });
-
-  it('throws CommandExecutionError when command throws', async () => {
-    @Command({ name: 'fail' })
-    class FailingCommand {
-      run() {
-        throw new Error('Command failed');
-      }
-    }
-
-    await expect(runCommand(FailingCommand, [])).rejects.toThrow(CommandExecutionError);
-  });
-});
-
-describe('runCommand with static schema', () => {
   it('parses positional args from schema', async () => {
     const received: { target: string } = { target: '' };
 
@@ -230,6 +174,19 @@ describe('runCommand with static schema', () => {
     expect(received.target).toBe('production');
     expect(received.port).toBe(8080);
     expect(received.verbose).toBe(true);
+  });
+
+  it('throws CommandExecutionError when command throws', async () => {
+    class FailingCommand {
+      static schema = cliSchema({});
+
+      run() {
+        throw new Error('Command failed');
+      }
+    }
+    Command({ name: 'fail' })(FailingCommand);
+
+    await expect(runCommand(FailingCommand, [])).rejects.toThrow(CommandExecutionError);
   });
 });
 

--- a/packages/cli/src/commands/run/runner.ts
+++ b/packages/cli/src/commands/run/runner.ts
@@ -1,11 +1,4 @@
-import type {
-  ArgDef,
-  CommandClass,
-  CommandContext,
-  LegacyCommandClass,
-  NewCommandClass,
-  SchemaDefinition,
-} from '@zeltjs/core';
+import type { ArgDef, CommandClass, SchemaDefinition } from '@zeltjs/core';
 import { runInCommandContext } from '@zeltjs/core';
 import { Container } from '@needle-di/core';
 import type { ArgsDef, BooleanArgDef, StringArgDef } from 'citty';
@@ -39,86 +32,11 @@ export class SchemaValidationError extends Error {
   }
 }
 
-type LegacyInstanceShape = {
-  args?: Record<string, { type: string; default?: string }>;
-  options?: Record<string, { type: string; alias?: string; default?: boolean | string }>;
-  run: (ctx: CommandContext) => Promise<void> | void;
-};
-
-type NewInstanceShape = {
-  run: (ctx?: unknown) => Promise<void> | void;
-};
+type CommandInstance = InstanceType<CommandClass>;
 
 type ParsedArgs = {
   _: string[];
   [key: string]: unknown;
-};
-
-// --- Legacy API helpers ---
-
-const toPositionalArg = (def: { default?: string }): ArgsDef[string] =>
-  def.default !== undefined ? { type: 'positional', default: def.default } : { type: 'positional' };
-
-const toBooleanArg = (def: { alias?: string; default?: boolean | string }): BooleanArgDef => {
-  const base: BooleanArgDef = { type: 'boolean' };
-  if (def.alias !== undefined) base.alias = def.alias;
-  if (def.default !== undefined) base.default = def.default as boolean;
-  return base;
-};
-
-const toStringArg = (def: { alias?: string; default?: boolean | string }): StringArgDef => {
-  const base: StringArgDef = { type: 'string' };
-  if (def.alias !== undefined) base.alias = def.alias;
-  if (def.default !== undefined) base.default = def.default as string;
-  return base;
-};
-
-const buildLegacyCittyArgs = (commandClass: LegacyCommandClass): ArgsDef => {
-  const instance = Object.create(commandClass.prototype) as LegacyInstanceShape;
-  const cittyArgs: ArgsDef = {};
-
-  for (const [key, def] of Object.entries(instance.args ?? {})) {
-    cittyArgs[key] = toPositionalArg(def);
-  }
-
-  for (const [key, def] of Object.entries(instance.options ?? {})) {
-    cittyArgs[key] = def.type === 'boolean' ? toBooleanArg(def) : toStringArg(def);
-  }
-
-  return cittyArgs;
-};
-
-const buildLegacyArgs = (
-  instance: LegacyInstanceShape,
-  parsed: ParsedArgs,
-): Record<string, string | undefined> => {
-  const positionalKeys = Object.keys(instance.args ?? {});
-  const args: Record<string, string | undefined> = {};
-  for (let i = 0; i < positionalKeys.length; i++) {
-    const key = positionalKeys[i];
-    if (key) {
-      args[key] = (parsed._[i] as string | undefined) ?? (instance.args?.[key]?.default as string);
-    }
-  }
-  return args;
-};
-
-const buildLegacyOptions = (
-  instance: LegacyInstanceShape,
-  parsed: ParsedArgs,
-): Record<string, unknown> => {
-  const options: Record<string, unknown> = {};
-  for (const key of Object.keys(instance.options ?? {})) {
-    options[key] = parsed[key] ?? instance.options?.[key]?.default;
-  }
-  return options;
-};
-
-// --- New API helpers ---
-
-const getStaticSchema = (commandClass: CommandClass): SchemaDefinition | undefined => {
-  const maybeSchema = (commandClass as { schema?: SchemaDefinition }).schema;
-  return maybeSchema;
 };
 
 const validateSchema = (schema: SchemaDefinition): void => {
@@ -214,32 +132,10 @@ const buildNewArgs = (schema: SchemaDefinition, parsed: ParsedArgs): Record<stri
   return result;
 };
 
-// --- Legacy execution ---
-
-const parseAndResolveLegacy = (
-  commandClass: LegacyCommandClass,
+const parseAndResolve = (
+  commandClass: CommandClass,
   argv: string[],
-): { instance: LegacyInstanceShape; ctx: CommandContext } => {
-  const cittyArgs = buildLegacyCittyArgs(commandClass);
-  const parsed = parseArgs(argv, cittyArgs) as ParsedArgs;
-
-  const container = new Container();
-  const instance = container.get(commandClass) as LegacyInstanceShape;
-
-  const ctx: CommandContext = {
-    args: buildLegacyArgs(instance, parsed),
-    options: buildLegacyOptions(instance, parsed),
-  } as CommandContext;
-
-  return { instance, ctx };
-};
-
-// --- New execution ---
-
-const parseAndResolveNew = (
-  commandClass: NewCommandClass,
-  argv: string[],
-): { instance: NewInstanceShape; parsedArgs: Record<string, unknown> } => {
+): { instance: CommandInstance; parsedArgs: Record<string, unknown> } => {
   const schema = commandClass.schema;
 
   validateSchema(schema);
@@ -250,29 +146,15 @@ const parseAndResolveNew = (
   const parsedArgs = buildNewArgs(schema, parsed);
 
   const container = new Container();
-  const instance = container.get(commandClass) as NewInstanceShape;
+  const instance = container.get(commandClass) as CommandInstance;
 
   return { instance, parsedArgs };
 };
 
-// --- Main entry point ---
-
 export const runCommand = async (commandClass: CommandClass, argv: string[]): Promise<void> => {
-  const staticSchema = getStaticSchema(commandClass);
-
-  if (staticSchema !== undefined) {
-    const { instance, parsedArgs } = parseAndResolveNew(commandClass as NewCommandClass, argv);
-    try {
-      await Promise.resolve(runInCommandContext({ parsedArgs }, () => instance.run()));
-    } catch (cause) {
-      throw new CommandExecutionError(cause);
-    }
-    return;
-  }
-
-  const { instance, ctx } = parseAndResolveLegacy(commandClass as LegacyCommandClass, argv);
+  const { instance, parsedArgs } = parseAndResolve(commandClass, argv);
   try {
-    await Promise.resolve(instance.run(ctx));
+    await Promise.resolve(runInCommandContext({ parsedArgs }, () => instance.run()));
   } catch (cause) {
     throw new CommandExecutionError(cause);
   }

--- a/packages/cli/src/commands/run/runner.ts
+++ b/packages/cli/src/commands/run/runner.ts
@@ -1,4 +1,4 @@
-import type { ArgDef, CommandClass, SchemaDefinition } from '@zeltjs/core';
+import type { ArgDef, CommandClass, CommandRunner, SchemaDefinition } from '@zeltjs/core';
 import { runInCommandContext } from '@zeltjs/core';
 import { Container } from '@needle-di/core';
 import type { ArgsDef, BooleanArgDef, StringArgDef } from 'citty';
@@ -31,8 +31,6 @@ export class SchemaValidationError extends Error {
     this.name = 'SchemaValidationError';
   }
 }
-
-type CommandInstance = InstanceType<CommandClass>;
 
 type ParsedArgs = {
   _: string[];
@@ -135,7 +133,7 @@ const buildNewArgs = (schema: SchemaDefinition, parsed: ParsedArgs): Record<stri
 const parseAndResolve = (
   commandClass: CommandClass,
   argv: string[],
-): { instance: CommandInstance; parsedArgs: Record<string, unknown> } => {
+): { instance: CommandRunner; parsedArgs: Record<string, unknown> } => {
   const schema = commandClass.schema;
 
   validateSchema(schema);
@@ -146,7 +144,7 @@ const parseAndResolve = (
   const parsedArgs = buildNewArgs(schema, parsed);
 
   const container = new Container();
-  const instance = container.get(commandClass) as CommandInstance;
+  const instance = container.get<CommandRunner>(commandClass);
 
   return { instance, parsedArgs };
 };

--- a/packages/core/src/command/types.ts
+++ b/packages/core/src/command/types.ts
@@ -45,23 +45,10 @@ export type CommandContext<
   readonly options: InferOptions<TOptions>;
 };
 
-// Legacy command class (args/options properties)
-export type LegacyCommandClass = new (
-  ...args: never[]
-) => {
-  args?: ArgsDefinition;
-  options?: OptionsDefinition;
-  run(ctx: CommandContext): Promise<void> | void;
-};
-
-// New command class (static schema)
-export type NewCommandClass = (new (
+export type CommandClass = (new (
   ...args: never[]
 ) => {
   run(ctx?: unknown): Promise<void> | void;
 }) & {
   schema: import('./schema').SchemaDefinition;
 };
-
-// Union of both for backward compatibility
-export type CommandClass = LegacyCommandClass | NewCommandClass;

--- a/packages/core/src/command/types.ts
+++ b/packages/core/src/command/types.ts
@@ -45,10 +45,14 @@ export type CommandContext<
   readonly options: InferOptions<TOptions>;
 };
 
+import type { SchemaDefinition } from './schema';
+
+export type CommandRunner = {
+  run(): Promise<void> | void;
+};
+
 export type CommandClass = (new (
   ...args: never[]
-) => {
-  run(ctx?: unknown): Promise<void> | void;
-}) & {
-  schema: import('./schema').SchemaDefinition;
+) => CommandRunner) & {
+  schema: SchemaDefinition;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,8 +45,6 @@ export type {
   CommandContext,
   InferArgs,
   InferOptions,
-  LegacyCommandClass,
-  NewCommandClass,
   OptionDefinition,
   OptionsDefinition,
 } from './command/types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export type {
   ArgsDefinition,
   CommandClass,
   CommandContext,
+  CommandRunner,
   InferArgs,
   InferOptions,
   OptionDefinition,


### PR DESCRIPTION
## Summary

- Remove Legacy Command API (instance properties `args`/`options` + `ctx` argument)
- Unify `LegacyCommandClass` and `NewCommandClass` into single `CommandClass` type
- Add `CommandRunner` type alias for DI type inference, removing `as` assertion from `container.get()`
- Remove ~165 lines of legacy support code from runner.ts

## Changes

- **packages/core/src/command/types.ts**: Remove legacy types, add `CommandRunner` type alias
- **packages/cli/src/commands/run/runner.ts**: Remove legacy helpers (`buildLegacy*`, `parseAndResolveLegacy`)
- **packages/adapter-node/src/on-node.ts**: Update `run()` call to match new signature
- **eslint.config.mjs**: Remove unnecessary `unsafe-*` exceptions

## Test plan

- [x] `pnpm --filter @zeltjs/core test` passes
- [x] `pnpm --filter @zeltjs/cli test` passes
- [x] `pnpm --filter @zeltjs/adapter-node test` passes
- [x] `pnpm run precommit` passes