### PR TITLE
refactor(core): move createTestTargetBase to internal-bridge subpath

### DIFF
--- a/packages/auth-jwt/vitest.config.ts
+++ b/packages/auth-jwt/vitest.config.ts
@@ -12,6 +12,10 @@ export default mergeConfig(
     resolve: {
       alias: {
         // Resolve @zeltjs/core from source to share the same @needle-di/core instance as direct imports.
+        '@zeltjs/core/internal-bridge/testing': resolve(
+          __dirname,
+          '../core/src/internal-bridge/testing.ts',
+        ),
         '@zeltjs/core': resolve(__dirname, '../core/src/index.ts'),
       },
     },

--- a/packages/auth-session/vitest.config.ts
+++ b/packages/auth-session/vitest.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@zeltjs/core/internal-bridge/testing': resolve(
+        __dirname,
+        '../core/src/internal-bridge/testing.ts',
+      ),
       '@zeltjs/core': resolve(__dirname, '../core/src/index.ts'),
       '@zeltjs/kv': resolve(__dirname, '../kv/src/index.ts'),
     },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -13,6 +13,10 @@ export default mergeConfig(
     },
     resolve: {
       alias: {
+        '@zeltjs/core/internal-bridge/testing': path.resolve(
+          __dirname,
+          '../core/src/internal-bridge/testing.ts',
+        ),
         '@zeltjs/core': path.resolve(__dirname, '../core/src/index.ts'),
       },
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,10 @@
     "./runtime": {
       "types": "./dist/runtime/index.d.ts",
       "import": "./dist/runtime/index.js"
+    },
+    "./internal-bridge/testing": {
+      "types": "./dist/internal-bridge/testing.d.ts",
+      "import": "./dist/internal-bridge/testing.js"
     }
   },
   "files": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,9 +93,6 @@ export type {
 export { Config, injectConfig, overrideConfig } from './config';
 export type { ConfigClass } from './config';
 
-export { createTestTargetBase } from './internal/container';
-export type { CreateTestTargetOptions, TestTargetResult } from './internal/container';
-
 export { LifecycleManager } from './lifecycle';
 export type { Lifecycle, Disposable } from './lifecycle';
 

--- a/packages/core/src/internal-bridge/testing.ts
+++ b/packages/core/src/internal-bridge/testing.ts
@@ -1,0 +1,2 @@
+export { createTestTargetBase } from '../internal/container';
+export type { CreateTestTargetOptions, TestTargetResult } from '../internal/container';

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     'src/modules/logger/index.ts',
     'src/modules/env/index.ts',
     'src/runtime/index.ts',
+    'src/internal-bridge/testing.ts',
   ],
   format: ['esm'],
   dts: true,

--- a/packages/kv-driver-redis/src/redis-kv.lifecycle.test.ts
+++ b/packages/kv-driver-redis/src/redis-kv.lifecycle.test.ts
@@ -1,4 +1,5 @@
-import { createTestTargetBase, LifecycleManager } from '@zeltjs/core';
+import { LifecycleManager } from '@zeltjs/core';
+import { createTestTargetBase } from '@zeltjs/core/internal-bridge/testing';
 import { describe, expect, it, vi } from 'vitest';
 
 import { RedisKVConfig } from './redis-kv.config';

--- a/packages/rate-limit/src/rate-limit.config.test.ts
+++ b/packages/rate-limit/src/rate-limit.config.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { MemoryKV } from '@zeltjs/kv';
-import { createTestTargetBase } from '@zeltjs/core';
+import { createTestTargetBase } from '@zeltjs/core/internal-bridge/testing';
 
 import { RateLimitConfig } from './rate-limit.config';
 

--- a/packages/rate-limit/src/rate-limiter.service.test.ts
+++ b/packages/rate-limit/src/rate-limiter.service.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { MemoryKVService, type AtomicKVStore, KVError } from '@zeltjs/kv';
 import type { LoggerService } from '@zeltjs/core';
-import { createTestTargetBase } from '@zeltjs/core';
+import { createTestTargetBase } from '@zeltjs/core/internal-bridge/testing';
 
 import { RateLimitConfig } from './rate-limit.config';
 import { RateLimitService } from './rate-limit.service';

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,5 +1,8 @@
 export { createTestTarget } from './test-target';
-export type { CreateTestTargetOptions, TestTargetResult } from '@zeltjs/core';
+export type {
+  CreateTestTargetOptions,
+  TestTargetResult,
+} from '@zeltjs/core/internal-bridge/testing';
 
 export { configureTestDefaults, getTestDefaults } from './global-config';
 export { onTest } from './on-test';

--- a/packages/testing/src/test-target.ts
+++ b/packages/testing/src/test-target.ts
@@ -1,10 +1,16 @@
-import { createTestTargetBase } from '@zeltjs/core';
-import type { CreateTestTargetOptions, TestTargetResult } from '@zeltjs/core';
+import { createTestTargetBase } from '@zeltjs/core/internal-bridge/testing';
+import type {
+  CreateTestTargetOptions,
+  TestTargetResult,
+} from '@zeltjs/core/internal-bridge/testing';
 
 import { getTestDefaults } from './global-config';
 import { registerShutdown } from './shutdown-registry';
 
-export type { CreateTestTargetOptions, TestTargetResult } from '@zeltjs/core';
+export type {
+  CreateTestTargetOptions,
+  TestTargetResult,
+} from '@zeltjs/core/internal-bridge/testing';
 
 type AnyConstructor = new (...args: never[]) => unknown;
 


### PR DESCRIPTION
## Summary

- Move `createTestTargetBase` from `@zeltjs/core` main export to `@zeltjs/core/internal-bridge/testing` subpath
- Keep public API clean while allowing `@zeltjs/testing` to remain a separate devDependency package
- Update vitest configs to resolve the new subpath alias

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm build` succeeds