### PR TITLE
feat(eslint-plugin): add DI naming convention rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Format check
         run: pnpm format:check
 
+      - name: Build eslint-plugin
+        run: pnpm --filter @zeltjs/eslint-plugin build
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,8 @@ import oxlint from 'eslint-plugin-oxlint';
 import sonarjs from 'eslint-plugin-sonarjs';
 import tseslint from 'typescript-eslint';
 
+import zeltPlugin from '@zeltjs/eslint-plugin';
+
 const TEST_FILES = ['**/*.test.{ts,tsx}', '**/*.e2e.test.{ts,tsx}'];
 const FIXTURE_FILES = ['**/_fixtures/**/*.{ts,tsx}', '**/test/fixtures/**/*.{ts,tsx}'];
 const EXAMPLE_FILES = ['examples/**/*.{ts,tsx}'];
@@ -22,13 +24,18 @@ export default tseslint.config(
       '**/generated/**',
       'website/**',
       'vitest.shared.ts',
+      'packages/eslint-plugin/**',
     ],
   },
   tseslint.configs.recommended,
   ...oxlint.configs['flat/all'],
   eslintComments.recommended,
   {
-    plugins: { 'import-x': importX, sonarjs },
+    plugins: {
+      'import-x': importX,
+      sonarjs,
+      zelt: zeltPlugin,
+    },
   },
   ...strictTypes.configs.recommended,
   ...strictTypes.configs.test,
@@ -57,6 +64,14 @@ export default tseslint.config(
       parserOptions: {
         projectService: true,
       },
+    },
+  },
+  {
+    files: ['packages/**/*.{ts,tsx}'],
+    ignores: [...TEST_FILES, ...EXAMPLE_FILES, ...FIXTURE_FILES],
+    rules: {
+      'zelt/config-di-scope': 'warn',
+      'zelt/decorator-file-naming': 'warn',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@9wick/eslint-plugin-strict-type-rules": "1.1.1",
+    "@zeltjs/eslint-plugin": "workspace:*",
     "@biomejs/biome": "2.4.14",
     "@eslint-community/eslint-plugin-eslint-comments": "4.7.1",
     "@swc/core": "1.15.33",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@zeltjs/eslint-plugin",
+  "version": "0.0.1",
+  "description": "ESLint plugin for Zelt DI naming conventions",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "eslint": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/eslint": "^9.6.1",
+    "@types/estree": "^1.0.7",
+    "@types/node": "^22.15.21",
+    "tsdown": "^0.12.6",
+    "typescript": "^5.8.3"
+  },
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "zelt",
+    "di",
+    "naming-conventions"
+  ],
+  "license": "MIT"
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,0 +1,13 @@
+import type { ESLint } from 'eslint';
+
+import configDiScope from './rules/config-di-scope';
+import decoratorFileNaming from './rules/decorator-file-naming';
+
+const plugin: ESLint.Plugin = {
+  rules: {
+    'config-di-scope': configDiScope,
+    'decorator-file-naming': decoratorFileNaming,
+  },
+};
+
+export default plugin;

