### PR TITLE
feat(db): add @zeltjs/db package with ALS transaction propagation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -305,6 +305,27 @@ export default tseslint.config(
     },
   },
   {
+    // TC39 method decorator requires `any` for generic method type compatibility.
+    // Type assertion is unavoidable at this decorator type boundary.
+    files: ['packages/db/src/decorator.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@9wick/strict-type-rules/no-as-assertion': 'off',
+    },
+  },
+  {
+    // createTransactionMiddleware defines a dynamic class inline via a factory function.
+    // inject() returns `any` at the generic type boundary; the class name cannot match the file.
+    files: ['packages/db/src/middleware.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      'zelt/decorator-file-naming': 'off',
+    },
+  },
+  {
     // Command module uses AsyncLocalStorage and generic type inference at runtime boundaries.
     // Type assertions are needed for inferred schema types. Throws for developer errors (calling
     // args() outside command context) which should crash immediately during development.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@zeltjs/db",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zeltjs/zelt.git",
+    "directory": "packages/db"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run",
+    "typecheck": "tsc -b"
+  },
+  "peerDependencies": {
+    "@zeltjs/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@zeltjs/core": "workspace:*",
+    "@types/node": "22.19.17"
+  }
+}

--- a/packages/db/src/database-service.test.ts
+++ b/packages/db/src/database-service.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DatabaseService } from './database-service';
+
+class MockDatabaseService extends DatabaseService<{ query: (sql: string) => string }> {
+  setupCalled = false;
+  transactionCalls: unknown[] = [];
+
+  async setup() {
+    this.setupCalled = true;
+    return { query: (sql: string) => `result: ${sql}` };
+  }
+
+  async transaction<T>(
+    client: { query: (sql: string) => string },
+    fn: (tx: { query: (sql: string) => string }) => Promise<T>,
+  ): Promise<T> {
+    this.transactionCalls.push({ client });
+    return fn(client);
+  }
+}
+
+const mockLifecycleManager = {
+  register: vi.fn(),
+};
+
+vi.mock('@zeltjs/core', () => ({
+  inject: vi.fn(() => mockLifecycleManager),
+  LifecycleManager: class {},
+}));
+
+describe('DatabaseService', () => {
+  let service: MockDatabaseService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new MockDatabaseService();
+  });
+
+  describe('lifecycle', () => {
+    it('should register with LifecycleManager on construction', () => {
+      expect(mockLifecycleManager.register).toHaveBeenCalledWith(service);
+    });
+
+    it('should call setup() on startup and set originalClient', async () => {
+      await service.startup();
+
+      expect(service.setupCalled).toBe(true);
+      expect(service.client.query('test')).toBe('result: test');
+    });
+  });
+
+  describe('client getter', () => {
+    it('should return originalClient when not in transaction', async () => {
+      await service.startup();
+
+      const result = service.client.query('SELECT 1');
+
+      expect(result).toBe('result: SELECT 1');
+    });
+  });
+
+  describe('withTransaction', () => {
+    it('should execute function within transaction context', async () => {
+      await service.startup();
+
+      const result = await service.withTransaction(async () => {
+        return service.client.query('SELECT * FROM users');
+      });
+
+      expect(result).toBe('result: SELECT * FROM users');
+      expect(service.transactionCalls).toHaveLength(1);
+    });
+
+    it('should provide tx client inside transaction', async () => {
+      await service.startup();
+      let clientInsideTx: { query: (sql: string) => string } | undefined;
+
+      await service.withTransaction(async () => {
+        clientInsideTx = service.client;
+      });
+
+      expect(clientInsideTx).toBeDefined();
+    });
+  });
+
+  describe('nested transactions', () => {
+    it('should use current tx client for nested withTransaction', async () => {
+      await service.startup();
+      const clients: unknown[] = [];
+
+      await service.withTransaction(async () => {
+        clients.push(service.client);
+        await service.withTransaction(async () => {
+          clients.push(service.client);
+        });
+        clients.push(service.client);
+      });
+
+      expect(service.transactionCalls).toHaveLength(2);
+    });
+
+    it('should restore previous tx context after nested transaction completes', async () => {
+      await service.startup();
+      let outerClientAfterNested: unknown;
+
+      await service.withTransaction(async () => {
+        const outerClient = service.client;
+        await service.withTransaction(async () => {
+          // nested
+        });
+        outerClientAfterNested = service.client;
+        expect(outerClientAfterNested).toBe(outerClient);
+      });
+    });
+  });
+
+  describe('shutdown', () => {
+    it('should call shutdown handlers in reverse order', async () => {
+      await service.startup();
+      const order: number[] = [];
+      service['onShutdown'](async () => {
+        order.push(1);
+      });
+      service['onShutdown'](async () => {
+        order.push(2);
+      });
+
+      await service.shutdown();
+
+      expect(order).toEqual([2, 1]);
+    });
+  });
+});

