### PR TITLE
chore: migrate docs hosting to Cloudflare Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # zeltjs
 
+[![Documentation](https://img.shields.io/badge/docs-zeltjs.com-blue)](https://zeltjs.com)
+
 > Edge/serverless 時代のための、Laravel/FuelPHP 的な型安全 TypeScript アプリケーションフレームワーク。
 >
 > A fast, type-safe application framework for TypeScript, bringing Laravel/FuelPHP-like productivity to edge and serverless runtimes.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,8 +11,8 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://zeltjs.github.io',
-  baseUrl: '/zelt/',
+  url: 'https://zeltjs.com',
+  baseUrl: '/',
 
   organizationName: 'zeltjs',
   projectName: 'zelt',


### PR DESCRIPTION
## Summary
- Update Docusaurus config to use `https://zeltjs.com` as base URL
- Remove `/zelt/` base path prefix (no longer needed with custom domain)
- Add documentation badge to README

## Test plan
- [ ] Verify docs site builds correctly
- [ ] Confirm links work without `/zelt/` prefix after deployment