### PR TITLE
feat(core): add structured error classes with Zelt prefix

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -347,6 +347,14 @@ export default tseslint.config(
     },
   },
   {
+    // Error factory uses generic K to index coreErrorDefinitions; TypeScript cannot narrow
+    // the union type at the generic boundary, requiring type assertion.
+    files: ['packages/core/src/errors/factory.ts'],
+    rules: {
+      '@9wick/strict-type-rules/no-as-assertion': 'off',
+    },
+  },
+  {
     // RateLimit decorator defines a dynamic middleware class inline.
     // The class name cannot match the file name pattern.
     files: ['packages/rate-limit/src/rate-limit.decorator.ts'],

--- a/packages/core/src/app/create-app.ts
+++ b/packages/core/src/app/create-app.ts
@@ -1,6 +1,7 @@
 import type { CommandClass } from '../command/types';
 import type { ConfigClass } from '../config';
 import { createContainer } from '../di/container';
+import { ZeltAppConfigurationError, ZeltLifecycleStateError } from '../errors';
 import { LifecycleManager } from '../lifecycle';
 
 import type { Module, ReadyContext } from './module';
@@ -136,7 +137,8 @@ const createReady =
   (deps: ReadyDeps) =>
   async (readyOptions?: ReadyOptions): Promise<ReadyResult> => {
     const { state, modules, configModule, configs } = deps;
-    if (state.disposed) throw new Error('Cannot ready() after shutdown()');
+    if (state.disposed)
+      throw new ZeltLifecycleStateError({ operation: 'ready', currentState: 'disposed' });
     if (state.readyPromise) return state.readyPromise;
 
     const warmup = readyOptions?.warmup ?? false;
@@ -230,7 +232,7 @@ const buildAppObject = (
 export function createApp<TOptions extends CreateAppOptions>(options: TOptions): App<TOptions>;
 export function createApp(options: CreateAppOptions): App<CreateAppOptions> {
   if (!options.http && !options.commands?.length) {
-    throw new Error('createApp requires at least http or commands option');
+    throw new ZeltAppConfigurationError({ reason: 'no_http_or_commands' });
   }
 
   const appModules = createAppModules(options);

--- a/packages/core/src/app/modules/command-module.ts
+++ b/packages/core/src/app/modules/command-module.ts
@@ -1,5 +1,6 @@
 import { getCommandMetadata } from '../../command/metadata';
 import type { CommandClass } from '../../command/types';
+import { ZeltAppConfigurationError, ZeltDecoratorUsageError } from '../../errors';
 import type { Module, ReadyContext } from '../module';
 
 export type CommandModule = Module & {
@@ -17,10 +18,14 @@ const validateCommands = (commands: readonly CommandClass[]): Map<string, Comman
   for (const cls of commands) {
     const meta = getCommandMetadata(cls);
     if (!meta) {
-      throw new Error(`Command class ${cls.name} is missing @Command decorator`);
+      throw new ZeltDecoratorUsageError({
+        decoratorName: 'Command',
+        reason: 'missing_decorator',
+        targetName: cls.name,
+      });
     }
     if (commandMap.has(meta.name)) {
-      throw new Error(`Duplicate command name: ${meta.name}`);
+      throw new ZeltAppConfigurationError({ reason: 'duplicate_command', details: meta.name });
     }
     commandMap.set(meta.name, cls);
   }

--- a/packages/core/src/app/modules/config-module.ts
+++ b/packages/core/src/app/modules/config-module.ts
@@ -1,4 +1,5 @@
 import type { ConfigClass } from '../../config';
+import { ZeltLifecycleStateError } from '../../errors';
 import type { Module, ReadyContext } from '../module';
 
 type AnyConstructorClass = new (...args: never[]) => object;
@@ -26,13 +27,13 @@ const createState = (): ConfigModuleState => ({
 
 const assertNotDisposed = (state: ConfigModuleState, operation: string): void => {
   if (state.isDisposed) {
-    throw new Error(`Cannot ${operation}() after shutdown()`);
+    throw new ZeltLifecycleStateError({ operation, currentState: 'disposed' });
   }
 };
 
 const assertNotReady = (state: ConfigModuleState, operation: string): void => {
   if (state.isReady) {
-    throw new Error(`Cannot ${operation}() after ready()`);
+    throw new ZeltLifecycleStateError({ operation, currentState: 'ready' });
   }
 };
 

--- a/packages/core/src/app/modules/http-module.ts
+++ b/packages/core/src/app/modules/http-module.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { match, P } from 'ts-pattern';
 import type { ResolverHandle } from '../../di/container';
+import { ZeltLifecycleStateError } from '../../errors';
 import { DefaultErrorHandler } from '../../http/default.error-handler';
 import { buildRoutes, warmupControllers } from '../../http/internal/route-builder';
 import type {
@@ -175,7 +176,7 @@ export const createHttpModule = (options: HttpOptions): HttpModule => {
 
   const fetch = async (req: Request): Promise<Response> => {
     if (!state.hono) {
-      throw new Error('Cannot fetch() before ready()');
+      throw new ZeltLifecycleStateError({ operation: 'fetch', currentState: 'not_ready' });
     }
     return state.hono.fetch(req);
   };

--- a/packages/core/src/command/command-context.ts
+++ b/packages/core/src/command/command-context.ts
@@ -1,5 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
+import { ZeltContextNotAvailableError } from '../errors';
+
 export type CommandContextStore = {
   readonly parsedArgs: Record<string, unknown>;
 };
@@ -12,7 +14,7 @@ export const runInCommandContext = <T>(ctx: CommandContextStore, fn: () => T): T
 export const getCommandContext = (): CommandContextStore => {
   const ctx = storage.getStore();
   if (!ctx) {
-    throw new Error('zelt/command: args() called outside command execution');
+    throw new ZeltContextNotAvailableError({ primitive: 'args', requiredContext: 'command' });
   }
   return ctx;
 };

--- a/packages/core/src/di/container.test.ts
+++ b/packages/core/src/di/container.test.ts
@@ -140,8 +140,6 @@ describe('createTestTargetBase', () => {
 
     await shutdown();
 
-    expect(() => get(SomeService)).toThrow(
-      'Cannot resolve SomeService: TestTarget has been shut down',
-    );
+    expect(() => get(SomeService)).toThrow(/Cannot get\(\) after shutdown\(\)/);
   });
 });

--- a/packages/core/src/di/container.ts
+++ b/packages/core/src/di/container.ts
@@ -1,6 +1,7 @@
 import { Container } from '@needle-di/core';
 import type { ConfigClass } from '../config';
 import { getConfig, overrideConfig, resolveConfig } from '../config';
+import { ZeltLifecycleStateError } from '../errors';
 import { LifecycleManager } from '../lifecycle';
 
 type Class<T> = new (...args: never[]) => T;
@@ -104,8 +105,7 @@ export const createTestTargetBase = async <T extends object>(
 
   const get = <U extends object>(cls: Class<U>): U => {
     if (disposed) {
-      const name = cls.name || 'unknown';
-      throw new Error(`Cannot resolve ${name}: TestTarget has been shut down`);
+      throw new ZeltLifecycleStateError({ operation: 'get', currentState: 'disposed' });
     }
     return container.get<U>(cls);
   };

--- a/packages/core/src/errors/classes.ts
+++ b/packages/core/src/errors/classes.ts
@@ -1,0 +1,9 @@
+import { createErrorClass } from './factory';
+
+export const ZeltDecoratorUsageError = createErrorClass('ZeltDecoratorUsageError');
+export const ZeltLifecycleStateError = createErrorClass('ZeltLifecycleStateError');
+export const ZeltContextNotAvailableError = createErrorClass('ZeltContextNotAvailableError');
+export const ZeltAppConfigurationError = createErrorClass('ZeltAppConfigurationError');
+export const ZeltRouteConfigurationError = createErrorClass('ZeltRouteConfigurationError');
+export const ZeltMiddlewareExecutionError = createErrorClass('ZeltMiddlewareExecutionError');
+export const ZeltNotImplementedError = createErrorClass('ZeltNotImplementedError');

--- a/packages/core/src/errors/definitions.ts
+++ b/packages/core/src/errors/definitions.ts
@@ -1,0 +1,50 @@
+export const coreErrorDefinitions = {
+  ZeltDecoratorUsageError: (ctx: {
+    decoratorName: string;
+    reason: 'static_method' | 'missing_decorator';
+    targetName?: string;
+  }) =>
+    ctx.reason === 'static_method'
+      ? `@${ctx.decoratorName} cannot be applied to static methods`
+      : `${ctx.targetName ?? 'class'} is missing @${ctx.decoratorName} decorator`,
+
+  ZeltLifecycleStateError: (ctx: {
+    operation: string;
+    currentState: 'disposed' | 'ready' | 'not_ready';
+  }) => {
+    if (ctx.currentState === 'disposed') return `Cannot ${ctx.operation}() after shutdown()`;
+    if (ctx.currentState === 'not_ready') return `Cannot ${ctx.operation}() before ready()`;
+    return `Cannot ${ctx.operation}() after ready()`;
+  },
+
+  ZeltContextNotAvailableError: (ctx: {
+    primitive: string;
+    requiredContext: 'entry' | 'command';
+  }) => `${ctx.primitive}() called outside ${ctx.requiredContext} execution`,
+
+  ZeltAppConfigurationError: (ctx: {
+    reason: 'no_http_or_commands' | 'duplicate_command';
+    details?: string;
+  }) =>
+    ctx.reason === 'no_http_or_commands'
+      ? 'createApp requires at least http or commands option'
+      : `Duplicate command name: ${ctx.details}`,
+
+  ZeltRouteConfigurationError: (ctx: {
+    reason: 'missing_path_param' | 'invalid_route';
+    paramName?: string;
+  }) =>
+    ctx.reason === 'missing_path_param'
+      ? `path parameter "${ctx.paramName}" is not defined`
+      : 'Invalid route configuration',
+
+  ZeltMiddlewareExecutionError: (_ctx: { reason: 'next_called_multiple_times' }) =>
+    'next() called multiple times',
+
+  ZeltNotImplementedError: (ctx: { className: string; methodName: string }) =>
+    `${ctx.className}.${ctx.methodName}() not implemented`,
+} as const;
+
+export type CoreErrorContextMap = {
+  [K in keyof typeof coreErrorDefinitions]: Parameters<(typeof coreErrorDefinitions)[K]>[0];
+};

--- a/packages/core/src/errors/errors.test.ts
+++ b/packages/core/src/errors/errors.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ZeltAppConfigurationError,
+  ZeltContextNotAvailableError,
+  ZeltDecoratorUsageError,
+  ZeltLifecycleStateError,
+  ZeltMiddlewareExecutionError,
+  ZeltNotImplementedError,
+  ZeltRouteConfigurationError,
+} from './index';
+
+describe('ZeltDecoratorUsageError', () => {
+  it('formats static_method reason correctly', () => {
+    const error = new ZeltDecoratorUsageError({
+      decoratorName: 'Authorized',
+      reason: 'static_method',
+    });
+    expect(error.message).toBe('@Authorized cannot be applied to static methods');
+    expect(error.name).toBe('ZeltDecoratorUsageError');
+    expect(error.context).toEqual({ decoratorName: 'Authorized', reason: 'static_method' });
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(ZeltDecoratorUsageError);
+  });
+
+  it('supports cause for error chaining', () => {
+    const originalError = new Error('original cause');
+    const error = new ZeltDecoratorUsageError(
+      { decoratorName: 'Get', reason: 'static_method' },
+      originalError,
+    );
+    expect(error.cause).toBe(originalError);
+  });
+
+  it('formats missing_decorator reason correctly', () => {
+    const error = new ZeltDecoratorUsageError({
+      decoratorName: 'Controller',
+      reason: 'missing_decorator',
+      targetName: 'UserController',
+    });
+    expect(error.message).toBe('UserController is missing @Controller decorator');
+  });
+
+  it('uses default targetName when not provided', () => {
+    const error = new ZeltDecoratorUsageError({
+      decoratorName: 'Controller',
+      reason: 'missing_decorator',
+    });
+    expect(error.message).toBe('class is missing @Controller decorator');
+  });
+});
+
+describe('ZeltLifecycleStateError', () => {
+  it('formats disposed state correctly', () => {
+    const error = new ZeltLifecycleStateError({
+      operation: 'ready',
+      currentState: 'disposed',
+    });
+    expect(error.message).toBe('Cannot ready() after shutdown()');
+    expect(error.name).toBe('ZeltLifecycleStateError');
+    expect(error).toBeInstanceOf(ZeltLifecycleStateError);
+  });
+
+  it('formats ready state correctly', () => {
+    const error = new ZeltLifecycleStateError({
+      operation: 'addFallbackConfig',
+      currentState: 'ready',
+    });
+    expect(error.message).toBe('Cannot addFallbackConfig() after ready()');
+  });
+
+  it('formats not_ready state correctly', () => {
+    const error = new ZeltLifecycleStateError({
+      operation: 'fetch',
+      currentState: 'not_ready',
+    });
+    expect(error.message).toBe('Cannot fetch() before ready()');
+  });
+});
+
+describe('ZeltContextNotAvailableError', () => {
+  it('formats entry context correctly', () => {
+    const error = new ZeltContextNotAvailableError({
+      primitive: 'response',
+      requiredContext: 'entry',
+    });
+    expect(error.message).toBe('response() called outside entry execution');
+    expect(error.name).toBe('ZeltContextNotAvailableError');
+    expect(error).toBeInstanceOf(ZeltContextNotAvailableError);
+  });
+
+  it('formats command context correctly', () => {
+    const error = new ZeltContextNotAvailableError({
+      primitive: 'args',
+      requiredContext: 'command',
+    });
+    expect(error.message).toBe('args() called outside command execution');
+  });
+});
+
+describe('ZeltAppConfigurationError', () => {
+  it('formats no_http_or_commands reason correctly', () => {
+    const error = new ZeltAppConfigurationError({
+      reason: 'no_http_or_commands',
+    });
+    expect(error.message).toBe('createApp requires at least http or commands option');
+    expect(error.name).toBe('ZeltAppConfigurationError');
+    expect(error).toBeInstanceOf(ZeltAppConfigurationError);
+  });
+
+  it('formats duplicate_command reason correctly', () => {
+    const error = new ZeltAppConfigurationError({
+      reason: 'duplicate_command',
+      details: 'build',
+    });
+    expect(error.message).toBe('Duplicate command name: build');
+  });
+});
+
+describe('ZeltRouteConfigurationError', () => {
+  it('formats missing_path_param reason correctly', () => {
+    const error = new ZeltRouteConfigurationError({
+      reason: 'missing_path_param',
+      paramName: 'id',
+    });
+    expect(error.message).toBe('path parameter "id" is not defined');
+    expect(error.name).toBe('ZeltRouteConfigurationError');
+    expect(error).toBeInstanceOf(ZeltRouteConfigurationError);
+  });
+
+  it('formats invalid_route reason correctly', () => {
+    const error = new ZeltRouteConfigurationError({
+      reason: 'invalid_route',
+    });
+    expect(error.message).toBe('Invalid route configuration');
+  });
+});
+
+describe('ZeltMiddlewareExecutionError', () => {
+  it('formats next_called_multiple_times reason correctly', () => {
+    const error = new ZeltMiddlewareExecutionError({
+      reason: 'next_called_multiple_times',
+    });
+    expect(error.message).toBe('next() called multiple times');
+    expect(error.name).toBe('ZeltMiddlewareExecutionError');
+    expect(error).toBeInstanceOf(ZeltMiddlewareExecutionError);
+  });
+});
+
+describe('ZeltNotImplementedError', () => {
+  it('formats not implemented error correctly', () => {
+    const error = new ZeltNotImplementedError({
+      className: 'CliConfig',
+      methodName: 'cwd',
+    });
+    expect(error.message).toBe('CliConfig.cwd() not implemented');
+    expect(error.name).toBe('ZeltNotImplementedError');
+    expect(error).toBeInstanceOf(ZeltNotImplementedError);
+  });
+});

--- a/packages/core/src/errors/factory.ts
+++ b/packages/core/src/errors/factory.ts
@@ -1,0 +1,30 @@
+import type { CoreErrorContextMap } from './definitions';
+import { coreErrorDefinitions } from './definitions';
+
+type ZeltErrorClass<K extends keyof CoreErrorContextMap> = {
+  new (
+    context: CoreErrorContextMap[K],
+    cause?: unknown,
+  ): Error & {
+    readonly name: K;
+    readonly context: CoreErrorContextMap[K];
+  };
+};
+
+export const createErrorClass = <K extends keyof typeof coreErrorDefinitions>(
+  name: K,
+): ZeltErrorClass<K> => {
+  const ErrorClass = class extends Error {
+    override readonly name = name;
+    constructor(
+      public readonly context: CoreErrorContextMap[K],
+      cause?: unknown,
+    ) {
+      super((coreErrorDefinitions[name] as (ctx: CoreErrorContextMap[K]) => string)(context), {
+        cause,
+      });
+      Object.setPrototypeOf(this, new.target.prototype);
+    }
+  };
+  return ErrorClass;
+};

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,0 +1,3 @@
+export * from './classes';
+export { type CoreErrorContextMap, coreErrorDefinitions } from './definitions';
+export { createErrorClass } from './factory';

--- a/packages/core/src/http/decorators/authorized.ts
+++ b/packages/core/src/http/decorators/authorized.ts
@@ -1,3 +1,4 @@
+import { ZeltDecoratorUsageError } from '../../errors';
 import { resolveMethodArgs } from '../../internal/decorator-context';
 import { appendPendingAuthorizedMetadata } from '../internal/metadata';
 import type { RequestContextSchema } from '../primitives/get-context';
@@ -9,7 +10,7 @@ export const Authorized =
   (...args: unknown[]): void => {
     const { pendingKey, methodName, isStatic } = resolveMethodArgs(args);
     if (isStatic) {
-      throw new Error('zelt: @Authorized cannot be applied to static methods');
+      throw new ZeltDecoratorUsageError({ decoratorName: 'Authorized', reason: 'static_method' });
     }
     appendPendingAuthorizedMetadata(pendingKey, methodName, roles);
   };

--- a/packages/core/src/http/decorators/http-method.ts
+++ b/packages/core/src/http/decorators/http-method.ts
@@ -1,3 +1,4 @@
+import { ZeltDecoratorUsageError } from '../../errors';
 import { resolveMethodArgs } from '../../internal/decorator-context';
 import type { HttpMethod } from '../internal/metadata';
 import { appendPendingRouteMetadata } from '../internal/metadata';
@@ -8,7 +9,7 @@ const makeDecorator =
   (...args: unknown[]): void => {
     const { pendingKey, methodName, isStatic } = resolveMethodArgs(args);
     if (isStatic) {
-      throw new Error(`zelt: @${method} cannot be applied to static methods`);
+      throw new ZeltDecoratorUsageError({ decoratorName: method, reason: 'static_method' });
     }
     appendPendingRouteMetadata(pendingKey, { method, path, methodName });
   };

--- a/packages/core/src/http/decorators/skip-middleware.ts
+++ b/packages/core/src/http/decorators/skip-middleware.ts
@@ -1,3 +1,4 @@
+import { ZeltDecoratorUsageError } from '../../errors';
 import { resolveMethodArgs } from '../../internal/decorator-context';
 import { appendPendingSkipMiddlewareMetadata } from '../internal/metadata';
 import type { MiddlewareIdentifier } from '../middleware/types';
@@ -7,7 +8,10 @@ export const SkipMiddleware =
   (...args: unknown[]): void => {
     const { pendingKey, methodName, isStatic } = resolveMethodArgs(args);
     if (isStatic) {
-      throw new Error('zelt: @SkipMiddleware cannot be applied to static methods');
+      throw new ZeltDecoratorUsageError({
+        decoratorName: 'SkipMiddleware',
+        reason: 'static_method',
+      });
     }
     appendPendingSkipMiddlewareMetadata(pendingKey, methodName, middlewares);
   };

--- a/packages/core/src/http/decorators/use-middleware.ts
+++ b/packages/core/src/http/decorators/use-middleware.ts
@@ -1,5 +1,6 @@
 import { match, P } from 'ts-pattern';
 
+import { ZeltDecoratorUsageError } from '../../errors';
 import { resolveClassArgs, resolveMethodArgs } from '../../internal/decorator-context';
 import {
   appendPendingMethodMiddlewareMetadata,
@@ -28,7 +29,10 @@ export const UseMiddleware =
     // Method decorator
     const { pendingKey, methodName, isStatic } = resolveMethodArgs(args);
     if (isStatic) {
-      throw new Error('zelt: @UseMiddleware cannot be applied to static methods');
+      throw new ZeltDecoratorUsageError({
+        decoratorName: 'UseMiddleware',
+        reason: 'static_method',
+      });
     }
     appendPendingMethodMiddlewareMetadata(pendingKey, methodName, middlewares);
   };

--- a/packages/core/src/http/internal/entry-context.ts
+++ b/packages/core/src/http/internal/entry-context.ts
@@ -2,6 +2,8 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { Context } from 'hono';
 
+import { ZeltContextNotAvailableError } from '../../errors';
+
 type FormBody = Record<string, string | File | (string | File)[]>;
 
 type EntryInput = {
@@ -21,6 +23,10 @@ export const runInEntryContext = <T>(ctx: EntryContext, fn: () => T): T => stora
 
 export const getEntryContext = (): EntryContext => {
   const ctx = storage.getStore();
-  if (!ctx) throw new Error('zelt: primitive called outside entry execution');
+  if (!ctx)
+    throw new ZeltContextNotAvailableError({
+      primitive: 'getEntryContext',
+      requiredContext: 'entry',
+    });
   return ctx;
 };

--- a/packages/core/src/http/internal/route-builder.ts
+++ b/packages/core/src/http/internal/route-builder.ts
@@ -1,6 +1,11 @@
 import type { Context, Env, Hono, Input } from 'hono';
 
 import type { ResolverHandle } from '../../di/container';
+import {
+  ZeltDecoratorUsageError,
+  ZeltMiddlewareExecutionError,
+  ZeltRouteConfigurationError,
+} from '../../errors';
 import type { LifecycleManager } from '../../lifecycle';
 import type {
   FunctionMiddleware,
@@ -48,7 +53,11 @@ export const collectRoutes = (controllers: readonly ControllerClass[]): readonly
   for (const cls of controllers) {
     const meta = getControllerMetadata(cls);
     if (!meta) {
-      throw new Error('zelt: controller is missing @Controller decorator');
+      throw new ZeltDecoratorUsageError({
+        decoratorName: 'Controller',
+        reason: 'missing_decorator',
+        targetName: cls.name,
+      });
     }
     for (const r of getRouteMetadata(cls)) {
       routes.push({
@@ -67,9 +76,7 @@ const resolveHandler = (instance: object, methodName: string | symbol): (() => u
   // forces narrowing before any call, keeping the handler invocation typesafe.
   const value: unknown = Reflect.get(instance, methodName);
   if (typeof value !== 'function') {
-    throw new Error(
-      `zelt: route handler ${String(methodName)} is not a function on the controller`,
-    );
+    throw new ZeltRouteConfigurationError({ reason: 'invalid_route' });
   }
   return () => {
     const result: unknown = value.call(instance);
@@ -223,7 +230,8 @@ const composeHandler = (
     let response: Response | undefined;
 
     const dispatch = async (i: number): Promise<void> => {
-      if (i <= index) throw new Error('next() called multiple times');
+      if (i <= index)
+        throw new ZeltMiddlewareExecutionError({ reason: 'next_called_multiple_times' });
       index = i;
       if (i < middlewares.length) {
         const mw = middlewares[i];

--- a/packages/core/src/http/primitives/path-param.ts
+++ b/packages/core/src/http/primitives/path-param.ts
@@ -1,9 +1,10 @@
+import { ZeltRouteConfigurationError } from '../../errors';
 import { getEntryContext } from '../internal/entry-context';
 
 export const pathParam = (name: string): string => {
   const value = getEntryContext().input.pathParams[name];
   if (value === undefined) {
-    throw new Error(`zelt: path parameter "${name}" is not defined`);
+    throw new ZeltRouteConfigurationError({ reason: 'missing_path_param', paramName: name });
   }
   return value;
 };

--- a/packages/core/src/http/primitives/response.test.ts
+++ b/packages/core/src/http/primitives/response.test.ts
@@ -78,6 +78,6 @@ describe('response()', () => {
   });
 
   it('throws when called outside entry execution', () => {
-    expect(() => response()).toThrow('zelt: primitive called outside entry execution');
+    expect(() => response()).toThrow(/called outside entry execution/);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,17 @@ export { Config, overrideConfig } from './config';
 export { inject } from './di/inject';
 // DI
 export { Injectable } from './di/injectable';
+export type { CoreErrorContextMap } from './errors';
+// Errors
+export {
+  ZeltAppConfigurationError,
+  ZeltContextNotAvailableError,
+  ZeltDecoratorUsageError,
+  ZeltLifecycleStateError,
+  ZeltMiddlewareExecutionError,
+  ZeltNotImplementedError,
+  ZeltRouteConfigurationError,
+} from './errors';
 // HTTP decorators
 export { Authorized } from './http/decorators/authorized';
 export { Controller } from './http/decorators/controller';

--- a/packages/core/src/modules/cli/cli.config.ts
+++ b/packages/core/src/modules/cli/cli.config.ts
@@ -1,4 +1,5 @@
 import { Config } from '../../config';
+import { ZeltNotImplementedError } from '../../errors';
 
 export type Signal = 'SIGINT' | 'SIGTERM';
 export type SignalHandler = () => void;
@@ -6,26 +7,26 @@ export type SignalHandler = () => void;
 @Config
 export class CliConfig {
   cwd(): string {
-    throw new Error('CliConfig.cwd() not implemented');
+    throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'cwd' });
   }
 
   argv(): readonly string[] {
-    throw new Error('CliConfig.argv() not implemented');
+    throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'argv' });
   }
 
   exit(_code: number): never {
-    throw new Error('CliConfig.exit() not implemented');
+    throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'exit' });
   }
 
   setExitCode(_code: number): void {
-    throw new Error('CliConfig.setExitCode() not implemented');
+    throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'setExitCode' });
   }
 
   onSignal(_signal: Signal, _handler: SignalHandler): void {
-    throw new Error('CliConfig.onSignal() not implemented');
+    throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'onSignal' });
   }
 
   offSignal(_signal: Signal, _handler: SignalHandler): void {
-    throw new Error('CliConfig.offSignal() not implemented');
+    throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'offSignal' });
   }
 }

--- a/packages/core/src/scheduler/decorators/cron.ts
+++ b/packages/core/src/scheduler/decorators/cron.ts
@@ -1,3 +1,4 @@
+import { ZeltDecoratorUsageError } from '../../errors';
 import { resolveMethodArgs } from '../../internal/decorator-context';
 import { appendPendingScheduleMetadata } from '../internal/scheduler-metadata';
 
@@ -10,7 +11,7 @@ export const Cron =
   (...args: unknown[]): void => {
     const { pendingKey, methodName, isStatic } = resolveMethodArgs(args);
     if (isStatic) {
-      throw new Error('@Cron cannot be applied to static methods');
+      throw new ZeltDecoratorUsageError({ decoratorName: 'Cron', reason: 'static_method' });
     }
     appendPendingScheduleMetadata(pendingKey, {
       methodName,

--- a/packages/core/src/scheduler/decorators/daily.ts
+++ b/packages/core/src/scheduler/decorators/daily.ts
@@ -1,3 +1,4 @@
+import { ZeltDecoratorUsageError } from '../../errors';
 import { resolveMethodArgs } from '../../internal/decorator-context';
 import { appendPendingScheduleMetadata } from '../internal/scheduler-metadata';
 
@@ -12,7 +13,7 @@ export const Daily =
   (...args: unknown[]): void => {
     const { pendingKey, methodName, isStatic } = resolveMethodArgs(args);
     if (isStatic) {
-      throw new Error('@Daily cannot be applied to static methods');
+      throw new ZeltDecoratorUsageError({ decoratorName: 'Daily', reason: 'static_method' });
     }
     const minute = options.minute ?? 0;
     const cronExpression = `${minute} ${options.hour} * * *`;

--- a/packages/core/src/scheduler/decorators/every.ts
+++ b/packages/core/src/scheduler/decorators/every.ts
@@ -1,3 +1,4 @@
+import { ZeltDecoratorUsageError } from '../../errors';
 import { resolveMethodArgs } from '../../internal/decorator-context';
 import { appendPendingScheduleMetadata } from '../internal/scheduler-metadata';
 
@@ -10,7 +11,7 @@ export const Every =
   (...args: unknown[]): void => {
     const { pendingKey, methodName, isStatic } = resolveMethodArgs(args);
     if (isStatic) {
-      throw new Error('@Every cannot be applied to static methods');
+      throw new ZeltDecoratorUsageError({ decoratorName: 'Every', reason: 'static_method' });
     }
 
     const cronExpression =

--- a/packages/core/src/scheduler/decorators/hourly.ts
+++ b/packages/core/src/scheduler/decorators/hourly.ts
@@ -1,3 +1,4 @@
+import { ZeltDecoratorUsageError } from '../../errors';
 import { resolveMethodArgs } from '../../internal/decorator-context';
 import { appendPendingScheduleMetadata } from '../internal/scheduler-metadata';
 
@@ -11,7 +12,7 @@ export const Hourly =
   (...args: unknown[]): void => {
     const { pendingKey, methodName, isStatic } = resolveMethodArgs(args);
     if (isStatic) {
-      throw new Error('@Hourly cannot be applied to static methods');
+      throw new ZeltDecoratorUsageError({ decoratorName: 'Hourly', reason: 'static_method' });
     }
     const minute = options?.minute ?? 0;
     const cronExpression = `${minute} * * * *`;

--- a/packages/core/src/scheduler/decorators/weekly.ts
+++ b/packages/core/src/scheduler/decorators/weekly.ts
@@ -1,3 +1,4 @@
+import { ZeltDecoratorUsageError } from '../../errors';
 import { resolveMethodArgs } from '../../internal/decorator-context';
 import { appendPendingScheduleMetadata } from '../internal/scheduler-metadata';
 
@@ -25,7 +26,7 @@ export const Weekly =
   (...args: unknown[]): void => {
     const { pendingKey, methodName, isStatic } = resolveMethodArgs(args);
     if (isStatic) {
-      throw new Error('@Weekly cannot be applied to static methods');
+      throw new ZeltDecoratorUsageError({ decoratorName: 'Weekly', reason: 'static_method' });
     }
     const minute = options.minute ?? 0;
     const cronDay = dayToCron[options.day];


### PR DESCRIPTION
## Summary

- Add 7 structured error classes (`ZeltDecoratorUsageError`, `ZeltLifecycleStateError`, etc.) with typed context data
- Implement factory pattern for error class generation with proper TypeScript types
- Support error chaining via ES2022 `cause` parameter
- Replace generic Error throws across core package with typed Zelt*Error classes

## Test plan

- [x] All 282 core tests passing
- [x] Error class tests cover all 7 error types (15 test cases)
- [x] `instanceof` checks work correctly
- [x] Error messages generated from structured context