--- a/packages/db/src/database-service.ts
+++ b/packages/db/src/database-service.ts
@@ -1,0 +1,43 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { Lifecycle } from '@zeltjs/core';
+import { inject, LifecycleManager } from '@zeltjs/core';
+
+export abstract class DatabaseService<TDatabase> implements Lifecycle {
+  private readonly txStorage = new AsyncLocalStorage<TDatabase>();
+  protected originalClient!: TDatabase;
+  private shutdownHandlers: (() => Promise<void>)[] = [];
+
+  constructor(lifecycle = inject(LifecycleManager)) {
+    lifecycle.register(this);
+  }
+
+  async startup(): Promise<void> {
+    this.originalClient = await this.setup();
+  }
+
+  abstract setup(): Promise<TDatabase>;
+
+  abstract transaction<T>(client: TDatabase, fn: (tx: TDatabase) => Promise<T>): Promise<T>;
+
+  get client(): TDatabase {
+    return this.txStorage.getStore() ?? this.originalClient;
+  }
+
+  withTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    const current = this.txStorage.getStore();
+    const targetClient = current ?? this.originalClient;
+
+    return this.transaction(targetClient, (tx) => this.txStorage.run(tx, fn));
+  }
+
+  protected onShutdown(fn: () => Promise<void>): void {
+    this.shutdownHandlers.push(fn);
+  }
+
+  async shutdown(): Promise<void> {
+    for (const handler of this.shutdownHandlers.reverse()) {
+      await handler();
+    }
+  }
+}

--- a/packages/db/src/db.config.ts
+++ b/packages/db/src/db.config.ts
@@ -1,0 +1,10 @@
+import { Config } from '@zeltjs/core';
+
+export type TransactionMode = 'auto' | 'require';
+
+@Config
+export class DbConfig {
+  get transactionMode(): TransactionMode {
+    return 'auto';
+  }
+}

--- a/packages/db/src/decorator.test.ts
+++ b/packages/db/src/decorator.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DatabaseService } from './database-service';
+import { createTransactionDecorator } from './decorator';
+
+class MockDatabaseService extends DatabaseService<{ id: string }> {
+  withTransactionCalls: (() => Promise<unknown>)[] = [];
+
+  async setup() {
+    return { id: 'mock-client' };
+  }
+
+  async transaction<T>(client: { id: string }, fn: (tx: { id: string }) => Promise<T>): Promise<T> {
+    return fn(client);
+  }
+
+  override withTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    this.withTransactionCalls.push(fn as () => Promise<unknown>);
+    return fn();
+  }
+}
+
+const mockService = new MockDatabaseService();
+
+vi.mock('@zeltjs/core', () => ({
+  inject: vi.fn((cls: unknown) => {
+    if (cls === MockDatabaseService) return mockService;
+    return { register: vi.fn() };
+  }),
+  LifecycleManager: class {},
+}));
+
+describe('createTransactionDecorator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockService.withTransactionCalls = [];
+  });
+
+  it('should create a Transaction decorator factory', () => {
+    const Transaction = createTransactionDecorator(MockDatabaseService);
+
+    expect(typeof Transaction).toBe('function');
+  });
+
+  it('should wrap method in withTransaction when decorated', async () => {
+    const Transaction = createTransactionDecorator(MockDatabaseService);
+
+    class TestService {
+      @Transaction()
+      async doWork(value: number): Promise<number> {
+        return value * 2;
+      }
+    }
+
+    const testService = new TestService();
+    const result = await testService.doWork(5);
+
+    expect(result).toBe(10);
+    expect(mockService.withTransactionCalls).toHaveLength(1);
+  });
+
+  it('should preserve method arguments and return value', async () => {
+    const Transaction = createTransactionDecorator(MockDatabaseService);
+
+    class TestService {
+      @Transaction()
+      async add(a: number, b: number): Promise<number> {
+        return a + b;
+      }
+    }
+
+    const testService = new TestService();
+    const result = await testService.add(3, 4);
+
+    expect(result).toBe(7);
+  });
+});

