### PR TITLE
chore(gwq): copy lefthook-local.yml to worktrees

### DIFF
--- a/.gwq.toml
+++ b/.gwq.toml
@@ -1,3 +1,6 @@
+[copy]
+patterns = 'lefthook-local.yml'
+
 [[repository_settings]]
-repository = "."
-setup_commands = ["pnpm i"]
+repository = '.'
+setup_commands = ['pnpm i']


### PR DESCRIPTION
## Summary

- Add `copy.patterns` to `.gwq.toml` to copy `lefthook-local.yml` when creating worktrees
- Ensures local git hooks (worktree-guard) are available in linked worktrees

## Test plan

- [ ] Create a new worktree with `gwq add -b <branch>`
- [ ] Verify `lefthook-local.yml` exists in the new worktree