### PR TITLE
fix: use setup_commands for codepolicy cache copy

### DIFF
--- a/.gwq.toml
+++ b/.gwq.toml
@@ -1,4 +1,7 @@
 [[repository_settings]]
 repository = '.'
-copy_files = ['lefthook-local.yml', '.codepolicy/cache']
-setup_commands = ['pnpm i']
+copy_files = ['lefthook-local.yml']
+setup_commands = [
+  'cp -r "$(git worktree list --porcelain | grep -m1 "^worktree " | cut -d" " -f2-)/.codepolicy/cache" .codepolicy/ 2>/dev/null || true',
+  'pnpm i',
+]


### PR DESCRIPTION
## Summary

gwqの`copy_files`はディレクトリコピーをサポートしていないため、`setup_commands`でキャッシュディレクトリをコピーするように修正。

## Changes

- `.codepolicy/cache`を`copy_files`から削除
- `setup_commands`にgit worktreeのrootからキャッシュをコピーするコマンドを追加