### PR TITLE
feat(di): add transient pattern for per-call instance creation

### DIFF
--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -248,6 +248,37 @@ describe('onNode with commands', () => {
   });
 });
 
+describe('command transient behavior', () => {
+  it('creates new command instance for each execCommand call', async () => {
+    const instanceIds: number[] = [];
+
+    @Command({ name: 'track' })
+    class TrackCommand {
+      static schema = cliSchema({});
+      private id = Math.random();
+
+      run() {
+        instanceIds.push(this.id);
+      }
+    }
+
+    const app = createApp({
+      commands: [TrackCommand],
+    });
+
+    const nodeApp = await onNode(app);
+
+    await nodeApp.execCommand(['track']);
+    await nodeApp.execCommand(['track']);
+    await nodeApp.execCommand(['track']);
+
+    await nodeApp.shutdown();
+
+    expect(instanceIds).toHaveLength(3);
+    expect(new Set(instanceIds).size).toBe(3); // All different IDs
+  });
+});
+
 describe('onNode with schedulers', () => {
   let nodeApp: (HttpNodeApp & SchedulerNodeAppPart) | undefined;
 

--- a/packages/core/src/command/decorator.ts
+++ b/packages/core/src/command/decorator.ts
@@ -1,5 +1,6 @@
 import { injectable } from '@needle-di/core';
 
+import { registerAsTransient } from '../di/transient';
 import { resolveClassArgs } from '../internal/decorator-context';
 
 import type { CommandMetadata } from './metadata';
@@ -18,5 +19,6 @@ export const Command =
       ? { name: options.name, description: options.description }
       : { name: options.name };
     setCommandMetadata(cls, meta);
+    registerAsTransient(injectableClass);
     injectable()(injectableClass);
   };

--- a/packages/core/src/di/container.ts
+++ b/packages/core/src/di/container.ts
@@ -2,6 +2,7 @@ import { Container } from '@needle-di/core';
 import type { ConfigClass } from '../config';
 import { getConfig, overrideConfig, resolveConfig } from '../config';
 import { LifecycleManager } from '../lifecycle';
+import { resolve } from './resolve';
 
 type Class<T> = new (...args: never[]) => T;
 
@@ -42,7 +43,7 @@ export const createContainer = (options: CreateContainerOptions = {}): ResolverH
   resolveConfigs(container, configs);
   resolveConfigs(container, overrides);
   return {
-    get: <T extends object>(cls: Class<T>): T => container.get<T>(cls),
+    get: <T extends object>(cls: Class<T>): T => resolve(container, cls),
     getConfig: <T extends object>(configClass: ConfigClass<T>): T =>
       getConfig(container, configClass),
   };

--- a/packages/core/src/di/container.ts
+++ b/packages/core/src/di/container.ts
@@ -94,7 +94,7 @@ export const createTestTargetBase = async <T extends object>(
     throw error;
   }
 
-  const target = container.get<T>(targetClass);
+  const target = resolve(container, targetClass);
 
   let disposed = false;
   const shutdown = async (): Promise<void> => {
@@ -108,7 +108,7 @@ export const createTestTargetBase = async <T extends object>(
       const name = cls.name || 'unknown';
       throw new Error(`Cannot resolve ${name}: TestTarget has been shut down`);
     }
-    return container.get<U>(cls);
+    return resolve(container, cls);
   };
 
   return { target, get, shutdown };

--- a/packages/core/src/di/inject.test.ts
+++ b/packages/core/src/di/inject.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { inject } from './inject';
 import { overrideLeaf, registerAsLeaf } from './leaf';
+import { registerAsTransient } from './transient';
 
 @injectable()
 class Service {
@@ -110,5 +111,24 @@ describe('inject (unified)', () => {
 
       expect(container.get(TokenConsumer).value).toBe('token-value');
     });
+  });
+});
+
+describe('inject with transient', () => {
+  it('injects transient class as new instance each time', () => {
+    @injectable()
+    class TransientDep {}
+    registerAsTransient(TransientDep);
+
+    @injectable()
+    class Consumer {
+      dep1: TransientDep = inject(TransientDep);
+      dep2: TransientDep = inject(TransientDep);
+    }
+
+    const container = new Container();
+    const consumer = container.get(Consumer);
+
+    expect(consumer.dep1).not.toBe(consumer.dep2);
   });
 });

--- a/packages/core/src/di/inject.ts
+++ b/packages/core/src/di/inject.ts
@@ -1,9 +1,7 @@
 import type { inject as InjectFn, InjectionToken, Token } from '@needle-di/core';
-import { inject } from '@needle-di/core';
+import { Container, inject } from '@needle-di/core';
 
-import { injectLeaf, isLeafClass } from './leaf';
-
-type AnyClass = new (...args: never[]) => unknown;
+import { resolve } from './resolve';
 
 const isClassToken = <T>(token: Token<T>): boolean =>
   typeof token === 'function' && token.prototype !== undefined;
