### PR TITLE
feat: add Bun, Lambda, and Electron runtime adapters

### DIFF
--- a/packages/adapter-bun/package.json
+++ b/packages/adapter-bun/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zeltjs/adapter-bun",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zeltjs/zelt.git",
+    "directory": "packages/adapter-bun"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run",
+    "typecheck": "tsc -b"
+  },
+  "dependencies": {
+    "@zeltjs/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "1.2.17"
+  }
+}

--- a/packages/adapter-bun/src/bun-env.config.ts
+++ b/packages/adapter-bun/src/bun-env.config.ts
@@ -1,0 +1,8 @@
+import { Config, EnvConfig } from '@zeltjs/core';
+
+@Config
+export class BunEnvConfig extends EnvConfig {
+  override get(key: string): string | undefined {
+    return Bun.env[key];
+  }
+}

--- a/packages/adapter-bun/src/index.ts
+++ b/packages/adapter-bun/src/index.ts
@@ -1,0 +1,11 @@
+export { BunEnvConfig } from './bun-env.config';
+export {
+  type BunApp,
+  type BunAppOptions,
+  type CommandBunApp,
+  type ExecResult,
+  type FullBunApp,
+  type HttpBunApp,
+  onBun,
+  type ServerHandle,
+} from './on-bun';

