### PR TITLE
feat(eslint-plugin): add require-inject-config rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,7 @@ export default tseslint.config(
     rules: {
       'zelt/config-di-scope': 'warn',
       'zelt/decorator-file-naming': 'warn',
+      'zelt/require-inject-config': 'error',
     },
   },
   {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -16,7 +16,8 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "eslint": "^9.0.0"
@@ -25,8 +26,10 @@
     "@types/eslint": "^9.6.1",
     "@types/estree": "^1.0.7",
     "@types/node": "^22.15.21",
+    "@typescript-eslint/parser": "^8.32.1",
     "tsdown": "^0.12.6",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.5"
   },
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -2,11 +2,13 @@ import type { ESLint } from 'eslint';
 
 import configDiScope from './rules/config-di-scope';
 import decoratorFileNaming from './rules/decorator-file-naming';
+import requireInjectConfig from './rules/require-inject-config';
 
 const plugin: ESLint.Plugin = {
   rules: {
     'config-di-scope': configDiScope,
     'decorator-file-naming': decoratorFileNaming,
+    'require-inject-config': requireInjectConfig,
   },
 };
 

--- a/packages/eslint-plugin/src/rules/require-inject-config.test.ts
+++ b/packages/eslint-plugin/src/rules/require-inject-config.test.ts
@@ -1,0 +1,90 @@
+import { RuleTester } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+
+import rule from './require-inject-config';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tsParser,
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('require-inject-config', rule, {
+  valid: [
+    {
+      code: `
+        import { inject } from '@zeltjs/core';
+        import { MyService } from './my.service';
+        class Test {
+          constructor(private service = inject(MyService)) {}
+        }
+      `,
+    },
+    {
+      code: `
+        import { injectConfig } from '@zeltjs/core';
+        import { AppConfig } from './app.config';
+        class Test {
+          constructor(private config = injectConfig(AppConfig)) {}
+        }
+      `,
+    },
+    {
+      code: `
+        import { inject } from '@zeltjs/core';
+        import { Logger } from './logger';
+        class Test {
+          constructor(private logger = inject(Logger)) {}
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { inject } from '@zeltjs/core';
+        import { AppConfig } from './app.config';
+        class Test {
+          constructor(private config = inject(AppConfig)) {}
+        }
+      `,
+      errors: [
+        {
+          messageId: 'useInjectConfig',
+          data: { configName: 'AppConfig' },
+        },
+      ],
+      output: `
+        import { inject, injectConfig } from '@zeltjs/core';
+        import { AppConfig } from './app.config';
+        class Test {
+          constructor(private config = injectConfig(AppConfig)) {}
+        }
+      `,
+    },
+    {
+      code: `
+        import { inject } from '@zeltjs/core';
+        import { EnvConfig } from '../modules/env/env.config';
+        class Test {
+          constructor(private config = inject(EnvConfig)) {}
+        }
+      `,
+      errors: [
+        {
+          messageId: 'useInjectConfig',
+          data: { configName: 'EnvConfig' },
+        },
+      ],
+      output: `
+        import { inject, injectConfig } from '@zeltjs/core';
+        import { EnvConfig } from '../modules/env/env.config';
+        class Test {
+          constructor(private config = injectConfig(EnvConfig)) {}
+        }
+      `,
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/require-inject-config.ts
+++ b/packages/eslint-plugin/src/rules/require-inject-config.ts
@@ -1,0 +1,98 @@
+import path from 'node:path';
+import type { Rule } from 'eslint';
+import type { ImportSpecifier } from 'estree';
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce using injectConfig() instead of inject() for @Config classes',
+    },
+    messages: {
+      useInjectConfig:
+        'Use injectConfig({{configName}}) instead of inject({{configName}}). Classes from *.config.ts files must use injectConfig().',
+    },
+    fixable: 'code',
+    schema: [],
+  },
+
+  create(context) {
+    const configClasses = new Set<string>();
+    let hasInjectConfigImport = false;
+    let injectImportNode: ImportSpecifier | null = null;
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+        if (typeof source !== 'string') {
+          return;
+        }
+
+        if (source.endsWith('.config')) {
+          const configFileName = path.basename(source) + '.ts';
+          if (configFileName.endsWith('.config.ts')) {
+            for (const specifier of node.specifiers) {
+              if (
+                specifier.type === 'ImportSpecifier' &&
+                specifier.imported.type === 'Identifier' &&
+                specifier.imported.name.endsWith('Config')
+              ) {
+                configClasses.add(specifier.local.name);
+              }
+            }
+          }
+        }
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier') {
+            if (specifier.imported.name === 'injectConfig') {
+              hasInjectConfigImport = true;
+            }
+            if (specifier.imported.name === 'inject') {
+              injectImportNode = specifier;
+            }
+          }
+        }
+      },
+
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier' || node.callee.name !== 'inject') {
+          return;
+        }
+
+        const firstArg = node.arguments[0];
+        if (!firstArg || firstArg.type !== 'Identifier') {
+          return;
+        }
+
+        const argName = firstArg.name;
+
+        if (!configClasses.has(argName)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'useInjectConfig',
+          data: {
+            configName: argName,
+          },
+          fix(fixer) {
+            const fixes: Rule.Fix[] = [];
+
+            fixes.push(fixer.replaceText(node.callee, 'injectConfig'));
+
+            if (!hasInjectConfigImport && injectImportNode) {
+              fixes.push(fixer.insertTextAfter(injectImportNode, ', injectConfig'));
+              hasInjectConfigImport = true;
+            }
+
+            return fixes;
+          },
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin/vitest.config.ts
+++ b/packages/eslint-plugin/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,12 +348,18 @@ importers:
       '@types/node':
         specifier: ^22.15.21
         version: 22.19.17
+      '@typescript-eslint/parser':
+        specifier: ^8.32.1
+        version: 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tsdown:
         specifier: ^0.12.6
         version: 0.12.9(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/kv:
     dependencies:
@@ -14852,6 +14858,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.1
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.1
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.59.1(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@6.0.2)
@@ -14865,6 +14892,10 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/visitor-keys': 8.59.1
+
+  '@typescript-eslint/tsconfig-utils@8.59.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@typescript-eslint/tsconfig-utils@8.59.1(typescript@6.0.2)':
     dependencies:
@@ -14883,6 +14914,21 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.59.1': {}
+
+  '@typescript-eslint/typescript-estree@8.59.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/visitor-keys': 8.59.1
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/typescript-estree@8.59.1(typescript@6.0.2)':
     dependencies:
@@ -20832,6 +20878,10 @@ snapshots:
   trough@2.2.0: {}
 
   ts-algebra@2.0.0: {}
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   ts-api-utils@2.5.0(typescript@6.0.2):
     dependencies:


### PR DESCRIPTION
## Summary

- Add new ESLint rule `zelt/require-inject-config` to enforce using `injectConfig()` instead of `inject()` for `@Config` classes
- Classes imported from `*.config.ts` files must use `injectConfig()` for DI
- Includes autofix support that replaces `inject(ConfigClass)` with `injectConfig(ConfigClass)` and adds the import if needed

## Test plan

- [x] Unit tests pass (`pnpm test` in eslint-plugin)
- [x] Rule correctly detects `inject(ConfigClass)` when ConfigClass is from `*.config.ts`
- [x] Rule allows `inject()` for non-Config classes
- [x] Autofix replaces `inject` with `injectConfig` and adds import