### PR TITLE
refactor(adapter-node): rename exec to execCommand

### DIFF
--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -181,7 +181,7 @@ describe('onNode with commands', () => {
     const app = createApp({ commands: [TestCommand] });
     nodeApp = await onNode(app);
 
-    const result = await nodeApp.exec(['test-cmd']);
+    const result = await nodeApp.execCommand(['test-cmd']);
 
     expect(result.exitCode).toBe(0);
     expect(runFn).toHaveBeenCalled();
@@ -198,7 +198,7 @@ describe('onNode with commands', () => {
     const app = createApp({ commands: [ExistingCommand] });
     nodeApp = await onNode(app);
 
-    const result = await nodeApp.exec(['nonexistent']);
+    const result = await nodeApp.execCommand(['nonexistent']);
 
     expect(result.exitCode).toBe(1);
   });
@@ -214,7 +214,7 @@ describe('onNode with commands', () => {
     const app = createApp({ commands: [TestCommand] });
     nodeApp = await onNode(app);
 
-    const result = await nodeApp.exec([]);
+    const result = await nodeApp.execCommand([]);
 
     expect(result.exitCode).toBe(1);
   });
@@ -232,7 +232,7 @@ describe('onNode with commands', () => {
     const app = createApp({ commands: [FailingCommand] });
     nodeApp = await onNode(app);
 
-    const result = await nodeApp.exec(['failing']);
+    const result = await nodeApp.execCommand(['failing']);
 
     expect(result.exitCode).toBe(1);
   });

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -35,7 +35,7 @@ export type HttpNodeApp = ReadyResult &
 
 export type CommandNodeApp = ReadyResult &
   NodeAppBase & {
-    readonly exec: (argv: string[]) => Promise<ExecResult>;
+    readonly execCommand: (argv: string[]) => Promise<ExecResult>;
     readonly shutdown: () => Promise<void>;
   };
 
@@ -158,7 +158,7 @@ const buildCommandNodeApp = (
   return {
     ...resolver,
     args,
-    exec: createExecForCommands(caps.hasCommand, caps.getCommands, resolver.get, stderr),
+    execCommand: createExecForCommands(caps.hasCommand, caps.getCommands, resolver.get, stderr),
     shutdown,
   };
 };
@@ -182,7 +182,7 @@ const mergeNodeApps = (
 ): NodeApp => {
   const { httpResult, commandResult } = result;
   if (httpResult && commandResult) {
-    const fullApp: FullNodeApp = { ...httpResult, exec: commandResult.exec };
+    const fullApp: FullNodeApp = { ...httpResult, execCommand: commandResult.execCommand };
     return fullApp;
   }
   if (httpResult) return httpResult;


### PR DESCRIPTION
## Summary

- Rename `CommandNodeApp.exec()` to `execCommand()` for clearer API naming
- Avoid confusion with other exec-like APIs (e.g., RegExp.exec)

## Test plan

- [x] Unit tests pass (`pnpm test packages/adapter-node/src/on-node.test.ts`)
- [x] Type check passes (`pnpm typecheck`)