--- a/packages/adapter-bun/src/on-bun.ts
+++ b/packages/adapter-bun/src/on-bun.ts
@@ -1,0 +1,208 @@
+import type { CommandApp, CommandClass, HttpApp, ReadyOptions, ReadyResult } from '@zeltjs/core';
+
+import { BunEnvConfig } from './bun-env.config';
+
+type ServeOptions = {
+  readonly port?: number;
+  readonly hostname?: string;
+};
+
+export type ServerHandle = {
+  readonly address: { port: number; hostname: string };
+  readonly shutdown: () => Promise<void>;
+};
+
+export type BunAppOptions = {
+  readonly warmup?: boolean;
+};
+
+export type ExecResult = {
+  readonly exitCode: 0 | 1;
+};
+
+type BunAppBase = {
+  readonly args: readonly string[];
+};
+
+export type HttpBunApp = ReadyResult &
+  BunAppBase & {
+    readonly serve: (options?: ServeOptions) => ServerHandle;
+    readonly shutdown: () => Promise<void>;
+  };
+
+export type CommandBunApp = ReadyResult &
+  BunAppBase & {
+    readonly execCommand: (argv: string[]) => Promise<ExecResult>;
+    readonly shutdown: () => Promise<void>;
+  };
+
+export type FullBunApp = HttpBunApp & CommandBunApp;
+
+export type BunApp = HttpBunApp | CommandBunApp | FullBunApp;
+
+type Stderr = { write: (s: string) => void };
+
+const successResult: ExecResult = { exitCode: 0 };
+const failureResult: ExecResult = { exitCode: 1 };
+
+const createServeForHttp = (
+  appFetch: (request: Request) => Promise<Response>,
+  appShutdown: () => Promise<void>,
+): ((options?: ServeOptions) => ServerHandle) => {
+  return (options?: ServeOptions): ServerHandle => {
+    const port = options?.port ?? 3000;
+    const hostname = options?.hostname ?? '0.0.0.0';
+
+    const server = Bun.serve({
+      fetch: appFetch,
+      port,
+      hostname,
+    });
+
+    const shutdown = async (): Promise<void> => {
+      await server.stop();
+      await appShutdown();
+    };
+
+    return {
+      address: { port: server.port ?? port, hostname: server.hostname ?? hostname },
+      shutdown,
+    };
+  };
+};
+
+const runCommand = (
+  CommandClass: CommandClass,
+  get: <T extends object>(cls: new (...args: never[]) => T) => T,
+): Promise<ExecResult> => {
+  const instance = get(CommandClass);
+  return Promise.resolve()
+    .then(() => instance.run())
+    .then(() => successResult)
+    .catch(() => failureResult);
+};
+
+const createExecForCommands = (
+  hasCommand: (name: string) => boolean,
+  getCommands: () => ReadonlyMap<string, CommandClass>,
+  get: <T extends object>(cls: new (...args: never[]) => T) => T,
+  stderr: Stderr,
+): ((argv: string[]) => Promise<ExecResult>) => {
+  return async (argv: string[]): Promise<ExecResult> => {
+    const commandName = argv[0];
+    if (!commandName) {
+      stderr.write('No command specified\n');
+      return failureResult;
+    }
+
+    if (!hasCommand(commandName)) {
+      stderr.write(`Command not found: ${commandName}\n`);
+      return failureResult;
+    }
+
+    const commandMap = getCommands();
+    const CommandClass = commandMap.get(commandName);
+    if (!CommandClass) {
+      return failureResult;
+    }
+
+    return runCommand(CommandClass, get);
+  };
+};
+
+const getStderr = (): Stderr => globalThis.process.stderr;
+
+const getArgs = (): readonly string[] => Bun.argv.slice(2);
+
+type AppCapabilities = {
+  fetch?: (request: Request) => Promise<Response>;
+  hasCommand?: (name: string) => boolean;
+  getCommands?: () => ReadonlyMap<string, CommandClass>;
+};
+
+const extractCapabilities = (app: HttpApp | CommandApp | (HttpApp & CommandApp)): AppCapabilities =>
+  app;
+
+type BuildResult = {
+  httpResult: HttpBunApp | undefined;
+  commandResult: CommandBunApp | undefined;
+};
+
+const buildHttpBunApp = (
+  caps: AppCapabilities,
+  resolver: ReadyResult,
+  shutdown: () => Promise<void>,
+  args: readonly string[],
+): HttpBunApp | undefined => {
+  if (typeof caps.fetch !== 'function') return undefined;
+  return { ...resolver, args, serve: createServeForHttp(caps.fetch, shutdown), shutdown };
+};
+
+const buildCommandBunApp = (
+  caps: AppCapabilities,
+  resolver: ReadyResult,
+  shutdown: () => Promise<void>,
+  stderr: Stderr,
+  args: readonly string[],
+): CommandBunApp | undefined => {
+  if (typeof caps.hasCommand !== 'function' || typeof caps.getCommands !== 'function')
+    return undefined;
+  return {
+    ...resolver,
+    args,
+    execCommand: createExecForCommands(caps.hasCommand, caps.getCommands, resolver.get, stderr),
+    shutdown,
+  };
+};
+
+const buildBunApps = (
+  caps: AppCapabilities,
+  resolver: ReadyResult,
+  shutdown: () => Promise<void>,
+  stderr: Stderr,
+  args: readonly string[],
+): BuildResult => ({
+  httpResult: buildHttpBunApp(caps, resolver, shutdown, args),
+  commandResult: buildCommandBunApp(caps, resolver, shutdown, stderr, args),
+});
+
+const mergeBunApps = (
+  result: BuildResult,
+  resolver: ReadyResult,
+  shutdown: () => Promise<void>,
+  args: readonly string[],
+): BunApp => {
+  const { httpResult, commandResult } = result;
+  if (httpResult && commandResult) {
+    const fullApp: FullBunApp = { ...httpResult, execCommand: commandResult.execCommand };
+    return fullApp;
+  }
+  if (httpResult) return httpResult;
+  if (commandResult) return commandResult;
+  return {
+    ...resolver,
+    args,
+    shutdown,
+    serve: () => ({ address: { port: 0, hostname: '' }, shutdown }),
+  };
+};
+
+export function onBun(app: HttpApp & CommandApp, options?: BunAppOptions): Promise<FullBunApp>;
+export function onBun(app: HttpApp, options?: BunAppOptions): Promise<HttpBunApp>;
+export function onBun(app: CommandApp, options?: BunAppOptions): Promise<CommandBunApp>;
+export async function onBun(
+  app: HttpApp | CommandApp | (HttpApp & CommandApp),
+  options: BunAppOptions = {},
+): Promise<BunApp> {
+  app.addFallbackConfig(BunEnvConfig);
+
+  const readyOptions: ReadyOptions = { warmup: options.warmup ?? true };
+  const resolver = await app.ready(readyOptions);
+
+  const caps = extractCapabilities(app);
+  const stderr = getStderr();
+  const args = getArgs();
+  const result = buildBunApps(caps, resolver, app.shutdown, stderr, args);
+
+  return mergeBunApps(result, resolver, app.shutdown, args);
+}

