### PR TITLE
ci: add knip check to pre-push hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,6 +19,8 @@ pre-rebase:
 
 pre-push:
   commands:
+    knip:
+      run: pnpm knip
     prevent-force-push:
       run: |
         while read local_ref local_sha remote_ref remote_sha; do


### PR DESCRIPTION
## Summary
- Add knip command to lefthook pre-push hook
- Catches unused code before push, reducing CI failure rate
- Shifts knip check left in the workflow without blocking individual commits

## Test plan
- [x] Verified knip runs on `git push`
- [x] Confirmed existing pre-push hooks (prevent-force-push) still work