--- a/packages/db/src/decorator.ts
+++ b/packages/db/src/decorator.ts
@@ -1,0 +1,18 @@
+import { inject } from '@zeltjs/core';
+
+import type { DatabaseService } from './database-service';
+
+type DatabaseServiceClass<T> = new (...args: never[]) => DatabaseService<T>;
+
+// biome-ignore lint/suspicious/noExplicitAny: required for TC39 decorator type compatibility
+type AnyAsyncFn = (...args: any[]) => Promise<any>;
+
+export function createTransactionDecorator<T>(serviceClass: DatabaseServiceClass<T>) {
+  return function Transaction() {
+    return <M extends AnyAsyncFn>(originalMethod: M, _context: ClassMethodDecoratorContext): M =>
+      async function (this: unknown, ...args: Parameters<M>) {
+        const service = inject(serviceClass);
+        return service.withTransaction(() => originalMethod.apply(this, args)) as ReturnType<M>;
+      } as M;
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,6 @@
+// @zeltjs/db - ORM-agnostic database abstraction with transaction propagation
+
+export { DatabaseService } from './database-service';
+export { DbConfig, type TransactionMode } from './db.config';
+export { createTransactionDecorator } from './decorator';
+export { createTransactionMiddleware } from './middleware';

--- a/packages/db/src/middleware.test.ts
+++ b/packages/db/src/middleware.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DatabaseService } from './database-service';
+import { createTransactionMiddleware } from './middleware';
+
+class MockDatabaseService extends DatabaseService<{ id: string }> {
+  withTransactionCalls: (() => Promise<unknown>)[] = [];
+
+  async setup() {
+    return { id: 'mock-client' };
+  }
+
+  async transaction<T>(client: { id: string }, fn: (tx: { id: string }) => Promise<T>): Promise<T> {
+    return fn(client);
+  }
+
+  override withTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    this.withTransactionCalls.push(fn as () => Promise<unknown>);
+    return fn();
+  }
+}
+
+const mockService = new MockDatabaseService();
+
+vi.mock('@zeltjs/core', () => ({
+  inject: vi.fn((cls: unknown) => {
+    if (cls === MockDatabaseService) return mockService;
+    return { register: vi.fn() };
+  }),
+  Middleware: (target: unknown) => target,
+  LifecycleManager: class {},
+}));
+
+describe('createTransactionMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockService.withTransactionCalls = [];
+  });
+
+  it('should create a middleware class', () => {
+    const TransactionMiddleware = createTransactionMiddleware(MockDatabaseService);
+
+    expect(typeof TransactionMiddleware).toBe('function');
+  });
+
+  it('should wrap next() in withTransaction', async () => {
+    const TransactionMiddleware = createTransactionMiddleware(MockDatabaseService);
+    const middleware = new TransactionMiddleware();
+    let nextCalled = false;
+
+    await middleware.use({} as never, async () => {
+      nextCalled = true;
+    });
+
+    expect(nextCalled).toBe(true);
+    expect(mockService.withTransactionCalls).toHaveLength(1);
+  });
+
+  it('should return result from next()', async () => {
+    const TransactionMiddleware = createTransactionMiddleware(MockDatabaseService);
+    const middleware = new TransactionMiddleware();
+
+    // use() returns Promise<Response | undefined>, next() returns Promise<void>
+    // so the return value from next is discarded; we just verify it completes
+    let nextCalled = false;
+    const result = await middleware.use({} as never, async () => {
+      nextCalled = true;
+    });
+
+    expect(nextCalled).toBe(true);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/db/src/middleware.ts
+++ b/packages/db/src/middleware.ts
@@ -1,0 +1,22 @@
+import type { MiddlewareInstance, Next, RequestContext } from '@zeltjs/core';
+import { inject, Middleware } from '@zeltjs/core';
+
+import type { DatabaseService } from './database-service';
+
+type DatabaseServiceClass<T> = new (...args: never[]) => DatabaseService<T>;
+
+type TransactionMiddlewareClass = new () => MiddlewareInstance;
+
+export function createTransactionMiddleware<T>(
+  serviceClass: DatabaseServiceClass<T>,
+): TransactionMiddlewareClass {
+  @Middleware
+  class TransactionMiddleware implements MiddlewareInstance {
+    constructor(private service: DatabaseService<T> = inject(serviceClass)) {}
+
+    use(_ctx: RequestContext, next: Next): Promise<Response | undefined> {
+      return this.service.withTransaction(() => next()).then(() => undefined);
+    }
+  }
+  return TransactionMiddleware;
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@9wick/eslint-plugin-strict-type-rules/tsconfig/strictest.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "erasableSyntaxOnly": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/db/tsdown.config.ts
+++ b/packages/db/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  fixedExtension: false,
+  deps: {
+    neverBundle: ['@zeltjs/core', /^@zeltjs\/core\//],
+  },
+});

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { sharedConfig } from '../../vitest.shared';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      name: '@zeltjs/db',
+      include: ['src/**/*.test.ts'],
+    },
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,15 @@ importers:
         specifier: 1.3.1
         version: 1.3.1(typescript@6.0.2)
 
+  packages/db:
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.17
+        version: 22.19.17
+      '@zeltjs/core':
+        specifier: workspace:*
+        version: link:../core
+
   packages/eslint-plugin:
     dependencies:
       eslint:


### PR DESCRIPTION
## Summary

- Add `@zeltjs/db` package providing ORM-agnostic database abstraction
- `DatabaseService<T>` base class with AsyncLocalStorage-based transaction propagation
- `createTransactionDecorator` and `createTransactionMiddleware` factories for flexible transaction boundaries
- Nested transaction support (delegates to ORM's SAVEPOINT mechanism)

## Test plan

- [x] Unit tests for DatabaseService (lifecycle, client getter, withTransaction, nested transactions, shutdown)
- [x] Unit tests for @Transaction() decorator
- [x] Unit tests for TransactionMiddleware
- [x] All 14 tests passing
- [x] TypeScript type checking passes
- [x] Build successful