--- a/packages/adapter-bun/tsconfig.json
+++ b/packages/adapter-bun/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@9wick/eslint-plugin-strict-type-rules/tsconfig/strictest.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "erasableSyntaxOnly": false,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/adapter-bun/tsdown.config.ts
+++ b/packages/adapter-bun/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  fixedExtension: false,
+  deps: {
+    neverBundle: [/^@zeltjs\//],
+  },
+});

--- a/packages/adapter-bun/vitest.config.ts
+++ b/packages/adapter-bun/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({});

--- a/packages/adapter-electron/package.json
+++ b/packages/adapter-electron/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@zeltjs/adapter-electron",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zeltjs/zelt.git",
+    "directory": "packages/adapter-electron"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run",
+    "typecheck": "tsc -b"
+  },
+  "dependencies": {
+    "@zeltjs/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.17"
+  },
+  "peerDependencies": {
+    "electron": ">=28.0.0"
+  },
+  "peerDependenciesMeta": {
+    "electron": {
+      "optional": true
+    }
+  }
+}

--- a/packages/adapter-electron/src/electron-env.config.ts
+++ b/packages/adapter-electron/src/electron-env.config.ts
@@ -1,0 +1,8 @@
+import { Config, EnvConfig } from '@zeltjs/core';
+
+@Config
+export class ElectronEnvConfig extends EnvConfig {
+  override get(key: string): string | undefined {
+    return process.env[key];
+  }
+}

--- a/packages/adapter-electron/src/index.ts
+++ b/packages/adapter-electron/src/index.ts
@@ -1,0 +1,2 @@
+export { ElectronEnvConfig } from './electron-env.config';
+export { type ElectronApp, type ElectronAppOptions, onElectron } from './on-electron';

--- a/packages/adapter-electron/src/on-electron.ts
+++ b/packages/adapter-electron/src/on-electron.ts
@@ -1,0 +1,28 @@
+import type { HttpApp, ReadyOptions, ReadyResult } from '@zeltjs/core';
+
+import { ElectronEnvConfig } from './electron-env.config';
+
+export type ElectronAppOptions = {
+  readonly warmup?: boolean;
+};
+
+export type ElectronApp = ReadyResult & {
+  readonly fetch: (request: Request) => Promise<Response>;
+  readonly shutdown: () => Promise<void>;
+};
+
+export const onElectron = async (
+  app: HttpApp,
+  options: ElectronAppOptions = {},
+): Promise<ElectronApp> => {
+  app.addFallbackConfig(ElectronEnvConfig);
+
+  const readyOptions: ReadyOptions = { warmup: options.warmup ?? true };
+  const resolver = await app.ready(readyOptions);
+
+  return {
+    ...resolver,
+    fetch: app.fetch,
+    shutdown: app.shutdown,
+  };
+};

--- a/packages/adapter-electron/tsconfig.json
+++ b/packages/adapter-electron/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@9wick/eslint-plugin-strict-type-rules/tsconfig/strictest.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "erasableSyntaxOnly": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/adapter-electron/tsdown.config.ts
+++ b/packages/adapter-electron/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  fixedExtension: false,
+  deps: {
+    neverBundle: [/^@zeltjs\//, 'electron'],
+  },
+});

--- a/packages/adapter-electron/vitest.config.ts
+++ b/packages/adapter-electron/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({});