--- a/packages/eslint-plugin/src/rules/config-di-scope.ts
+++ b/packages/eslint-plugin/src/rules/config-di-scope.ts
@@ -1,0 +1,152 @@
+import path from 'node:path';
+import type { Rule } from 'eslint';
+
+const KNOWN_SUFFIXES = [
+  'config',
+  'service',
+  'middleware',
+  'controller',
+  'decorator',
+  'types',
+  'lib',
+  'test',
+  'formatter',
+];
+
+interface FilePrefixAndSuffix {
+  prefix: string;
+  suffix: string | null;
+}
+
+function extractFilePrefixAndSuffix(filename: string): FilePrefixAndSuffix {
+  const withoutExt = filename.replace(/\.ts$/, '');
+  const parts = withoutExt.split('.');
+
+  if (parts.length < 2) {
+    return { prefix: parts[0] ?? '', suffix: null };
+  }
+
+  const lastPart = parts[parts.length - 1];
+
+  if (lastPart && KNOWN_SUFFIXES.includes(lastPart)) {
+    return {
+      prefix: parts.slice(0, -1).join('.'),
+      suffix: lastPart,
+    };
+  }
+
+  return { prefix: withoutExt, suffix: null };
+}
+
+function prefixMatches(
+  callerPrefix: string,
+  callerSuffix: string | null,
+  configPrefix: string,
+): boolean {
+  const normalize = (s: string) => s.replace(/[-._]/g, '-');
+
+  if (normalize(callerPrefix) === normalize(configPrefix)) {
+    return true;
+  }
+
+  if (callerSuffix) {
+    const callerFull = `${callerPrefix}-${callerSuffix}`;
+    if (normalize(callerFull) === normalize(configPrefix)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce that injectConfig() caller file prefix matches the config file prefix',
+    },
+    messages: {
+      prefixMismatch:
+        'injectConfig({{configName}}): caller prefix "{{callerPrefix}}" does not match config file prefix "{{configPrefix}}". Rename to {{expectedFile}}',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.filename;
+    const basename = path.basename(filename);
+    const { prefix: callerPrefix, suffix: callerSuffix } = extractFilePrefixAndSuffix(basename);
+
+    if (basename.endsWith('.config.ts') || basename.endsWith('.test.ts')) {
+      return {};
+    }
+
+    const importedConfigs = new Map<string, { configPrefix: string; configFileName: string }>();
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+        if (typeof source !== 'string' || !source.endsWith('.config')) {
+          return;
+        }
+
+        const configFileName = path.basename(source) + '.ts';
+        const { prefix: configPrefix } = extractFilePrefixAndSuffix(configFileName);
+
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported.type === 'Identifier' &&
+            specifier.imported.name.endsWith('Config')
+          ) {
+            importedConfigs.set(specifier.local.name, {
+              configPrefix,
+              configFileName,
+            });
+          }
+        }
+      },
+
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier' || node.callee.name !== 'injectConfig') {
+          return;
+        }
+
+        const firstArg = node.arguments[0];
+        if (!firstArg || firstArg.type !== 'Identifier') {
+          return;
+        }
+
+        const configName = firstArg.name;
+        const configInfo = importedConfigs.get(configName);
+
+        if (!configInfo) {
+          return;
+        }
+
+        const { configPrefix } = configInfo;
+
+        if (prefixMatches(callerPrefix, callerSuffix, configPrefix)) {
+          return;
+        }
+
+        const fileParts = basename.split('.');
+        const suffix = fileParts.slice(1).join('.');
+        const expectedFile = `${configPrefix}.${suffix}`;
+
+        context.report({
+          node,
+          messageId: 'prefixMismatch',
+          data: {
+            configName,
+            callerPrefix,
+            configPrefix,
+            expectedFile,
+          },
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin/src/rules/decorator-file-naming.ts
+++ b/packages/eslint-plugin/src/rules/decorator-file-naming.ts
@@ -1,0 +1,174 @@
+import path from 'node:path';
+import type { Rule } from 'eslint';
+import type { Identifier, Expression } from 'estree';
+
+interface Decorator {
+  expression: Expression;
+}
+
+const DI_DECORATORS = ['Config', 'Injectable', 'Controller', 'Middleware', 'ErrorHandler'];
+
+const SUFFIX_MAP: Record<string, string> = {
+  Config: 'config',
+  Service: 'service',
+  Controller: 'controller',
+  Middleware: 'middleware',
+  ErrorHandler: 'error-handler',
+  Formatter: 'formatter',
+};
+
+function findDIDecorator(decorators: Decorator[]): string | null {
+  for (const dec of decorators) {
+    let name: string | null = null;
+
+    if (dec.expression.type === 'Identifier') {
+      name = dec.expression.name;
+    } else if (
+      dec.expression.type === 'CallExpression' &&
+      dec.expression.callee.type === 'Identifier'
+    ) {
+      name = dec.expression.callee.name;
+    }
+
+    if (name && DI_DECORATORS.includes(name)) {
+      return name;
+    }
+  }
+  return null;
+}
+
+interface ParsedClassName {
+  expectedPrefix: string | null;
+  expectedSuffix: string | null;
+}
+
+function parseClassName(className: string): ParsedClassName {
+  for (const [suffix, fileSuffix] of Object.entries(SUFFIX_MAP)) {
+    if (className.endsWith(suffix)) {
+      const withoutSuffix = className.slice(0, -suffix.length);
+      const expectedPrefix = camelToKebab(withoutSuffix);
+      return { expectedPrefix, expectedSuffix: fileSuffix };
+    }
+  }
+
+  return { expectedPrefix: null, expectedSuffix: null };
+}
+
+function camelToKebab(str: string): string {
+  return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+function extractFilePrefix(filename: string): string {
+  const withoutExt = filename.replace(/\.ts$/, '');
+  const parts = withoutExt.split('.');
+
+  if (parts.length >= 2) {
+    return parts.slice(0, -1).join('.');
+  }
+
+  return parts[0] ?? '';
+}
+
+function extractFileSuffix(filename: string): string {
+  const withoutExt = filename.replace(/\.ts$/, '');
+  const parts = withoutExt.split('.');
+
+  return parts[parts.length - 1] ?? '';
+}
+
+function prefixMatches(actual: string, expected: string): boolean {
+  const normalizePrefix = (p: string) => p.replace(/[-._]/g, '-');
+  return normalizePrefix(actual) === normalizePrefix(expected);
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce that DI-decorated classes are in files with matching names',
+    },
+    messages: {
+      fileNameMismatch:
+        '@{{decorator}} class "{{className}}" should be in a file matching "{{expectedPattern}}", but found "{{actualFile}}"',
+      unknownSuffix:
+        '@{{decorator}} class "{{className}}" has unknown suffix. Use one of: {{knownSuffixes}}',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.filename;
+    const basename = path.basename(filename);
+
+    if (basename.endsWith('.test.ts')) {
+      return {};
+    }
+
+    return {
+      ClassDeclaration(node) {
+        const decorators = (node as unknown as { decorators?: Decorator[] }).decorators;
+        if (!decorators || decorators.length === 0) {
+          return;
+        }
+
+        const decorator = findDIDecorator(decorators);
+        if (!decorator) {
+          return;
+        }
+
+        const className = (node.id as Identifier | null)?.name;
+        if (!className) {
+          return;
+        }
+
+        const { expectedPrefix, expectedSuffix } = parseClassName(className);
+        if (!expectedPrefix || !expectedSuffix) {
+          context.report({
+            node,
+            messageId: 'unknownSuffix',
+            data: {
+              decorator,
+              className,
+              knownSuffixes: Object.keys(SUFFIX_MAP).join(', '),
+            },
+          });
+          return;
+        }
+
+        const actualPrefix = extractFilePrefix(basename);
+        const actualSuffix = extractFileSuffix(basename);
+
+        if (actualSuffix !== expectedSuffix) {
+          const expectedPattern = `${expectedPrefix}.${expectedSuffix}.ts (or with . _ separators)`;
+          context.report({
+            node,
+            messageId: 'fileNameMismatch',
+            data: {
+              decorator,
+              className,
+              expectedPattern,
+              actualFile: basename,
+            },
+          });
+          return;
+        }
+
+        if (!prefixMatches(actualPrefix, expectedPrefix)) {
+          const expectedPattern = `${expectedPrefix}.${expectedSuffix}.ts (or with . _ separators)`;
+          context.report({
+            node,
+            messageId: 'fileNameMismatch',
+            data: {
+              decorator,
+              className,
+              expectedPattern,
+              actualFile: basename,
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/eslint-plugin/tsdown.config.ts
+++ b/packages/eslint-plugin/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.5
         version: 4.1.5(vitest@4.1.5)
+      '@zeltjs/eslint-plugin':
+        specifier: workspace:*
+        version: link:packages/eslint-plugin
       codepolicy:
         specifier: 0.2.2
         version: 0.2.2(zod@4.4.2)
@@ -329,6 +332,28 @@ importers:
       valibot:
         specifier: 1.3.1
         version: 1.3.1(typescript@6.0.2)
+
+  packages/eslint-plugin:
+    dependencies:
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4(jiti@2.6.1)
+    devDependencies:
+      '@types/eslint':
+        specifier: ^9.6.1
+        version: 9.6.1
+      '@types/estree':
+        specifier: ^1.0.7
+        version: 1.0.8
+      '@types/node':
+        specifier: ^22.15.21
+        version: 22.19.17
+      tsdown:
+        specifier: ^0.12.6
+        version: 0.12.9(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
 
   packages/kv:
     dependencies:
@@ -2810,21 +2835,49 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/config-array@0.23.5':
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/config-helpers@0.5.5':
     resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/plugin-kit@0.7.1':
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
@@ -5133,6 +5186,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-kit@2.2.0:
+    resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
+    engines: {node: '>=20.19.0'}
+
   ast-kit@3.0.0-beta.1:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
@@ -5289,6 +5346,9 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
+  birpc@2.9.0:
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
@@ -5393,6 +5453,10 @@ packages:
     peerDependenciesMeta:
       magicast:
         optional: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -5989,6 +6053,10 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -6349,6 +6417,10 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -6356,6 +6428,10 @@ packages:
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
@@ -6370,6 +6446,20 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
@@ -6762,6 +6852,10 @@ packages:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
     engines: {node: '>=10'}
 
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
   globals@17.6.0:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
@@ -6859,6 +6953,9 @@ packages:
   hono@4.12.16:
     resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
     engines: {node: '>=16.9.0'}
+
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
@@ -9080,6 +9177,22 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown-plugin-dts@0.13.14:
+    resolution: {integrity: sha512-wjNhHZz9dlN6PTIXyizB6u/mAg1wEFMW9yw7imEVe3CxHSRnNHVyycIX0yDEOVJfDNISLPbkCIPEpFpizy5+PQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: ^1.0.0-beta.9
+      typescript: ^5.0.0
+      vue-tsc: ^2.2.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
   rolldown-plugin-dts@0.23.2:
     resolution: {integrity: sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==}
     engines: {node: '>=20.19.0'}
@@ -9680,6 +9793,28 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
+  tsdown@0.12.9:
+    resolution: {integrity: sha512-MfrXm9PIlT3saovtWKf/gCJJ/NQCdE0SiREkdNC+9Qy6UHhdeDPxnkFaBD7xttVUmgp0yUHtGirpoLB+OVLuLA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      publint: ^0.3.0
+      typescript: ^5.0.0
+      unplugin-lightningcss: ^0.4.0
+      unplugin-unused: ^0.5.0
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      publint:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-lightningcss:
+        optional: true
+      unplugin-unused:
+        optional: true
+
   tsdown@0.21.10:
     resolution: {integrity: sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==}
     engines: {node: '>=20.19.0'}
@@ -9782,6 +9917,9 @@ packages:
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+
+  unconfig@7.5.0:
+    resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -12987,7 +13125,20 @@ snapshots:
       eslint: 10.3.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@eslint/config-array@0.23.5':
     dependencies:
@@ -12997,15 +13148,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
   '@eslint/config-helpers@0.5.5':
     dependencies:
       '@eslint/core': 1.2.1
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
 
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
   '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
 
   '@eslint/plugin-kit@0.7.1':
     dependencies:
@@ -15117,6 +15299,11 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-kit@2.2.0:
+    dependencies:
+      '@babel/parser': 7.29.3
+      pathe: 2.0.3
+
   ast-kit@3.0.0-beta.1:
     dependencies:
       '@babel/parser': 8.0.0-rc.3
@@ -15289,6 +15476,8 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
+  birpc@2.9.0: {}
+
   birpc@4.0.0: {}
 
   bl@4.1.0:
@@ -15437,6 +15626,8 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 2.3.1
       rc9: 2.1.2
+
+  cac@6.7.14: {}
 
   cac@7.0.0: {}
 
@@ -16026,6 +16217,8 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
+  diff@8.0.4: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -16429,6 +16622,11 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -16437,6 +16635,8 @@ snapshots:
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.1: {}
 
@@ -16476,6 +16676,53 @@ snapshots:
       jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
+
+  eslint@9.39.4(jiti@2.6.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
     dependencies:
@@ -16939,6 +17186,8 @@ snapshots:
     dependencies:
       ini: 2.0.0
 
+  globals@14.0.0: {}
+
   globals@17.6.0: {}
 
   globby@11.1.0:
@@ -17119,6 +17368,8 @@ snapshots:
       react-is: 16.13.1
 
   hono@4.12.16: {}
+
+  hookable@5.5.3: {}
 
   hookable@6.1.1: {}
 
@@ -19822,6 +20073,23 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown-plugin-dts@0.13.14(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.17)(typescript@5.9.3):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      ast-kit: 2.2.0
+      birpc: 2.9.0
+      debug: 4.4.3
+      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      get-tsconfig: 4.14.0
+      rolldown: 1.0.0-rc.17
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - oxc-resolver
+      - supports-color
+
   rolldown-plugin-dts@0.23.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.17)(typescript@6.0.2):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
@@ -20597,6 +20865,29 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tsdown@0.12.9(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 6.7.14
+      chokidar: 4.0.3
+      debug: 4.4.3
+      diff: 8.0.4
+      empathic: 2.0.0
+      hookable: 5.5.3
+      rolldown: 1.0.0-rc.17
+      rolldown-plugin-dts: 0.13.14(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.17)(typescript@5.9.3)
+      semver: 7.7.4
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.14
+      unconfig: 7.5.0
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - supports-color
+      - vue-tsc
+
   tsdown@0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2):
     dependencies:
       ansis: 4.2.0
@@ -20693,6 +20984,14 @@ snapshots:
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
+
+  unconfig@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      defu: 6.1.7
+      jiti: 2.6.1
+      quansync: 1.0.0
+      unconfig-core: 7.5.0
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
## Summary

- Add `@zeltjs/eslint-plugin` package with two ESLint rules for DI naming conventions
- `config-di-scope`: Enforce that `injectConfig()` caller file prefix matches the config file prefix
- `decorator-file-naming`: Enforce that DI-decorated classes use known suffixes (Service, Controller, Middleware, Formatter, etc.)

## Rules

### config-di-scope

```typescript
// ✅ OK: rate-limit.service.ts → rate-limit.config.ts
import { RateLimitConfig } from './rate-limit.config';
injectConfig(RateLimitConfig);

// ❌ NG: rate-limiter.service.ts → rate-limit.config.ts (prefix mismatch)
import { RateLimitConfig } from './rate-limit.config';
injectConfig(RateLimitConfig);
```

### decorator-file-naming

```typescript
// ✅ OK: class ends with known suffix
@Injectable()
export class RateLimitService { ... }

// ❌ NG: unknown suffix
@Injectable()
export class RateLimiter { ... }
```

## Notes

- Rules are set to `warn` level for gradual adoption
- Current codebase has 9 warnings that need to be addressed in follow-up PRs

## Test plan

- [x] `pnpm lint` runs successfully with new plugin
- [x] Rules detect violations in existing code (as warnings)
- [x] `pnpm precommit` passes