### PR TITLE
docs: sync documentation with recent API changes

### DIFF
--- a/website/docs/authentication.md
+++ b/website/docs/authentication.md
@@ -42,11 +42,13 @@ export const jwtAuth: FunctionMiddleware = async (c, next) => {
 ### Register as Global Middleware
 
 ```typescript
-import { createHttpApp } from '@zeltjs/core';
+import { createApp } from '@zeltjs/core';
 
-const app = createHttpApp({
-  controllers: [UserController, AdminController],
-  middlewares: [jwtAuth],
+const app = createApp({
+  http: {
+    controllers: [UserController, AdminController],
+    middlewares: [jwtAuth],
+  },
 });
 ```
 
@@ -230,12 +232,14 @@ pnpm add @zeltjs/auth-jwt
 2. Register the `JwtMiddleware` and `JwtConfig`:
 
 ```typescript
-import { createHttpApp } from '@zeltjs/core';
+import { createApp } from '@zeltjs/core';
 import { JwtMiddleware, JwtConfig } from '@zeltjs/auth-jwt';
 
-const app = createHttpApp({
-  controllers: [UserController],
-  middlewares: [JwtMiddleware],
+const app = createApp({
+  http: {
+    controllers: [UserController],
+    middlewares: [JwtMiddleware],
+  },
   configs: [JwtConfig],
 });
 ```
@@ -296,9 +300,11 @@ class CustomJwtConfig extends JwtConfig {
 Register the custom config:
 
 ```typescript
-const app = createHttpApp({
-  controllers: [AuthController, UserController],
-  middlewares: [JwtMiddleware],
+const app = createApp({
+  http: {
+    controllers: [AuthController, UserController],
+    middlewares: [JwtMiddleware],
+  },
   configs: [CustomJwtConfig],
 });
 ```
@@ -328,10 +334,9 @@ pnpm add @zeltjs/auth-session @zeltjs/kv
 3. Register the middleware:
 
 ```typescript
-import { createHttpApp } from '@zeltjs/core';
+import { createApp, Config, inject } from '@zeltjs/core';
 import { MemoryKV } from '@zeltjs/kv';
 import { SessionMiddleware, SessionConfig } from '@zeltjs/auth-session';
-import { Config, injectConfig } from '@zeltjs/core';
 
 @Config
 class MySessionConfig extends SessionConfig {
@@ -342,12 +347,38 @@ class MySessionConfig extends SessionConfig {
   }
 }
 
-const app = createHttpApp({
-  controllers: [UserController],
-  middlewares: [SessionMiddleware],
+const app = createApp({
+  http: {
+    controllers: [UserController],
+    middlewares: [SessionMiddleware],
+  },
   configs: [MySessionConfig],
   injectables: [MemoryKV],
 });
+```
+
+### Type-Safe Sessions with SessionSchema
+
+Extend `SessionSchema` via declaration merging for type-safe session access:
+
+```typescript
+declare module '@zeltjs/auth-session' {
+  interface SessionSchema {
+    userId?: string;
+    name?: string;
+    cart?: CartItem[];
+  }
+}
+```
+
+Now all session functions are fully typed:
+
+```typescript
+const session = getSession();
+// TypeScript knows: session?.userId, session?.name, session?.cart
+
+setSession({ userId: '123', name: 'Alice' });
+// Type-checked against SessionSchema
 ```
 
 ### Session Functions
@@ -356,24 +387,19 @@ Use the session functions in your handlers:
 
 ```typescript
 import { Controller, Get, Post, bodyParam } from '@zeltjs/core';
-import { getSession, setSession, updateSession, destroySession } from '@zeltjs/auth-session';
-
-interface UserSession {
-  userId: string;
-  name: string;
-}
+import { getSession, setSession, destroySession } from '@zeltjs/auth-session';
 
 @Controller('/auth')
 class AuthController {
   @Post('/login')
   login(body = bodyParam(LoginSchema)) {
-    setSession<UserSession>({ userId: '123', name: body.name });
+    setSession({ userId: '123', name: body.name });
     return { success: true };
   }
 
   @Get('/me')
   me() {
-    const session = getSession<UserSession>();
+    const session = getSession();
     if (!session) {
       throw new HTTPException(401, { message: 'Not logged in' });
     }
@@ -392,9 +418,9 @@ class AuthController {
 
 | Function | Description |
 |----------|-------------|
-| `getSession<T>()` | Get current session data (returns `undefined` if not logged in) |
-| `setSession<T>(data)` | Set session data (replaces existing) |
-| `updateSession<T>(updater)` | Update session data with a function |
+| `getSession()` | Get current session data (returns `undefined` if not logged in) |
+| `setSession(data)` | Set session data (replaces existing) |
+| `updateSession(updater)` | Update session data with a function |
 | `destroySession()` | Destroy the session and clear the cookie |
 | `isNewSession()` | Check if this is a newly created session |
 | `getSessionId()` | Get the current session ID |

--- a/website/docs/command.md
+++ b/website/docs/command.md
@@ -3,32 +3,26 @@
 
 # Commands
 
-Zelt provides `@zeltjs/command` package for building CLI commands with dependency injection support.
-
-## Installation
-
-```bash
-pnpm add @zeltjs/command
-```
+Zelt provides CLI command support with dependency injection through `@zeltjs/core`.
 
 ## Creating a Command
 
-Use the `@Command` decorator to define a CLI command:
+Use the `@Command` decorator with `cliSchema()` and `args()` for type-safe CLI commands:
 
 ```typescript
-import { Command, type CommandContext } from '@zeltjs/command';
+import { Command, cliSchema, args } from '@zeltjs/core';
 
 @Command({
   name: 'greet',
   description: 'Greet a user',
 })
 export class GreetCommand {
-  args = {
-    name: { type: 'positional' as const, description: 'Name to greet' },
-  };
+  static schema = cliSchema({
+    args: [{ name: 'name', type: 'string' }],
+  });
 
-  run(ctx: CommandContext<typeof this.args>) {
-    console.log(`Hello, ${ctx.args.name}!`);
+  run(ctx = args(GreetCommand)) {
+    console.log(`Hello, ${ctx.name}!`);
   }
 }
 ```
@@ -58,28 +52,24 @@ zelt run greet Alice
 zelt run -c ./config/zelt.config.ts greet Alice
 ```
 
-## Arguments and Options
+## Schema Definition
+
+The `cliSchema()` function defines typed arguments and options:
 
 ### Positional Arguments
 
 ```typescript
 @Command({ name: 'copy' })
 export class CopyCommand {
-  args = {
-    source: { 
-      type: 'positional' as const,
-      required: true,
-      description: 'Source file path',
-    },
-    destination: {
-      type: 'positional' as const,
-      required: true,
-      description: 'Destination file path',
-    },
-  };
+  static schema = cliSchema({
+    args: [
+      { name: 'source', type: 'string' },
+      { name: 'destination', type: 'string' },
+    ],
+  });
 
-  run(ctx: CommandContext<typeof this.args>) {
-    console.log(`Copying ${ctx.args.source} to ${ctx.args.destination}`);
+  run(ctx = args(CopyCommand)) {
+    console.log(`Copying ${ctx.source} to ${ctx.destination}`);
   }
 }
 ```
@@ -89,26 +79,18 @@ export class CopyCommand {
 ```typescript
 @Command({ name: 'build' })
 export class BuildCommand {
-  options = {
-    watch: {
-      type: 'boolean' as const,
-      alias: 'w',
-      default: false,
-      description: 'Watch for changes',
-    },
-    outDir: {
-      type: 'string' as const,
-      alias: 'o',
-      default: 'dist',
-      description: 'Output directory',
-    },
-  };
+  static schema = cliSchema({
+    options: [
+      { name: 'watch', type: 'boolean', alias: 'w' },
+      { name: 'outDir', type: 'string', alias: 'o', default: 'dist' },
+    ],
+  });
 
-  run(ctx: CommandContext<Record<string, never>, typeof this.options>) {
-    if (ctx.options.watch) {
+  run(ctx = args(BuildCommand)) {
+    if (ctx.watch) {
       console.log('Watching for changes...');
     }
-    console.log(`Output directory: ${ctx.options.outDir}`);
+    console.log(`Output directory: ${ctx.outDir}`);
   }
 }
 ```
@@ -124,29 +106,18 @@ zelt run build -w -o out
 ```typescript
 @Command({ name: 'deploy' })
 export class DeployCommand {
-  args = {
-    environment: {
-      type: 'positional' as const,
-      required: true,
-      description: 'Target environment (staging, production)',
-    },
-  };
+  static schema = cliSchema({
+    args: [
+      { name: 'environment', type: 'string' },
+    ],
+    options: [
+      { name: 'dryRun', type: 'boolean' },
+      { name: 'tag', type: 'string' },
+    ],
+  });
 
-  options = {
-    dryRun: {
-      type: 'boolean' as const,
-      default: false,
-      description: 'Simulate deployment without making changes',
-    },
-    tag: {
-      type: 'string' as const,
-      description: 'Docker image tag to deploy',
-    },
-  };
-
-  run(ctx: CommandContext<typeof this.args, typeof this.options>) {
-    const { environment } = ctx.args;
-    const { dryRun, tag } = ctx.options;
+  run(ctx = args(DeployCommand)) {
+    const { environment, dryRun, tag } = ctx;
 
     if (dryRun) {
       console.log(`[DRY RUN] Would deploy to ${environment}`);
@@ -157,50 +128,87 @@ export class DeployCommand {
 }
 ```
 
-## Dependency Injection
+## Schema Types
 
-Commands support dependency injection, allowing you to use services:
+### Argument Types
+
+| Type | Description |
+|------|-------------|
+| `string` | String value |
+| `number` | Numeric value (automatically parsed) |
+
+Arguments can be marked as optional:
 
 ```typescript
-import { Command, type CommandContext } from '@zeltjs/command';
-import { inject } from '@zeltjs/core';
+static schema = cliSchema({
+  args: [
+    { name: 'file', type: 'string' },
+    { name: 'count', type: 'number', optional: true },
+  ],
+});
+```
+
+### Option Types
+
+| Type | Description |
+|------|-------------|
+| `string` | String option |
+| `number` | Numeric option (automatically parsed) |
+| `boolean` | Boolean flag |
+
+Options can have defaults:
+
+```typescript
+static schema = cliSchema({
+  options: [
+    { name: 'port', type: 'number', default: 3000 },
+    { name: 'verbose', type: 'boolean' },  // defaults to false
+  ],
+});
+```
+
+## Dependency Injection
+
+Commands support dependency injection:
+
+```typescript
+import { Command, cliSchema, args, inject } from '@zeltjs/core';
 import { DatabaseService } from '../services/database.service';
 
 @Command({ name: 'migrate' })
 export class MigrateCommand {
+  static schema = cliSchema({
+    options: [
+      { name: 'force', type: 'boolean' },
+    ],
+  });
+
   constructor(private readonly db = inject(DatabaseService)) {}
 
-  async run(ctx: CommandContext) {
+  async run(ctx = args(MigrateCommand)) {
+    if (ctx.force) {
+      console.log('Force migration enabled');
+    }
     await this.db.runMigrations();
     console.log('Migrations completed');
   }
 }
 ```
 
-## Type Inference
+## Programmatic Execution
 
-The `CommandContext` type automatically infers argument and option types:
+Commands can be executed programmatically using `onNode()`:
 
 ```typescript
-@Command({ name: 'example' })
-export class ExampleCommand {
-  args = {
-    file: { type: 'positional' as const, required: true },
-    count: { type: 'positional' as const, default: '10' },
-  };
+import { createApp } from '@zeltjs/core';
+import { onNode } from '@zeltjs/adapter-node';
+import { MigrateCommand } from './commands/migrate.command';
 
-  options = {
-    verbose: { type: 'boolean' as const, default: false },
-    format: { type: 'string' as const },
-  };
+const app = createApp({ commands: [MigrateCommand] });
+const nodeApp = await onNode(app);
 
-  run(ctx: CommandContext<typeof this.args, typeof this.options>) {
-    // ctx.args.file: string (required)
-    // ctx.args.count: string (has default)
-    // ctx.options.verbose: boolean (has default)
-    // ctx.options.format: string | undefined (optional)
-  }
-}
+const result = await nodeApp.exec(['migrate', '--force']);
+console.log(`Exit code: ${result.exitCode}`);
 ```
 
 ## Async Commands
@@ -210,7 +218,7 @@ Commands can be async:
 ```typescript
 @Command({ name: 'sync' })
 export class SyncCommand {
-  async run(ctx: CommandContext) {
+  async run() {
     console.log('Starting sync...');
     await this.fetchData();
     await this.processData();

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -50,15 +50,17 @@ export class DatabaseService {
 
 ## Registering Configuration
 
-Register config classes when creating the HTTP app:
+Register config classes when creating the app:
 
 ```typescript
-import { createHttpApp } from '@zeltjs/core';
+import { createApp } from '@zeltjs/core';
 import { DatabaseConfig } from './database.config';
 import { AppController } from './app.controller';
 
-const app = createHttpApp({
-  controllers: [AppController],
+const app = createApp({
+  http: {
+    controllers: [AppController],
+  },
   configs: [DatabaseConfig],
 });
 ```
@@ -83,8 +85,10 @@ export class TestDatabaseConfig extends DatabaseConfig {
 }
 
 // In test setup
-const app = createHttpApp({
-  controllers: [AppController],
+const app = createApp({
+  http: {
+    controllers: [AppController],
+  },
   configs: [TestDatabaseConfig],
 });
 ```
@@ -127,8 +131,10 @@ export class DatabaseConfig {
 }
 
 // Register both configs
-const app = createHttpApp({
-  controllers: [AppController],
+const app = createApp({
+  http: {
+    controllers: [AppController],
+  },
   configs: [ProcessEnvConfig, DatabaseConfig],
 });
 ```
@@ -153,8 +159,10 @@ export class DatabaseConfig {
 }
 
 // DotEnvConfig loads .env on construction
-const app = createHttpApp({
-  controllers: [AppController],
+const app = createApp({
+  http: {
+    controllers: [AppController],
+  },
   configs: [DotEnvConfig, DatabaseConfig],
 });
 ```


### PR DESCRIPTION
## Summary

- Update `command.md` to use new `cliSchema()` and `args()` API (replaces legacy `args`/`options` instance properties)
- Replace `createHttpApp` with `createApp({ http: {...} })` across all documentation
- Add `SessionSchema` declaration merging documentation for type-safe sessions

## Related PRs

- #69 feat(command)!: add cliSchema and args() for improved CLI API
- #73 refactor(core): unify createHttpApp into createApp with http option
- #81 refactor(auth-session): introduce SessionSchema for type-safe session access
- #82 refactor(command): remove Legacy Command API

## Test plan

- [x] Website build passes (`pnpm run build`)