### PR TITLE
refactor(core): unify inject and injectConfig with leaf category mechanism

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -189,6 +189,17 @@ export default tseslint.config(
     rules: {
       '@9wick/strict-type-rules/no-in-operator': 'off',
       '@9wick/strict-type-rules/no-as-assertion': 'off',
+      '@9wick/strict-type-rules/no-import-rename': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+    },
+  },
+  {
+    // Leaf mechanism: prototype chain traversal and type assertions for DI category resolution.
+    files: ['packages/core/src/di/leaf.ts', 'packages/core/src/di/inject.ts'],
+    rules: {
+      '@9wick/strict-type-rules/no-as-assertion': 'off',
+      '@9wick/strict-type-rules/no-import-rename': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
   {

--- a/packages/core/src/config/decorator.ts
+++ b/packages/core/src/config/decorator.ts
@@ -1,10 +1,10 @@
 import { injectable } from '@needle-di/core';
 
-import { registerConfigClass } from './token';
+import { registerAsLeaf } from '../di/leaf';
 
 type AnyConstructor = new (...args: never[]) => unknown;
 
 export const Config = (target: AnyConstructor): void => {
-  registerConfigClass(target);
+  registerAsLeaf(target);
   injectable()(target);
 };

--- a/packages/core/src/config/token.ts
+++ b/packages/core/src/config/token.ts
@@ -1,115 +1,33 @@
 import type { Container as ContainerType } from '@needle-di/core';
-import { Container, InjectionToken, inject } from '@needle-di/core';
+import { inject } from '../di/inject';
+import { getLeaf, overrideLeaf, registerAsLeaf, resolveLeaf } from '../di/leaf';
 
 import type { ConfigClass } from './types';
 
-type AnyConfigInstance = ConfigClass<object>;
 type AnyConfigClass = new (...args: never[]) => unknown;
 
-declare const rootConfigBrand: unique symbol;
-type RootConfigClass = ConfigClass<object> & { [rootConfigBrand]: unknown };
-
-type ConfigInjectionToken = InjectionToken<AnyConfigInstance>;
-
-const registeredConfigs = new WeakSet<AnyConfigClass>();
-const configClassMap = new WeakMap<RootConfigClass, ConfigInjectionToken>();
-// needle-di Container lacks a has() API, so we track bound tokens ourselves
-const boundTokens = new WeakMap<ContainerType, Set<ConfigInjectionToken>>();
-
-export const registerConfigClass = (cls: AnyConfigClass): void => {
-  registeredConfigs.add(cls);
-};
-
-const findRootConfigClass = (cls: AnyConfigClass): RootConfigClass => {
-  let current: AnyConfigClass | null = cls;
-  let root: AnyConfigClass | null = cls;
-
-  while (current && current !== Function.prototype) {
-    if (registeredConfigs.has(current)) {
-      root = current;
-    }
-    current = Object.getPrototypeOf(current) as AnyConfigClass | null;
-  }
-
-  return root as RootConfigClass;
-};
-
-const getConfigToken = (rootConfig: RootConfigClass): ConfigInjectionToken => {
-  const existing = configClassMap.get(rootConfig);
-  if (existing) return existing;
-  const token = new InjectionToken<AnyConfigInstance>(rootConfig.name);
-  configClassMap.set(rootConfig, token);
-  return token;
-};
-
-const isTokenBound = (container: ContainerType, token: ConfigInjectionToken): boolean =>
-  boundTokens.get(container)?.has(token) ?? false;
-
-const markTokenBound = (container: ContainerType, token: ConfigInjectionToken): void => {
-  const existing = boundTokens.get(container);
-  if (existing) {
-    existing.add(token);
-    return;
-  }
-  boundTokens.set(container, new Set([token]));
-};
-
-const bindConfig = (
-  container: ContainerType,
-  token: ConfigInjectionToken,
-  cls: AnyConfigClass,
-): void => {
-  const singleToken = new InjectionToken<AnyConfigInstance>(`${cls.name}:single`);
-  container.bind({
-    provide: singleToken,
-    useFactory: () => new (cls as new () => AnyConfigInstance)(),
-  });
-  container.bind({ provide: token, useExisting: singleToken });
-  markTokenBound(container, token);
-};
+export { registerAsLeaf as registerConfigClass };
 
 export const overrideConfig = (
   container: ContainerType,
   config: AnyConfigClass,
   options?: { readonly fallback?: boolean },
 ): void => {
-  const rootClass = findRootConfigClass(config);
-  const token = getConfigToken(rootClass);
-
-  if (options?.fallback && isTokenBound(container, token)) return;
-
-  if (!isTokenBound(container, token)) {
-    bindConfig(container, token, rootClass as unknown as AnyConfigClass);
-  }
-
-  // child overrides root via later bind (last-wins semantics in needle-di)
-  if ((config as unknown) !== (rootClass as unknown)) {
-    bindConfig(container, token, config);
-  }
+  overrideLeaf(container, config, options);
 };
 
 export const resolveConfig = (container: ContainerType, config: AnyConfigClass): void => {
-  const rootClass = findRootConfigClass(config);
-  const token = getConfigToken(rootClass);
-  container.get(token);
-};
-
-const ensureBound = (
-  container: ContainerType,
-  configClass: AnyConfigClass,
-): ConfigInjectionToken => {
-  const rootClass = findRootConfigClass(configClass);
-  const token = getConfigToken(rootClass);
-  if (!isTokenBound(container, token)) {
-    bindConfig(container, token, rootClass as unknown as AnyConfigClass);
-  }
-  return token;
+  resolveLeaf(container, config);
 };
 
 export const getConfig = <T extends object>(
   container: ContainerType,
   configClass: ConfigClass<T>,
-): T => container.get(ensureBound(container, configClass as AnyConfigClass)) as T;
+): T => getLeaf(container, configClass);
 
+/**
+ * @deprecated Use `inject(ConfigClass)` instead.
+ * The unified `inject` now handles leaf resolution automatically for @Config classes.
+ */
 export const injectConfig = <T extends object>(configClass: ConfigClass<T>): T =>
-  inject(ensureBound(inject(Container), configClass as AnyConfigClass)) as T;
+  inject(configClass);

--- a/packages/core/src/di/inject.test.ts
+++ b/packages/core/src/di/inject.test.ts
@@ -1,7 +1,8 @@
-import { Container, injectable } from '@needle-di/core';
+import { Container, InjectionToken, injectable } from '@needle-di/core';
 import { describe, expect, it } from 'vitest';
 
 import { inject } from './inject';
+import { overrideLeaf, registerAsLeaf } from './leaf';
 
 @injectable()
 class Service {
@@ -18,7 +19,7 @@ class Consumer {
   }
 }
 
-describe('inject (re-export)', () => {
+describe('inject (unified)', () => {
   it('resolves a constructor default through container.get', () => {
     const container = new Container();
     container.bind(Service);
@@ -34,7 +35,6 @@ describe('inject (re-export)', () => {
   });
 
   it('throws when token is not bound', () => {
-    // 非 @injectable() class は needle-di の auto-bind 対象外なので、bind しなければ確実に throw する
     class NotBound {}
 
     @injectable()
@@ -42,7 +42,73 @@ describe('inject (re-export)', () => {
       constructor(public dep = inject(NotBound)) {}
     }
     const container = new Container();
-    container.bind(Orphan); // NotBound は bind しない
+    container.bind(Orphan);
     expect(() => container.get(Orphan)).toThrow();
+  });
+
+  describe('leaf class resolution', () => {
+    it('inject(@leaf class) resolves via leaf mechanism', () => {
+      @injectable()
+      class BaseConfig {
+        get value() {
+          return 'base';
+        }
+      }
+      registerAsLeaf(BaseConfig);
+
+      @injectable()
+      class ChildConfig extends BaseConfig {
+        override get value() {
+          return 'child';
+        }
+      }
+      registerAsLeaf(ChildConfig);
+
+      @injectable()
+      class ServiceUsingConfig {
+        constructor(public config = inject(BaseConfig)) {}
+      }
+
+      const container = new Container();
+      overrideLeaf(container, ChildConfig);
+      container.bind(ServiceUsingConfig);
+
+      expect(container.get(ServiceUsingConfig).config.value).toBe('child');
+    });
+
+    it('inject(regular class) delegates to needle-di', () => {
+      @injectable()
+      class RegularService {
+        get name() {
+          return 'regular';
+        }
+      }
+
+      @injectable()
+      class RegularConsumer {
+        constructor(public svc = inject(RegularService)) {}
+      }
+
+      const container = new Container();
+      container.bind(RegularService);
+      container.bind(RegularConsumer);
+
+      expect(container.get(RegularConsumer).svc.name).toBe('regular');
+    });
+
+    it('inject(InjectionToken) delegates to needle-di', () => {
+      const TOKEN = new InjectionToken<string>('test-token');
+
+      @injectable()
+      class TokenConsumer {
+        constructor(public value = inject(TOKEN)) {}
+      }
+
+      const container = new Container();
+      container.bind({ provide: TOKEN, useValue: 'token-value' });
+      container.bind(TokenConsumer);
+
+      expect(container.get(TokenConsumer).value).toBe('token-value');
+    });
   });
 });

--- a/packages/core/src/di/inject.ts
+++ b/packages/core/src/di/inject.ts
@@ -1,1 +1,41 @@
-export { inject } from '@needle-di/core';
+import type { inject as InjectFn, InjectionToken, Token } from '@needle-di/core';
+import { inject } from '@needle-di/core';
+
+import { injectLeaf, isLeafClass } from './leaf';
+
+type AnyClass = new (...args: never[]) => unknown;
+
+const isClassToken = <T>(token: Token<T>): boolean =>
+  typeof token === 'function' && token.prototype !== undefined;
+
+const needleInject: typeof InjectFn = inject;
+
+function unifiedInject<T>(token: InjectionToken<T>): T;
+function unifiedInject<T>(token: Token<T>): T;
+function unifiedInject<T>(token: Token<T>, options: { multi: true }): T[];
+function unifiedInject<T>(token: Token<T>, options: { optional: true }): T | undefined;
+function unifiedInject<T>(
+  token: Token<T>,
+  options: { multi: true; optional: true },
+): T[] | undefined;
+function unifiedInject<T>(token: Token<T>, options: { lazy: true }): () => T;
+function unifiedInject<T>(token: Token<T>, options: { lazy: true; multi: true }): () => T[];
+function unifiedInject<T>(
+  token: Token<T>,
+  options: { lazy: true; optional: true },
+): () => T | undefined;
+function unifiedInject<T>(
+  token: Token<T>,
+  options: { lazy: true; multi: true; optional: true },
+): () => T[] | undefined;
+function unifiedInject<T>(
+  token: Token<T>,
+  options?: { multi?: boolean; optional?: boolean; lazy?: boolean },
+): unknown {
+  if (options === undefined && isClassToken(token) && isLeafClass(token as AnyClass)) {
+    return injectLeaf(token as new (...args: never[]) => object);
+  }
+  return needleInject(token, options as never);
+}
+
+export { unifiedInject as inject };

--- a/packages/core/src/di/leaf.test.ts
+++ b/packages/core/src/di/leaf.test.ts
@@ -1,0 +1,220 @@
+import { Container, injectable } from '@needle-di/core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  findRootLeafClass,
+  getLeaf,
+  isLeafClass,
+  overrideLeaf,
+  registerAsLeaf,
+  resolveLeaf,
+} from './leaf';
+
+describe('leaf mechanism', () => {
+  describe('registerAsLeaf / isLeafClass', () => {
+    it('returns false for unregistered class', () => {
+      class NotLeaf {}
+      expect(isLeafClass(NotLeaf)).toBe(false);
+    });
+
+    it('returns true after registerAsLeaf', () => {
+      @injectable()
+      class LeafClass {}
+      registerAsLeaf(LeafClass);
+      expect(isLeafClass(LeafClass)).toBe(true);
+    });
+
+    it('returns true for child of registered class', () => {
+      @injectable()
+      class ParentLeaf {}
+      registerAsLeaf(ParentLeaf);
+
+      @injectable()
+      class ChildLeaf extends ParentLeaf {}
+
+      expect(isLeafClass(ChildLeaf)).toBe(true);
+    });
+
+    it('returns true for grandchild of registered class', () => {
+      @injectable()
+      class GrandparentLeaf {}
+      registerAsLeaf(GrandparentLeaf);
+
+      @injectable()
+      class ParentLeaf extends GrandparentLeaf {}
+
+      @injectable()
+      class GrandchildLeaf extends ParentLeaf {}
+
+      expect(isLeafClass(GrandchildLeaf)).toBe(true);
+    });
+  });
+
+  describe('findRootLeafClass', () => {
+    it('returns self for directly registered class', () => {
+      @injectable()
+      class DirectLeaf {}
+      registerAsLeaf(DirectLeaf);
+
+      expect(findRootLeafClass(DirectLeaf)).toBe(DirectLeaf);
+    });
+
+    it('returns ancestor for inherited leaf', () => {
+      @injectable()
+      class RootLeaf {}
+      registerAsLeaf(RootLeaf);
+
+      @injectable()
+      class ChildLeaf extends RootLeaf {}
+
+      expect(findRootLeafClass(ChildLeaf)).toBe(RootLeaf);
+    });
+
+    it('returns topmost registered ancestor in multi-level hierarchy', () => {
+      @injectable()
+      class TopLeaf {}
+      registerAsLeaf(TopLeaf);
+
+      @injectable()
+      class MiddleLeaf extends TopLeaf {}
+      registerAsLeaf(MiddleLeaf);
+
+      @injectable()
+      class BottomLeaf extends MiddleLeaf {}
+
+      expect(findRootLeafClass(BottomLeaf)).toBe(TopLeaf);
+    });
+  });
+
+  describe('overrideLeaf / getLeaf', () => {
+    it('binds root class on first call', () => {
+      @injectable()
+      class RootConfig {
+        get value() {
+          return 'root';
+        }
+      }
+      registerAsLeaf(RootConfig);
+
+      const container = new Container();
+      overrideLeaf(container, RootConfig);
+
+      expect(getLeaf(container, RootConfig).value).toBe('root');
+    });
+
+    it('binds child class as override', () => {
+      @injectable()
+      class BaseConfig {
+        get value() {
+          return 'base';
+        }
+      }
+      registerAsLeaf(BaseConfig);
+
+      @injectable()
+      class ChildConfig extends BaseConfig {
+        override get value() {
+          return 'child';
+        }
+      }
+      registerAsLeaf(ChildConfig);
+
+      const container = new Container();
+      overrideLeaf(container, ChildConfig);
+
+      expect(getLeaf(container, BaseConfig).value).toBe('child');
+    });
+
+    it('respects fallback option', () => {
+      @injectable()
+      class FallbackConfig {
+        get value() {
+          return 'fallback';
+        }
+      }
+      registerAsLeaf(FallbackConfig);
+
+      @injectable()
+      class UserConfig extends FallbackConfig {
+        override get value() {
+          return 'user';
+        }
+      }
+      registerAsLeaf(UserConfig);
+
+      const container = new Container();
+      overrideLeaf(container, UserConfig);
+      overrideLeaf(container, FallbackConfig, { fallback: true });
+
+      expect(getLeaf(container, FallbackConfig).value).toBe('user');
+    });
+
+    it('last bind wins for multiple overrides', () => {
+      @injectable()
+      class MultiBase {
+        get value() {
+          return 'base';
+        }
+      }
+      registerAsLeaf(MultiBase);
+
+      @injectable()
+      class FirstChild extends MultiBase {
+        override get value() {
+          return 'first';
+        }
+      }
+      registerAsLeaf(FirstChild);
+
+      @injectable()
+      class SecondChild extends MultiBase {
+        override get value() {
+          return 'second';
+        }
+      }
+      registerAsLeaf(SecondChild);
+
+      const container = new Container();
+      overrideLeaf(container, FirstChild);
+      overrideLeaf(container, SecondChild);
+
+      expect(getLeaf(container, MultiBase).value).toBe('second');
+    });
+
+    it('returns singleton per container', () => {
+      @injectable()
+      class SingletonConfig {
+        id = Math.random();
+      }
+      registerAsLeaf(SingletonConfig);
+
+      const container = new Container();
+      overrideLeaf(container, SingletonConfig);
+
+      const first = getLeaf(container, SingletonConfig);
+      const second = getLeaf(container, SingletonConfig);
+      expect(first).toBe(second);
+    });
+  });
+
+  describe('resolveLeaf', () => {
+    it('forces instantiation of leaf class', () => {
+      let instantiated = false;
+
+      @injectable()
+      class SideEffectConfig {
+        constructor() {
+          instantiated = true;
+        }
+      }
+      registerAsLeaf(SideEffectConfig);
+
+      const container = new Container();
+      overrideLeaf(container, SideEffectConfig);
+
+      expect(instantiated).toBe(false);
+      resolveLeaf(container, SideEffectConfig);
+      expect(instantiated).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/di/leaf.ts
+++ b/packages/core/src/di/leaf.ts
@@ -1,0 +1,151 @@
+import type { Container as ContainerType, inject as InjectFn } from '@needle-di/core';
+import { Container, InjectionToken, inject } from '@needle-di/core';
+
+type AnyClass = new (...args: never[]) => unknown;
+type AnyInstance = object;
+
+declare const rootLeafBrand: unique symbol;
+type RootLeafClass = AnyClass & { [rootLeafBrand]: unknown };
+
+type LeafInjectionToken = InjectionToken<AnyInstance>;
+
+const leafClasses = new WeakSet<AnyClass>();
+const leafCategoryCache = new WeakMap<AnyClass, 'direct' | 'inherited'>();
+const leafTokenMap = new WeakMap<RootLeafClass, LeafInjectionToken>();
+const boundTokens = new WeakMap<ContainerType, Set<LeafInjectionToken>>();
+
+const toAnyClass = (proto: unknown): AnyClass | null => {
+  if (proto === null || proto === Function.prototype) return null;
+  const result: AnyClass = proto as AnyClass;
+  return result;
+};
+
+const toRootLeafClass = (cls: AnyClass): RootLeafClass => {
+  const result: RootLeafClass = cls as RootLeafClass;
+  return result;
+};
+
+export const registerAsLeaf = (cls: AnyClass): void => {
+  leafClasses.add(cls);
+  leafCategoryCache.set(cls, 'direct');
+};
+
+export const isLeafClass = (cls: AnyClass): boolean => {
+  const cached = leafCategoryCache.get(cls);
+  if (cached !== undefined) return true;
+
+  if (leafClasses.has(cls)) {
+    leafCategoryCache.set(cls, 'direct');
+    return true;
+  }
+
+  let current = toAnyClass(Object.getPrototypeOf(cls));
+  while (current) {
+    if (leafClasses.has(current)) {
+      leafCategoryCache.set(cls, 'inherited');
+      return true;
+    }
+    current = toAnyClass(Object.getPrototypeOf(current));
+  }
+
+  return false;
+};
+
+export const findRootLeafClass = (cls: AnyClass): RootLeafClass => {
+  let current: AnyClass | null = cls;
+  let root: AnyClass = cls;
+
+  while (current) {
+    if (leafClasses.has(current)) {
+      root = current;
+    }
+    current = toAnyClass(Object.getPrototypeOf(current));
+  }
+
+  return toRootLeafClass(root);
+};
+
+const getLeafToken = (rootClass: RootLeafClass): LeafInjectionToken => {
+  const existing = leafTokenMap.get(rootClass);
+  if (existing) return existing;
+
+  const token = new InjectionToken<AnyInstance>(rootClass.name);
+  leafTokenMap.set(rootClass, token);
+  return token;
+};
+
+const isTokenBound = (container: ContainerType, token: LeafInjectionToken): boolean =>
+  boundTokens.get(container)?.has(token) ?? false;
+
+const markTokenBound = (container: ContainerType, token: LeafInjectionToken): void => {
+  const existing = boundTokens.get(container);
+  if (existing) {
+    existing.add(token);
+    return;
+  }
+  boundTokens.set(container, new Set([token]));
+};
+
+const bindLeafInternal = (
+  container: ContainerType,
+  token: LeafInjectionToken,
+  cls: AnyClass,
+): void => {
+  const singleToken = new InjectionToken<AnyInstance>(`${cls.name}:single`);
+  const factory = cls as new () => AnyInstance;
+  container.bind({
+    provide: singleToken,
+    useFactory: () => new factory(),
+  });
+  container.bind({ provide: token, useExisting: singleToken });
+  markTokenBound(container, token);
+};
+
+export const overrideLeaf = (
+  container: ContainerType,
+  cls: AnyClass,
+  options?: { readonly fallback?: boolean },
+): void => {
+  const rootClass = findRootLeafClass(cls);
+  const token = getLeafToken(rootClass);
+
+  if (options?.fallback && isTokenBound(container, token)) return;
+
+  if (!isTokenBound(container, token)) {
+    bindLeafInternal(container, token, rootClass);
+  }
+
+  if (cls !== (rootClass as AnyClass)) {
+    bindLeafInternal(container, token, cls);
+  }
+};
+
+export const ensureLeafBound = (container: ContainerType, cls: AnyClass): LeafInjectionToken => {
+  const rootClass = findRootLeafClass(cls);
+  const token = getLeafToken(rootClass);
+
+  if (!isTokenBound(container, token)) {
+    bindLeafInternal(container, token, rootClass);
+  }
+
+  return token;
+};
+
+export const getLeaf = <T extends object>(
+  container: ContainerType,
+  cls: new (...args: never[]) => T,
+): T => container.get(ensureLeafBound(container, cls)) as T;
+
+const needleInject: typeof InjectFn = inject;
+
+export const injectLeaf = <T extends object>(cls: new (...args: never[]) => T): T => {
+  const container: ContainerType = needleInject(Container);
+  const token = ensureLeafBound(container, cls);
+  return needleInject(token) as T;
+};
+
+export const resolveLeaf = (container: ContainerType, cls: AnyClass): void => {
+  const rootClass = findRootLeafClass(cls);
+  const token = getLeafToken(rootClass);
+  container.get(token);
+};


### PR DESCRIPTION
## Summary

- `inject` と `injectConfig` を統一し、leaf カテゴリ機構を導入
- `@Config` クラスは自動的に leaf 解決される（継承階層の末端を返す）
- `injectConfig` は deprecated（次 PR で削除予定）

## Changes

- `di/leaf.ts`: 汎用 leaf カテゴリ機構（internal）
- `di/inject.ts`: `isLeafClass` で自動分岐する統一 inject
- `config/decorator.ts`: `registerAsLeaf` を使用
- `config/token.ts`: leaf 関数へ委譲、`@deprecated` 追加

## Test plan

- [x] 既存テスト（264 tests in core）が通過
- [x] 新規テスト（leaf.test.ts, inject.test.ts 追加分）が通過
- [x] lint / typecheck 通過