@@ -32,8 +30,9 @@ function unifiedInject<T>(
   token: Token<T>,
   options?: { multi?: boolean; optional?: boolean; lazy?: boolean },
 ): unknown {
-  if (options === undefined && isClassToken(token) && isLeafClass(token as AnyClass)) {
-    return injectLeaf(token as new (...args: never[]) => object);
+  if (options === undefined && isClassToken(token)) {
+    const container = needleInject(Container);
+    return resolve(container, token as new (...args: never[]) => object);
   }
   return needleInject(token, options as never);
 }

--- a/packages/core/src/di/leaf.ts
+++ b/packages/core/src/di/leaf.ts
@@ -1,5 +1,5 @@
-import type { Container as ContainerType, inject as InjectFn } from '@needle-di/core';
-import { Container, InjectionToken, inject } from '@needle-di/core';
+import type { Container as ContainerType } from '@needle-di/core';
+import { InjectionToken } from '@needle-di/core';
 
 type AnyClass = new (...args: never[]) => unknown;
 type AnyInstance = object;
@@ -135,14 +135,6 @@ export const getLeaf = <T extends object>(
   container: ContainerType,
   cls: new (...args: never[]) => T,
 ): T => container.get(ensureLeafBound(container, cls)) as T;
-
-const needleInject: typeof InjectFn = inject;
-
-export const injectLeaf = <T extends object>(cls: new (...args: never[]) => T): T => {
-  const container: ContainerType = needleInject(Container);
-  const token = ensureLeafBound(container, cls);
-  return needleInject(token) as T;
-};
 
 export const resolveLeaf = (container: ContainerType, cls: AnyClass): void => {
   const rootClass = findRootLeafClass(cls);

--- a/packages/core/src/di/resolve.test.ts
+++ b/packages/core/src/di/resolve.test.ts
@@ -1,0 +1,60 @@
+import { Container, injectable } from '@needle-di/core';
+import { describe, expect, it } from 'vitest';
+
+import { registerAsLeaf } from './leaf';
+import { resolve } from './resolve';
+import { registerAsTransient } from './transient';
+
+describe('resolve', () => {
+  it('resolves leaf class via getLeaf', () => {
+    @injectable()
+    class LeafConfig {
+      value = 'leaf';
+    }
+    registerAsLeaf(LeafConfig);
+
+    const container = new Container();
+    const instance1 = resolve(container, LeafConfig);
+    const instance2 = resolve(container, LeafConfig);
+
+    expect(instance1).toBe(instance2);
+    expect(instance1.value).toBe('leaf');
+  });
+
+  it('resolves transient class via getTransient', () => {
+    @injectable()
+    class TransientCmd {}
+    registerAsTransient(TransientCmd);
+
+    const container = new Container();
+    const instance1 = resolve(container, TransientCmd);
+    const instance2 = resolve(container, TransientCmd);
+
+    expect(instance1).not.toBe(instance2);
+  });
+
+  it('resolves regular class via container.get (singleton)', () => {
+    @injectable()
+    class RegularService {}
+
+    const container = new Container();
+    const instance1 = resolve(container, RegularService);
+    const instance2 = resolve(container, RegularService);
+
+    expect(instance1).toBe(instance2);
+  });
+
+  it('prioritizes leaf over transient if both registered', () => {
+    @injectable()
+    class DualRegistered {}
+    registerAsLeaf(DualRegistered);
+    registerAsTransient(DualRegistered);
+
+    const container = new Container();
+    const instance1 = resolve(container, DualRegistered);
+    const instance2 = resolve(container, DualRegistered);
+
+    // Leaf wins, so singleton behavior
+    expect(instance1).toBe(instance2);
+  });
+});

--- a/packages/core/src/di/resolve.ts
+++ b/packages/core/src/di/resolve.ts
@@ -1,0 +1,20 @@
+import type { Container } from '@needle-di/core';
+
+import { getLeaf, isLeafClass } from './leaf';
+import { getTransient, isTransientClass } from './transient';
+
+type AnyClass = new (...args: never[]) => unknown;
+
+export const resolve = <T extends object>(
+  container: Container,
+  cls: new (...args: never[]) => T,
+): T => {
+  const anyClass: AnyClass = cls;
+  if (isLeafClass(anyClass)) {
+    return getLeaf(container, cls);
+  }
+  if (isTransientClass(anyClass)) {
+    return getTransient(container, cls);
+  }
+  return container.get<T>(cls);
+};

--- a/packages/core/src/di/transient.test.ts
+++ b/packages/core/src/di/transient.test.ts
@@ -1,0 +1,20 @@
+import { injectable } from '@needle-di/core';
+import { describe, expect, it } from 'vitest';
+
+import { isTransientClass, registerAsTransient } from './transient';
+
+describe('transient mechanism', () => {
+  describe('registerAsTransient / isTransientClass', () => {
+    it('returns false for unregistered class', () => {
+      class NotTransient {}
+      expect(isTransientClass(NotTransient)).toBe(false);
+    });
+
+    it('returns true after registerAsTransient', () => {
+      @injectable()
+      class TransientClass {}
+      registerAsTransient(TransientClass);
+      expect(isTransientClass(TransientClass)).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/di/transient.test.ts
+++ b/packages/core/src/di/transient.test.ts
@@ -1,7 +1,7 @@
-import { injectable } from '@needle-di/core';
+import { Container, inject, injectable } from '@needle-di/core';
 import { describe, expect, it } from 'vitest';
 
-import { isTransientClass, registerAsTransient } from './transient';
+import { getTransient, isTransientClass, registerAsTransient } from './transient';
 
 describe('transient mechanism', () => {
   describe('registerAsTransient / isTransientClass', () => {
@@ -15,6 +15,53 @@ describe('transient mechanism', () => {
       class TransientClass {}
       registerAsTransient(TransientClass);
       expect(isTransientClass(TransientClass)).toBe(true);
+    });
+  });
+
+  describe('getTransient', () => {
+    it('returns new instance each time', () => {
+      @injectable()
+      class TransientService {}
+      registerAsTransient(TransientService);
+
+      const container = new Container();
+      const instance1 = getTransient(container, TransientService);
+      const instance2 = getTransient(container, TransientService);
+
+      expect(instance1).not.toBe(instance2);
+    });
+
+    it('resolves dependencies as singletons', () => {
+      @injectable()
+      class Dependency {
+        id = Math.random();
+      }
+
+      @injectable()
+      class TransientService {
+        constructor(readonly dep: Dependency = inject(Dependency)) {}
+      }
+      registerAsTransient(TransientService);
+
+      const container = new Container();
+      const instance1 = getTransient(container, TransientService);
+      const instance2 = getTransient(container, TransientService);
+
+      expect(instance1).not.toBe(instance2);
+      expect(instance1.dep).toBe(instance2.dep);
+    });
+
+    it('cleans up token after resolution', () => {
+      @injectable()
+      class CleanupTest {}
+      registerAsTransient(CleanupTest);
+
+      const container = new Container();
+      // If unbind is omitted, the second call throws "already constructed" error
+      expect(() => {
+        getTransient(container, CleanupTest);
+        getTransient(container, CleanupTest);
+      }).not.toThrow();
     });
   });
 });

--- a/packages/core/src/di/transient.ts
+++ b/packages/core/src/di/transient.ts
@@ -1,3 +1,6 @@
+import type { Container } from '@needle-di/core';
+import { InjectionToken } from '@needle-di/core';
+
 type AnyClass = new (...args: never[]) => unknown;
 
 const transientClasses = new WeakSet<AnyClass>();
@@ -7,3 +10,18 @@ export const registerAsTransient = (cls: AnyClass): void => {
 };
 
 export const isTransientClass = (cls: AnyClass): boolean => transientClasses.has(cls);
+
+type NullaryClass<T> = new () => T;
+
+export const getTransient = <T extends object>(
+  container: Container,
+  cls: new (...args: never[]) => T,
+): T => {
+  const token = new InjectionToken<T>(Symbol());
+  const factory: NullaryClass<T> = cls;
+  const provider = { provide: token, useFactory: () => new factory() };
+  container.bind(provider);
+  const instance = container.get(token);
+  container.unbind(provider);
+  return instance;
+};

--- a/packages/core/src/di/transient.ts
+++ b/packages/core/src/di/transient.ts
@@ -1,0 +1,9 @@
+type AnyClass = new (...args: never[]) => unknown;
+
+const transientClasses = new WeakSet<AnyClass>();
+
+export const registerAsTransient = (cls: AnyClass): void => {
+  transientClasses.add(cls);
+};
+
+export const isTransientClass = (cls: AnyClass): boolean => transientClasses.has(cls);


### PR DESCRIPTION
## Summary

- Add transient pattern to DI system for creating fresh instances per resolution
- Register `@Command` decorated classes as transient automatically
- Consolidate resolution logic into single `resolve()` function (SSOT)

## Changes

- `di/transient.ts`: WeakSet-based registration + unique token + unbind pattern
- `di/resolve.ts`: Single source of truth for leaf/transient/singleton resolution
- `di/container.ts`: Use resolve() in ResolverHandle.get() and createTestTargetBase
- `di/inject.ts`: Use resolve() in unifiedInject()
- `command/decorator.ts`: Register commands as transient
- `di/leaf.ts`: Remove unused injectLeaf function

## Test plan

- [x] Verify multiple getTransient calls return different instances
- [x] Verify @Command classes resolve as transient via integration test
- [x] All 481 tests pass