--- a/packages/adapter-lambda/package.json
+++ b/packages/adapter-lambda/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@zeltjs/adapter-lambda",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zeltjs/zelt.git",
+    "directory": "packages/adapter-lambda"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run",
+    "typecheck": "tsc -b"
+  },
+  "dependencies": {
+    "@zeltjs/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "8.10.150",
+    "@types/node": "22.19.17"
+  }
+}

--- a/packages/adapter-lambda/src/index.ts
+++ b/packages/adapter-lambda/src/index.ts
@@ -1,0 +1,8 @@
+export { LambdaEnvConfig } from './lambda-env.config';
+export {
+  type LambdaApp,
+  type LambdaAppOptions,
+  type LambdaHandlerV1,
+  type LambdaHandlerV2,
+  onLambda,
+} from './on-lambda';

--- a/packages/adapter-lambda/src/lambda-env.config.ts
+++ b/packages/adapter-lambda/src/lambda-env.config.ts
@@ -1,0 +1,8 @@
+import { Config, EnvConfig } from '@zeltjs/core';
+
+@Config
+export class LambdaEnvConfig extends EnvConfig {
+  override get(key: string): string | undefined {
+    return process.env[key];
+  }
+}

--- a/packages/adapter-lambda/src/on-lambda.ts
+++ b/packages/adapter-lambda/src/on-lambda.ts
@@ -1,0 +1,201 @@
+import type { HttpApp, ReadyOptions, ReadyResult } from '@zeltjs/core';
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResult,
+  APIGatewayProxyResultV2,
+  Context,
+} from 'aws-lambda';
+
+import { LambdaEnvConfig } from './lambda-env.config';
+
+export type LambdaAppOptions = {
+  readonly warmup?: boolean;
+};
+
+export type LambdaHandlerV2 = (
+  event: APIGatewayProxyEventV2,
+  context: Context,
+) => Promise<APIGatewayProxyResultV2>;
+
+export type LambdaHandlerV1 = (
+  event: APIGatewayProxyEvent,
+  context: Context,
+) => Promise<APIGatewayProxyResult>;
+
+export type LambdaApp = ReadyResult & {
+  readonly handler: LambdaHandlerV2;
+  readonly handlerV1: LambdaHandlerV1;
+  readonly shutdown: () => Promise<void>;
+};
+
+const buildHeadersFromRecord = (
+  headersRecord: Record<string, string | undefined> | undefined,
+): Headers => {
+  const headers = new Headers();
+  if (headersRecord) {
+    for (const [key, value] of Object.entries(headersRecord)) {
+      if (value) headers.set(key, value);
+    }
+  }
+  return headers;
+};
+
+const buildBodyFromEvent = (
+  body: string | null | undefined,
+  isBase64Encoded: boolean,
+): BodyInit | null => {
+  if (!body) return null;
+  if (isBase64Encoded) {
+    const buffer = Buffer.from(body, 'base64');
+    return new Blob([buffer]);
+  }
+  return body;
+};
+
+const buildRequestBody = (method: string, body: BodyInit | null): BodyInit | null => {
+  return method !== 'GET' && method !== 'HEAD' ? body : null;
+};
+
+const buildRequestFromEventV2 = (event: APIGatewayProxyEventV2): Request => {
+  const headers = buildHeadersFromRecord(event.headers);
+
+  const protocol = headers.get('x-forwarded-proto') ?? 'https';
+  const host = event.requestContext.domainName;
+  const path = event.rawPath;
+  const queryString = event.rawQueryString ? `?${event.rawQueryString}` : '';
+  const url = `${protocol}://${host}${path}${queryString}`;
+
+  const method = event.requestContext.http.method;
+  const body = buildBodyFromEvent(event.body, event.isBase64Encoded);
+  const requestBody = buildRequestBody(method, body);
+
+  return new Request(url, {
+    method,
+    headers,
+    body: requestBody,
+  });
+};
+
+const buildQueryStringFromParams = (
+  queryParams: Record<string, string | undefined> | null | undefined,
+): string => {
+  if (!queryParams) return '';
+  const params: Record<string, string> = {};
+  for (const [key, value] of Object.entries(queryParams)) {
+    if (value !== undefined) {
+      params[key] = value;
+    }
+  }
+  return `?${new URLSearchParams(params).toString()}`;
+};
+
+const buildRequestFromEventV1 = (event: APIGatewayProxyEvent): Request => {
+  const headers = buildHeadersFromRecord(event.headers);
+
+  const protocol = headers.get('x-forwarded-proto') ?? 'https';
+  const host = headers.get('host') ?? 'localhost';
+  const path = event.path;
+
+  const queryString = buildQueryStringFromParams(event.queryStringParameters);
+  const url = `${protocol}://${host}${path}${queryString}`;
+
+  const method = event.httpMethod;
+  const body = buildBodyFromEvent(event.body, event.isBase64Encoded);
+  const requestBody = buildRequestBody(method, body);
+
+  return new Request(url, {
+    method,
+    headers,
+    body: requestBody,
+  });
+};
+
+const buildResultFromResponseV2 = async (response: Response): Promise<APIGatewayProxyResultV2> => {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  const contentType = response.headers.get('content-type') ?? '';
+  const isBinary =
+    contentType.startsWith('image/') ||
+    contentType.startsWith('audio/') ||
+    contentType.startsWith('video/') ||
+    contentType === 'application/octet-stream';
+
+  const body = isBinary
+    ? Buffer.from(await response.arrayBuffer()).toString('base64')
+    : await response.text();
+
+  return {
+    statusCode: response.status,
+    headers,
+    body,
+    isBase64Encoded: isBinary,
+  };
+};
+
+const buildResultFromResponseV1 = async (response: Response): Promise<APIGatewayProxyResult> => {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  const contentType = response.headers.get('content-type') ?? '';
+  const isBinary =
+    contentType.startsWith('image/') ||
+    contentType.startsWith('audio/') ||
+    contentType.startsWith('video/') ||
+    contentType === 'application/octet-stream';
+
+  const body = isBinary
+    ? Buffer.from(await response.arrayBuffer()).toString('base64')
+    : await response.text();
+
+  return {
+    statusCode: response.status,
+    headers,
+    body,
+    isBase64Encoded: isBinary,
+  };
+};
+
+const createHandlerV2 = (appFetch: (request: Request) => Promise<Response>): LambdaHandlerV2 => {
+  return async (
+    event: APIGatewayProxyEventV2,
+    _context: Context,
+  ): Promise<APIGatewayProxyResultV2> => {
+    const request = buildRequestFromEventV2(event);
+    const response = await appFetch(request);
+    return buildResultFromResponseV2(response);
+  };
+};
+
+const createHandlerV1 = (appFetch: (request: Request) => Promise<Response>): LambdaHandlerV1 => {
+  return async (event: APIGatewayProxyEvent, _context: Context): Promise<APIGatewayProxyResult> => {
+    const request = buildRequestFromEventV1(event);
+    const response = await appFetch(request);
+    return buildResultFromResponseV1(response);
+  };
+};
+
+export const onLambda = async (
+  app: HttpApp,
+  options: LambdaAppOptions = {},
+): Promise<LambdaApp> => {
+  app.addFallbackConfig(LambdaEnvConfig);
+
+  const readyOptions: ReadyOptions = { warmup: options.warmup ?? false };
+  const resolver = await app.ready(readyOptions);
+
+  const handler = createHandlerV2(app.fetch);
+  const handlerV1 = createHandlerV1(app.fetch);
+
+  return {
+    ...resolver,
+    handler,
+    handlerV1,
+    shutdown: app.shutdown,
+  };
+};

--- a/packages/adapter-lambda/tsconfig.json
+++ b/packages/adapter-lambda/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@9wick/eslint-plugin-strict-type-rules/tsconfig/strictest.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "erasableSyntaxOnly": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/adapter-lambda/tsdown.config.ts
+++ b/packages/adapter-lambda/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  fixedExtension: false,
+  deps: {
+    neverBundle: [/^@zeltjs\//],
+  },
+});

--- a/packages/adapter-lambda/vitest.config.ts
+++ b/packages/adapter-lambda/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 1.5.9(@swc/core@1.15.33)
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/drizzle-todo:
     dependencies:
@@ -91,7 +91,7 @@ importers:
         version: 12.9.0
       drizzle-orm:
         specifier: 0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260506.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.2.14)
+        version: 0.45.2(@cloudflare/workers-types@4.20260506.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.2.17)
       valibot:
         specifier: 1.3.1
         version: 1.3.1(typescript@6.0.2)
@@ -159,6 +159,16 @@ importers:
         specifier: 4.88.0
         version: 4.88.0(@cloudflare/workers-types@4.20260506.1)
 
+  packages/adapter-bun:
+    dependencies:
+      '@zeltjs/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/bun':
+        specifier: 1.2.17
+        version: 1.2.17
+
   packages/adapter-cloudflare-workers:
     dependencies:
       '@zeltjs/core':
@@ -168,6 +178,32 @@ importers:
       '@cloudflare/workers-types':
         specifier: 4.20250523.0
         version: 4.20250523.0
+
+  packages/adapter-electron:
+    dependencies:
+      '@zeltjs/core':
+        specifier: workspace:*
+        version: link:../core
+      electron:
+        specifier: '>=28.0.0'
+        version: 42.0.1
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.17
+        version: 22.19.17
+
+  packages/adapter-lambda:
+    dependencies:
+      '@zeltjs/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: 8.10.150
+        version: 8.10.150
+      '@types/node':
+        specifier: 22.19.17
+        version: 22.19.17
 
   packages/adapter-node:
     dependencies:
@@ -2065,6 +2101,10 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@electron/get@5.0.0':
+    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
+    engines: {node: '>=22.12.0'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -4570,6 +4610,9 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
+  '@types/aws-lambda@8.10.150':
+    resolution: {integrity: sha512-AX+AbjH/rH5ezX1fbK8onC/a+HyQHo7QGmvoxAE42n22OsciAxvZoZNEr22tbXs8WfP1nIsBjKDpgPm3HjOZbA==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -4578,6 +4621,9 @@ packages:
 
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
+
+  '@types/bun@1.2.17':
+    resolution: {integrity: sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -4681,6 +4727,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
@@ -4749,6 +4798,9 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.59.1':
     resolution: {integrity: sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==}
@@ -5408,6 +5460,9 @@ packages:
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
@@ -5431,6 +5486,9 @@ packages:
 
   bun-types@1.2.14:
     resolution: {integrity: sha512-Kuh4Ub28ucMRWeiUUWMHsT9Wcbr4H3kLIO72RZZElSDxSu7vpetRvxIUDUaW6QtaIeixIpm7OXtNnZPf82EzwA==}
+
+  bun-types@1.2.17:
+    resolution: {integrity: sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -6253,6 +6311,11 @@ packages:
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
+  electron@42.0.1:
+    resolution: {integrity: sha512-d8HnycE970DGESe91Nj30eonFBUcAI9EZ1TwUGJVzSAnJZdh0BkFEinAXjdklvDYst+bVDc8HsksCuqVLrnqdg==}
+    engines: {node: '>= 22.12.0'}
+    hasBin: true
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -6298,6 +6361,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -6604,6 +6671,11 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -6638,6 +6710,9 @@ packages:
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6806,6 +6881,10 @@ packages:
 
   get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -8384,6 +8463,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -8866,6 +8948,10 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -9604,6 +9690,10 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
+  sumchecker@3.0.1:
+    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+    engines: {node: '>= 8.0'}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -9940,6 +10030,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
@@ -10413,6 +10506,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -12730,6 +12826,19 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@electron/get@5.0.0':
+    dependencies:
+      debug: 4.4.3
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
+      progress: 2.0.3
+      semver: 7.7.4
+      sumchecker: 3.0.1
+    optionalDependencies:
+      undici: 7.24.8
+    transitivePeerDependencies:
+      - supports-color
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -14622,6 +14731,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@types/aws-lambda@8.10.150': {}
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.17
@@ -14634,6 +14745,10 @@ snapshots:
   '@types/bonjour@3.5.13':
     dependencies:
       '@types/node': 22.19.17
+
+  '@types/bun@1.2.17':
+    dependencies:
+      bun-types: 1.2.17
 
   '@types/chai@5.2.3':
     dependencies:
@@ -14754,6 +14869,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.12.4':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/prismjs@1.26.6': {}
 
   '@types/qs@6.15.0': {}
@@ -14838,6 +14957,11 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.19.17
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
@@ -15025,6 +15149,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -15592,6 +15724,8 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  buffer-crc32@0.2.13: {}
+
   buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
@@ -15612,6 +15746,10 @@ snapshots:
   builtin-modules@3.3.0: {}
 
   bun-types@1.2.14:
+    dependencies:
+      '@types/node': 22.19.17
+
+  bun-types@1.2.17:
     dependencies:
       '@types/node': 22.19.17
 
@@ -16333,12 +16471,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260506.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.2.14):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260506.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.2.17):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260506.1
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.9.0
-      bun-types: 1.2.14
+      bun-types: 1.2.17
 
   dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
     optionalDependencies:
@@ -16357,6 +16495,14 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.349: {}
+
+  electron@42.0.1:
+    dependencies:
+      '@electron/get': 5.0.0
+      '@types/node': 24.12.4
+      extract-zip: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   emoji-regex@8.0.0: {}
 
@@ -16390,6 +16536,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  env-paths@3.0.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -16937,6 +17085,16 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -16974,6 +17132,10 @@ snapshots:
   fd-package-json@2.0.0:
     dependencies:
       walk-up-path: 4.0.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -17139,6 +17301,10 @@ snapshots:
     dependencies:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
 
   get-stream@6.0.1: {}
 
@@ -19155,6 +19321,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pend@1.2.0: {}
+
   perfect-debounce@1.0.0: {}
 
   picocolors@1.1.1: {}
@@ -19686,6 +19854,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
+
+  progress@2.0.3: {}
 
   prompts@2.4.2:
     dependencies:
@@ -20654,6 +20824,12 @@ snapshots:
       postcss: 8.5.13
       postcss-selector-parser: 6.1.2
 
+  sumchecker@3.0.1:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   supports-color@10.2.2: {}
 
   supports-color@7.2.0:
@@ -21020,6 +21196,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.16.0: {}
+
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
@@ -21227,6 +21405,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
+  vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.4
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.2
+      tsx: 4.21.0
+      yaml: 2.8.3
+
   vitest@4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
@@ -21251,6 +21445,34 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.4
       '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
     transitivePeerDependencies:
       - msw
@@ -21540,6 +21762,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- Add `@zeltjs/adapter-bun` for native Bun.serve() integration
- Add `@zeltjs/adapter-lambda` for AWS API Gateway v1/v2 handler support
- Add `@zeltjs/adapter-electron` for Electron main process integration

## Details

Each adapter follows the existing pattern (adapter-node, adapter-cloudflare-workers):
- Provides runtime-specific `EnvConfig` implementation
- Exports main entry function (`onBun`, `onLambda`, `onElectron`)

### Usage

```typescript
// Bun
import { onBun } from '@zeltjs/adapter-bun';
const app = await onBun(myApp);
app.serve({ port: 3000 });

// Lambda
import { onLambda } from '@zeltjs/adapter-lambda';
const app = await onLambda(myApp);
export const handler = app.handler; // API Gateway v2

// Electron (main process)
import { onElectron } from '@zeltjs/adapter-electron';
const app = await onElectron(myApp);
```

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] Build succeeds