### PR TITLE
feat(core): add structured error classes with Zelt prefix

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,6 +121,26 @@ export default tseslint.config(
     },
   },
   {
+    // Forbid raw Error — use structured Zelt*Error classes instead
+    files: ['packages/core/src/**/*.{ts,tsx}'],
+    ignores: [
+      ...TEST_FILES,
+      ...FIXTURE_FILES,
+      '**/errors/**',
+      // Stack trace utility uses Error().stack, not for throwing
+      'packages/core/src/http/internal/source-file.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'ThrowStatement > NewExpression[callee.name="Error"]',
+          message: 'Use structured Zelt*Error classes instead of raw Error',
+        },
+      ],
+    },
+  },
+  {
     // contract package uses neverthrow (ROP) — enforce no throw/try-catch
     files: ['packages/contract/src/**/*.{ts,tsx}'],
     ignores: [...TEST_FILES, ...FIXTURE_FILES],
@@ -252,6 +272,7 @@ export default tseslint.config(
   {
     // CLI entry points: type predicate needed for error type guard.
     files: [
+      'packages/cli/src/errors.ts',
       'packages/cli/src/config/loader.ts',
       'packages/cli/src/builders/tsdown.ts',
       'packages/cli/src/commands/run/runner.ts',
@@ -352,6 +373,19 @@ export default tseslint.config(
     files: ['packages/core/src/errors/factory.ts'],
     rules: {
       '@9wick/strict-type-rules/no-as-assertion': 'off',
+    },
+  },
+  {
+    // defineError/defineHttpException return anonymous classes that cannot satisfy
+    // their return types without type assertion. isKVError uses instanceof union check.
+    files: [
+      'packages/core/src/errors/define-error.ts',
+      'packages/core/src/errors/define-http-exception.ts',
+      'packages/kv/src/errors.ts',
+    ],
+    rules: {
+      '@9wick/strict-type-rules/no-as-assertion': 'off',
+      '@9wick/strict-type-rules/no-type-predicate': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -43,5 +43,10 @@
     "typescript-eslint": "8.59.1",
     "unplugin-swc": "1.5.9",
     "vitest": "4.1.5"
-  }
+  },
+  "workspaces": [
+    "packages/*",
+    "examples/*",
+    "website"
+  ]
 }

--- a/packages/adapter-bun/src/on-bun.ts
+++ b/packages/adapter-bun/src/on-bun.ts
@@ -71,6 +71,7 @@ const createServeForHttp = (
   };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const runCommand = (
   CommandClass: CommandClass,
   get: <T extends object>(cls: new (...args: never[]) => T) => T,
@@ -82,6 +83,7 @@ const runCommand = (
     .catch(() => failureResult);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const createExecForCommands = (
   hasCommand: (name: string) => boolean,
   getCommands: () => ReadonlyMap<string, CommandClass>,
@@ -138,6 +140,7 @@ const buildHttpBunApp = (
   return { ...resolver, args, serve: createServeForHttp(caps.fetch, shutdown), shutdown };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const buildCommandBunApp = (
   caps: AppCapabilities,
   resolver: ReadyResult,
@@ -155,6 +158,7 @@ const buildCommandBunApp = (
   };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const buildBunApps = (
   caps: AppCapabilities,
   resolver: ReadyResult,
@@ -187,9 +191,13 @@ const mergeBunApps = (
   };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export function onBun(app: HttpApp & CommandApp, options?: BunAppOptions): Promise<FullBunApp>;
+/** @throws {ZeltLifecycleStateError} */
 export function onBun(app: HttpApp, options?: BunAppOptions): Promise<HttpBunApp>;
+/** @throws {ZeltLifecycleStateError} */
 export function onBun(app: CommandApp, options?: BunAppOptions): Promise<CommandBunApp>;
+/** @throws {ZeltLifecycleStateError} */
 export async function onBun(
   app: HttpApp | CommandApp | (HttpApp & CommandApp),
   options: BunAppOptions = {},

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -91,6 +91,7 @@ const createListenForHttp = (
   };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const runCommand = (
   CommandClass: CommandClass,
   get: <T extends object>(cls: new (...args: never[]) => T) => T,
@@ -102,6 +103,7 @@ const runCommand = (
     .catch(() => failureResult);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const createExecForCommands = (
   hasCommand: (name: string) => boolean,
   getCommands: () => ReadonlyMap<string, CommandClass>,
@@ -162,6 +164,7 @@ const buildHttpNodeApp = (
   return { ...resolver, args, listen: createListenForHttp(caps.fetch, shutdown), shutdown };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const buildCommandNodeApp = (
   caps: AppCapabilities,
   resolver: ReadyResult,
@@ -188,6 +191,7 @@ const buildSchedulerPart = (caps: AppCapabilities): SchedulerNodeAppPart | undef
   };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const buildNodeApps = (
   caps: AppCapabilities,
   resolver: ReadyResult,
@@ -222,21 +226,28 @@ const mergeNodeApps = (
   return { ...resolver, args, shutdown, listen: () => new Promise(() => {}), ...schedulerMethods };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export function onNode(
   app: HttpApp & CommandApp & SchedulerApp,
   options?: NodeAppOptions,
 ): Promise<FullNodeApp & SchedulerNodeAppPart>;
+/** @throws {ZeltLifecycleStateError} */
 export function onNode(
   app: HttpApp & SchedulerApp,
   options?: NodeAppOptions,
 ): Promise<HttpNodeApp & SchedulerNodeAppPart>;
+/** @throws {ZeltLifecycleStateError} */
 export function onNode(
   app: CommandApp & SchedulerApp,
   options?: NodeAppOptions,
 ): Promise<CommandNodeApp & SchedulerNodeAppPart>;
+/** @throws {ZeltLifecycleStateError} */
 export function onNode(app: HttpApp & CommandApp, options?: NodeAppOptions): Promise<FullNodeApp>;
+/** @throws {ZeltLifecycleStateError} */
 export function onNode(app: HttpApp, options?: NodeAppOptions): Promise<HttpNodeApp>;
+/** @throws {ZeltLifecycleStateError} */
 export function onNode(app: CommandApp, options?: NodeAppOptions): Promise<CommandNodeApp>;
+/** @throws {ZeltLifecycleStateError} */
 export async function onNode(app: AnyApp, options: NodeAppOptions = {}): Promise<NodeApp> {
   app.addFallbackConfig(NodeCliConfig);
   app.addFallbackConfig(ProcessEnvConfig);

--- a/packages/auth-jwt/src/errors.ts
+++ b/packages/auth-jwt/src/errors.ts
@@ -1,0 +1,12 @@
+import { defineError } from '@zeltjs/core/internal-bridge/errors';
+
+export type JwtConfigErrorReason = 'missing_secret';
+
+const messages: Record<JwtConfigErrorReason, string> = {
+  missing_secret: 'JWT_SECRET environment variable is required',
+};
+
+export const ZeltJwtConfigError = defineError(
+  'ZeltJwtConfigError',
+  (ctx: { reason: JwtConfigErrorReason }) => messages[ctx.reason],
+);

--- a/packages/auth-jwt/src/exceptions.test.ts
+++ b/packages/auth-jwt/src/exceptions.test.ts
@@ -1,0 +1,61 @@
+import { HTTPException } from '@zeltjs/core';
+import { describe, expect, it } from 'vitest';
+
+import { UnauthorizedException } from './exceptions';
+
+describe('UnauthorizedException', () => {
+  it('is instanceof HTTPException', () => {
+    const err = new UnauthorizedException({ reason: 'missing_token' });
+    expect(err instanceof HTTPException).toBe(true);
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it('has correct status 401', () => {
+    const err = new UnauthorizedException({ reason: 'missing_token' });
+    expect(err.status).toBe(401);
+  });
+
+  it('has correct name', () => {
+    const err = new UnauthorizedException({ reason: 'missing_token' });
+    expect(err.name).toBe('UnauthorizedException');
+  });
+
+  it('exposes context property', () => {
+    const err = new UnauthorizedException({ reason: 'invalid_token' });
+    expect(err.context).toEqual({ reason: 'invalid_token' });
+  });
+
+  it('response body has correct message for missing_token', async () => {
+    const err = new UnauthorizedException({ reason: 'missing_token' });
+    const body = (await err.getResponse().json()) as { message: string };
+    expect(body.message).toBe('Authorization token is required');
+  });
+
+  it('response body has correct message for invalid_token', async () => {
+    const err = new UnauthorizedException({ reason: 'invalid_token' });
+    const body = (await err.getResponse().json()) as { message: string };
+    expect(body.message).toBe('Invalid authorization token');
+  });
+
+  it('response body has correct message for expired', async () => {
+    const err = new UnauthorizedException({ reason: 'expired' });
+    const body = (await err.getResponse().json()) as { message: string };
+    expect(body.message).toBe('Authorization token has expired');
+  });
+
+  it('getResponse returns correct response with WWW-Authenticate header', async () => {
+    const err = new UnauthorizedException({ reason: 'missing_token' });
+    const res = err.getResponse();
+    expect(res.status).toBe(401);
+    expect(res.headers.get('WWW-Authenticate')).toBe('Bearer');
+  });
+
+  it('getResponse returns JSON body with code and reason', async () => {
+    const err = new UnauthorizedException({ reason: 'invalid_token' });
+    const res = err.getResponse();
+    const body = (await res.json()) as { code: string; reason: string; message: string };
+    expect(body.code).toBe('UNAUTHORIZED');
+    expect(body.reason).toBe('invalid_token');
+    expect(body.message).toBe('Invalid authorization token');
+  });
+});

--- a/packages/auth-jwt/src/exceptions.ts
+++ b/packages/auth-jwt/src/exceptions.ts
@@ -1,0 +1,22 @@
+import { defineHttpException } from '@zeltjs/core';
+
+export type UnauthorizedReason = 'missing_token' | 'invalid_token' | 'expired';
+
+const messages: Record<UnauthorizedReason, string> = {
+  missing_token: 'Authorization token is required',
+  invalid_token: 'Invalid authorization token',
+  expired: 'Authorization token has expired',
+};
+
+export const UnauthorizedException = defineHttpException(
+  'UnauthorizedException',
+  401,
+  (ctx: { reason: UnauthorizedReason }) => messages[ctx.reason],
+  {
+    buildResponse: (ctx, status, message) =>
+      Response.json(
+        { code: 'UNAUTHORIZED', reason: ctx.reason, message },
+        { status, headers: { 'WWW-Authenticate': 'Bearer' } },
+      ),
+  },
+);

--- a/packages/auth-jwt/src/index.ts
+++ b/packages/auth-jwt/src/index.ts
@@ -1,3 +1,5 @@
+export { type JwtConfigErrorReason, ZeltJwtConfigError } from './errors';
+export { UnauthorizedException, type UnauthorizedReason } from './exceptions';
 export type { ResolveUserResult } from './jwt.config';
 export { JwtConfig } from './jwt.config';
 export { JwtMiddleware } from './jwt.middleware';

--- a/packages/auth-jwt/src/jwt.config.ts
+++ b/packages/auth-jwt/src/jwt.config.ts
@@ -1,6 +1,7 @@
 import type { RequestContextSchema } from '@zeltjs/core';
 import { Config } from '@zeltjs/core';
 
+import { ZeltJwtConfigError } from './errors';
 import type { JwtDriver, JwtPayload } from './jwt.types';
 
 export interface ResolveUserResult {
@@ -10,10 +11,13 @@ export interface ResolveUserResult {
 
 @Config
 export class JwtConfig {
+  /**
+   * @throws {ZeltJwtConfigError} When JWT_SECRET is not set
+   */
   get secret(): string {
     const secret = process.env['JWT_SECRET'];
     if (!secret) {
-      throw new Error('JWT_SECRET environment variable is required');
+      throw new ZeltJwtConfigError({ reason: 'missing_secret' });
     }
     return secret;
   }

--- a/packages/auth-jwt/src/jwt.middleware.ts
+++ b/packages/auth-jwt/src/jwt.middleware.ts
@@ -2,6 +2,7 @@ import type { Next, RequestContext } from '@zeltjs/core';
 import { inject, Middleware, setUser } from '@zeltjs/core';
 import { getCookie } from 'hono/cookie';
 
+import { UnauthorizedException } from './exceptions';
 import { JwtConfig } from './jwt.config';
 import { JwtService } from './jwt.service';
 
@@ -12,11 +13,15 @@ export class JwtMiddleware {
     private readonly config = inject(JwtConfig),
   ) {}
 
+  /**
+   * @throws {UnauthorizedException} When token is missing (401)
+   * @throws {UnauthorizedException} When token is invalid or expired (401)
+   */
   async use(c: RequestContext, next: Next): Promise<Response | undefined> {
     const token = this.extractToken(c);
 
     if (!token) {
-      return c.json({ error: 'Unauthorized' }, 401);
+      throw new UnauthorizedException({ reason: 'missing_token' });
     }
 
     const verified = await this.jwtService.verify(token).then(
@@ -25,7 +30,7 @@ export class JwtMiddleware {
     );
 
     if (!verified.ok) {
-      return c.json({ error: 'Unauthorized' }, 401);
+      throw new UnauthorizedException({ reason: 'invalid_token' });
     }
 
     const { user, roles } = await this.config.resolveUser(verified.payload);

--- a/packages/auth-jwt/vitest.config.ts
+++ b/packages/auth-jwt/vitest.config.ts
@@ -16,6 +16,10 @@ export default mergeConfig(
           __dirname,
           '../core/src/internal-bridge/testing.ts',
         ),
+        '@zeltjs/core/internal-bridge/errors': resolve(
+          __dirname,
+          '../core/src/internal-bridge/errors.ts',
+        ),
         '@zeltjs/core': resolve(__dirname, '../core/src/index.ts'),
       },
     },

--- a/packages/auth-session/src/errors.ts
+++ b/packages/auth-session/src/errors.ts
@@ -1,0 +1,13 @@
+import { defineError } from '@zeltjs/core/internal-bridge/errors';
+
+export type SessionConfigErrorReason = 'store_not_overridden' | 'missing_secret';
+
+const messages: Record<SessionConfigErrorReason, string> = {
+  store_not_overridden: 'SessionConfig.store must be overridden',
+  missing_secret: 'SESSION_SECRET environment variable is required',
+};
+
+export const ZeltSessionConfigError = defineError(
+  'ZeltSessionConfigError',
+  (ctx: { reason: SessionConfigErrorReason }) => messages[ctx.reason],
+);

--- a/packages/auth-session/src/index.ts
+++ b/packages/auth-session/src/index.ts
@@ -1,3 +1,4 @@
+export { type SessionConfigErrorReason, ZeltSessionConfigError } from './errors';
 export { SessionConfig } from './session.config';
 export {
   destroySession,

--- a/packages/auth-session/src/session.config.ts
+++ b/packages/auth-session/src/session.config.ts
@@ -1,12 +1,17 @@
 import { Config } from '@zeltjs/core';
 import type { KVStore } from '@zeltjs/kv';
 
+import { ZeltSessionConfigError } from './errors';
+
 @Config
 export class SessionConfig {
   static readonly Token = SessionConfig;
 
+  /**
+   * @throws {ZeltSessionConfigError} When store is not overridden
+   */
   get store(): KVStore {
-    throw new Error('SessionConfig.store must be overridden');
+    throw new ZeltSessionConfigError({ reason: 'store_not_overridden' });
   }
 
   get cookieName(): string {
@@ -17,10 +22,13 @@ export class SessionConfig {
     return 86400; // 24h
   }
 
+  /**
+   * @throws {ZeltSessionConfigError} When SESSION_SECRET is not set
+   */
   get secret(): string {
     const secret = process.env['SESSION_SECRET'];
     if (!secret) {
-      throw new Error('SESSION_SECRET environment variable is required');
+      throw new ZeltSessionConfigError({ reason: 'missing_secret' });
     }
     return secret;
   }

--- a/packages/auth-session/vitest.config.ts
+++ b/packages/auth-session/vitest.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
         __dirname,
         '../core/src/internal-bridge/testing.ts',
       ),
+      '@zeltjs/core/internal-bridge/errors': resolve(
+        __dirname,
+        '../core/src/internal-bridge/errors.ts',
+      ),
       '@zeltjs/core': resolve(__dirname, '../core/src/index.ts'),
       '@zeltjs/kv': resolve(__dirname, '../kv/src/index.ts'),
     },

--- a/packages/cli/src/builders/tsdown.ts
+++ b/packages/cli/src/builders/tsdown.ts
@@ -4,21 +4,12 @@ import { resolve } from 'node:path';
 import consola from 'consola';
 
 import type { BuildConfig } from '../config/schema';
+import { ZeltBuildError } from '../errors';
 
 export type BuildOptions = {
   readonly cwd: string;
   readonly config: BuildConfig;
 };
-
-export class BuildError extends Error {
-  readonly type = 'BUILD_FAILED' as const;
-  readonly exitCode: number;
-  constructor(exitCode: number) {
-    super(`Build failed with exit code ${exitCode}`);
-    this.name = 'BuildError';
-    this.exitCode = exitCode;
-  }
-}
 
 const buildArgs = (config: BuildConfig): string[] => {
   const args: string[] = [];
@@ -49,6 +40,7 @@ const buildArgs = (config: BuildConfig): string[] => {
   return args;
 };
 
+/** @throws {ZeltBuildError} */
 export const runTsdownBuild = async (options: BuildOptions): Promise<void> => {
   const { cwd, config } = options;
   const args = buildArgs(config);
@@ -74,6 +66,6 @@ export const runTsdownBuild = async (options: BuildOptions): Promise<void> => {
   });
 
   if (exitCode !== 0) {
-    throw new BuildError(exitCode);
+    throw new ZeltBuildError({ exitCode });
   }
 };

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -3,9 +3,16 @@ import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
 
-import { BuildError, runTsdownBuild } from '../builders/tsdown';
-import { ConfigLoadError, loadZeltConfig } from '../config/loader';
+import { runTsdownBuild } from '../builders/tsdown';
+import { loadZeltConfig } from '../config/loader';
 import type { BuildConfig } from '../config/schema';
+import type { ZeltBuildError, ZeltConfigLoadError } from '../errors';
+import {
+  isZeltBuildError,
+  isZeltConfigLoadError,
+  isZeltNoEntryError,
+  ZeltNoEntryError,
+} from '../errors';
 
 const cliConfig = new NodeCliConfig();
 
@@ -15,11 +22,10 @@ type BuildArgs = {
   readonly outDir?: string;
 };
 
-class NoEntryError extends Error {
-  readonly type = 'NO_ENTRY' as const;
-}
-
-type RunBuildError = ConfigLoadError | BuildError | NoEntryError;
+type RunBuildError =
+  | InstanceType<typeof ZeltConfigLoadError>
+  | InstanceType<typeof ZeltBuildError>
+  | InstanceType<typeof ZeltNoEntryError>;
 
 const resolveBuildConfig = (args: BuildArgs, buildConfig: BuildConfig | undefined) => ({
   ...buildConfig,
@@ -27,13 +33,14 @@ const resolveBuildConfig = (args: BuildArgs, buildConfig: BuildConfig | undefine
   outDir: args.outDir ?? buildConfig?.outDir,
 });
 
+/** @throws {ZeltConfigLoadError | ZeltBuildError | ZeltNoEntryError | InvalidConfigExportError} */
 const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
   const configFile = typedArgs.config;
   const config = await loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd });
   const buildConfig = resolveBuildConfig(typedArgs, config.build);
 
   if (buildConfig.entry === undefined) {
-    throw new NoEntryError();
+    throw new ZeltNoEntryError({});
   }
 
   consola.start('Building...');
@@ -43,16 +50,16 @@ const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
 
 const handleError = (error: RunBuildError): void => {
   match(error)
-    .with({ type: 'CONFIG_LOAD_FAILED' }, () => {
+    .when(isZeltConfigLoadError, () => {
       consola.error('Failed to load config');
     })
-    .with({ type: 'NO_ENTRY' }, () => {
+    .when(isZeltNoEntryError, () => {
       consola.error('No entry file specified. Use --entry or set build.entry in zelt.config.ts');
     })
-    .with({ type: 'BUILD_FAILED' }, () => {
+    .when(isZeltBuildError, () => {
       consola.error('Build failed');
     })
-    .exhaustive();
+    .otherwise(() => {});
 };
 
 export const buildCommand = defineCommand({
@@ -84,11 +91,7 @@ export const buildCommand = defineCommand({
     try {
       await runBuild(cwd, typedArgs);
     } catch (error) {
-      if (
-        error instanceof ConfigLoadError ||
-        error instanceof BuildError ||
-        error instanceof NoEntryError
-      ) {
+      if (isZeltConfigLoadError(error) || isZeltBuildError(error) || isZeltNoEntryError(error)) {
         handleError(error);
       } else {
         throw error;

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -3,9 +3,11 @@ import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
 
-import { ConfigLoadError, loadZeltConfig } from '../config/loader';
+import { loadZeltConfig } from '../config/loader';
 import type { DevConfig } from '../config/schema';
 import { startDevServer } from '../dev-server/server';
+import type { ZeltConfigLoadError } from '../errors';
+import { isZeltConfigLoadError, isZeltNoEntryError, ZeltNoEntryError } from '../errors';
 
 const cliConfig = new NodeCliConfig();
 
@@ -15,11 +17,7 @@ type DevArgs = {
   readonly port?: string;
 };
 
-class NoEntryError extends Error {
-  readonly type = 'NO_ENTRY' as const;
-}
-
-type DevError = ConfigLoadError | NoEntryError;
+type DevError = InstanceType<typeof ZeltConfigLoadError> | InstanceType<typeof ZeltNoEntryError>;
 
 const resolveDevConfig = (args: DevArgs, devConfig: DevConfig | undefined) => {
   const entry = args.entry ?? devConfig?.entry;
@@ -32,13 +30,14 @@ const resolveDevConfig = (args: DevArgs, devConfig: DevConfig | undefined) => {
   };
 };
 
+/** @throws {ZeltConfigLoadError | ZeltNoEntryError | InvalidConfigExportError} */
 const runDev = async (cwd: string, typedArgs: DevArgs): Promise<void> => {
   const configFile = typedArgs.config;
   const config = await loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd });
   const devConfig = resolveDevConfig(typedArgs, config.dev);
 
   if (devConfig.entry === undefined) {
-    throw new NoEntryError();
+    throw new ZeltNoEntryError({});
   }
 
   await startDevServer({ cwd, config: { ...devConfig, entry: devConfig.entry } });
@@ -46,13 +45,13 @@ const runDev = async (cwd: string, typedArgs: DevArgs): Promise<void> => {
 
 const handleError = (error: DevError): void => {
   match(error)
-    .with({ type: 'CONFIG_LOAD_FAILED' }, () => {
+    .when(isZeltConfigLoadError, () => {
       consola.error('Failed to load config');
     })
-    .with({ type: 'NO_ENTRY' }, () => {
+    .when(isZeltNoEntryError, () => {
       consola.error('No entry file specified. Use --entry or set dev.entry in zelt.config.ts');
     })
-    .exhaustive();
+    .otherwise(() => {});
 };
 
 export const devCommand = defineCommand({
@@ -84,7 +83,7 @@ export const devCommand = defineCommand({
     try {
       await runDev(cwd, typedArgs);
     } catch (error) {
-      if (error instanceof ConfigLoadError || error instanceof NoEntryError) {
+      if (isZeltConfigLoadError(error) || isZeltNoEntryError(error)) {
         handleError(error);
       } else {
         throw error;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -5,26 +5,23 @@ import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
 
-import { ConfigLoadError, loadZeltConfig } from '../config/loader';
+import { loadZeltConfig } from '../config/loader';
 import type { CliConfig } from '../config/schema';
+import type { ZeltConfigLoadError } from '../errors';
+import {
+  isZeltCliExecutionError,
+  isZeltConfigLoadError,
+  isZeltNoCliEntryError,
+  ZeltCliExecutionError,
+  ZeltNoCliEntryError,
+} from '../errors';
 
 const cliConfig = new NodeCliConfig();
 
-class NoCliEntryError extends Error {
-  readonly type = 'NO_CLI_ENTRY' as const;
-}
-
-class CliExecutionError extends Error {
-  readonly type = 'CLI_EXECUTION_FAILED' as const;
-  readonly exitCode: number;
-  constructor(exitCode: number) {
-    super(`CLI execution failed with exit code ${exitCode}`);
-    this.name = 'CliExecutionError';
-    this.exitCode = exitCode;
-  }
-}
-
-type RunError = ConfigLoadError | NoCliEntryError | CliExecutionError;
+type RunError =
+  | InstanceType<typeof ZeltConfigLoadError>
+  | InstanceType<typeof ZeltNoCliEntryError>
+  | InstanceType<typeof ZeltCliExecutionError>;
 
 const resolveCliConfig = (cliConfigFromFile: CliConfig | undefined) => ({
   entry: cliConfigFromFile?.entry,
@@ -42,7 +39,7 @@ const executeCliEntry = (cwd: string, entry: string, args: readonly string[]): P
       if (code === 0 || code === null) {
         resolve();
       } else {
-        reject(new CliExecutionError(code));
+        reject(new ZeltCliExecutionError({ exitCode: code }));
       }
     });
 
@@ -51,6 +48,7 @@ const executeCliEntry = (cwd: string, entry: string, args: readonly string[]): P
     });
   });
 
+/** @throws {ZeltConfigLoadError | ZeltNoCliEntryError | InvalidConfigExportError} */
 const runCli = async (
   cwd: string,
   configFile: string | undefined,
@@ -60,7 +58,7 @@ const runCli = async (
   const cliConf = resolveCliConfig(config.cli);
 
   if (cliConf.entry === undefined) {
-    throw new NoCliEntryError();
+    throw new ZeltNoCliEntryError({});
   }
 
   await executeCliEntry(cwd, cliConf.entry, args);
@@ -68,22 +66,20 @@ const runCli = async (
 
 const handleError = (error: RunError, setExitCode: (code: number) => void): void => {
   match(error)
-    .with({ type: 'CONFIG_LOAD_FAILED' }, () => {
+    .when(isZeltConfigLoadError, () => {
       consola.error('Failed to load config');
     })
-    .with({ type: 'NO_CLI_ENTRY' }, () => {
+    .when(isZeltNoCliEntryError, () => {
       consola.error('No CLI entry specified. Set cli.entry in zelt.config.ts');
     })
-    .with({ type: 'CLI_EXECUTION_FAILED' }, (e) => {
-      setExitCode(e.exitCode);
+    .when(isZeltCliExecutionError, (e) => {
+      setExitCode(e.context.exitCode);
     })
-    .exhaustive();
+    .otherwise(() => {});
 };
 
-const runErrorClasses = [ConfigLoadError, NoCliEntryError, CliExecutionError] as const;
-
 const isRunError = (error: unknown): error is RunError =>
-  runErrorClasses.some((ErrorClass) => error instanceof ErrorClass);
+  isZeltConfigLoadError(error) || isZeltNoCliEntryError(error) || isZeltCliExecutionError(error);
 
 export const runCommandDef = defineCommand({
   meta: {

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,3 +1,4 @@
+export { isZeltConfigLoadError, ZeltConfigLoadError } from '../errors';
 export { defineConfig } from './define-config';
-export { ConfigLoadError, type LoadConfigOptions, loadZeltConfig } from './loader';
+export { type LoadConfigOptions, loadZeltConfig } from './loader';
 export type { BuildConfig, DevConfig, OpenApiConfig, ZeltConfig } from './schema';

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -1,20 +1,12 @@
 import { loadConfig } from 'c12';
 
+import { ZeltConfigLoadError } from '../errors';
 import type { ZeltConfig } from './schema';
 
 export type LoadConfigOptions = {
   readonly cwd?: string;
   readonly configFile?: string;
 };
-
-export class ConfigLoadError extends Error {
-  readonly type = 'CONFIG_LOAD_FAILED' as const;
-  constructor(cause?: unknown) {
-    super('Failed to load config');
-    this.name = 'ConfigLoadError';
-    this.cause = cause;
-  }
-}
 
 const DEFAULT_BUILD_CONFIG = {
   outDir: './dist',
@@ -28,6 +20,7 @@ const DEFAULT_DEV_CONFIG = {
   debounceMs: 300,
 } as const;
 
+/** @throws {ZeltConfigLoadError} */
 export const loadZeltConfig = async (options: LoadConfigOptions = {}): Promise<ZeltConfig> => {
   const c12Options: Parameters<typeof loadConfig<ZeltConfig>>[0] = {
     name: 'zelt',
@@ -48,6 +41,6 @@ export const loadZeltConfig = async (options: LoadConfigOptions = {}): Promise<Z
     const result = await loadConfig<ZeltConfig>(c12Options);
     return result.config;
   } catch (cause) {
-    throw new ConfigLoadError(cause);
+    throw new ZeltConfigLoadError({}, cause);
   }
 };

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,41 @@
+import { defineError } from '@zeltjs/core/internal-bridge/errors';
+
+export const ZeltConfigLoadError = defineError(
+  'ZeltConfigLoadError',
+  () => 'Failed to load config',
+);
+
+export const ZeltBuildError = defineError(
+  'ZeltBuildError',
+  (ctx: { exitCode: number }) => `Build failed with exit code ${ctx.exitCode}`,
+);
+
+export const ZeltNoEntryError = defineError('ZeltNoEntryError', () => 'No entry file specified');
+
+export const ZeltNoCliEntryError = defineError(
+  'ZeltNoCliEntryError',
+  () => 'No CLI entry specified',
+);
+
+export const ZeltCliExecutionError = defineError(
+  'ZeltCliExecutionError',
+  (ctx: { exitCode: number }) => `CLI execution failed with exit code ${ctx.exitCode}`,
+);
+
+export const isZeltConfigLoadError = (
+  err: unknown,
+): err is InstanceType<typeof ZeltConfigLoadError> => err instanceof ZeltConfigLoadError;
+
+export const isZeltBuildError = (err: unknown): err is InstanceType<typeof ZeltBuildError> =>
+  err instanceof ZeltBuildError;
+
+export const isZeltNoEntryError = (err: unknown): err is InstanceType<typeof ZeltNoEntryError> =>
+  err instanceof ZeltNoEntryError;
+
+export const isZeltNoCliEntryError = (
+  err: unknown,
+): err is InstanceType<typeof ZeltNoCliEntryError> => err instanceof ZeltNoCliEntryError;
+
+export const isZeltCliExecutionError = (
+  err: unknown,
+): err is InstanceType<typeof ZeltCliExecutionError> => err instanceof ZeltCliExecutionError;

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -17,6 +17,10 @@ export default mergeConfig(
           __dirname,
           '../core/src/internal-bridge/testing.ts',
         ),
+        '@zeltjs/core/internal-bridge/errors': path.resolve(
+          __dirname,
+          '../core/src/internal-bridge/errors.ts',
+        ),
         '@zeltjs/core': path.resolve(__dirname, '../core/src/index.ts'),
       },
     },

--- a/packages/contract/src/cli.ts
+++ b/packages/contract/src/cli.ts
@@ -7,7 +7,7 @@ import { cliError, cliPrint } from './cli-output';
 import type { GenerateClientOptions } from './config/options';
 import type { ConfigError, ContractError } from './errors';
 import { generateClient } from './generate-client';
-import { findConfigFile, isLoadConfigError, loadConfig } from './load-config';
+import { findConfigFile, isZeltLoadConfigError, loadConfig } from './load-config';
 import { watchClient } from './watch';
 
 const cliConfig = new NodeCliConfig();
@@ -92,6 +92,7 @@ const formatError = (error: ContractError): string =>
 const isContractError = (error: unknown): error is ContractError =>
   typeof error === 'object' && error !== null && 'type' in error;
 
+/** @throws {ZeltInvalidConfigExportError} */
 const resolveConfig = async (
   configPath: string | undefined,
 ): Promise<GenerateClientOptions | ConfigError> => {
@@ -103,8 +104,8 @@ const resolveConfig = async (
   try {
     return await loadConfig(cfgPath, cliConfig);
   } catch (error) {
-    if (isLoadConfigError(error)) {
-      return error;
+    if (isZeltLoadConfigError(error)) {
+      return { type: 'INVALID_CONFIG_EXPORT', path: error.context.path };
     }
     throw error;
   }
@@ -113,6 +114,7 @@ const resolveConfig = async (
 const isConfigError = (result: GenerateClientOptions | ConfigError): result is ConfigError =>
   'type' in result;
 
+/** @throws {ContractError | ZeltInvalidConfigExportError} */
 const buildAction = async (opts: { config?: string }): Promise<void> => {
   const configOrError = await resolveConfig(opts.config);
   if (isConfigError(configOrError)) {
@@ -134,6 +136,7 @@ const buildAction = async (opts: { config?: string }): Promise<void> => {
   }
 };
 
+/** @throws {ContractError | ZeltInvalidConfigExportError} */
 const watchAction = async (opts: { config?: string }): Promise<void> => {
   const configOrError = await resolveConfig(opts.config);
   if (isConfigError(configOrError)) {

--- a/packages/contract/src/generate-client.ts
+++ b/packages/contract/src/generate-client.ts
@@ -24,6 +24,7 @@ export type GenerateClientResult = {
   readonly openApiChanged: boolean;
 };
 
+/** @throws {ContractError | AnalyzerError} */
 export const generateClient = async (
   options: GenerateClientOptions,
 ): Promise<GenerateClientResult> => {

--- a/packages/contract/src/load-config.ts
+++ b/packages/contract/src/load-config.ts
@@ -4,8 +4,8 @@ import { isAbsolute, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import type { CliConfig } from '@zeltjs/core';
+import { defineError } from '@zeltjs/core/internal-bridge/errors';
 import type { GenerateClientOptions } from './config/options';
-import type { ConfigError } from './errors';
 
 const DEFAULT_CONFIG_NAMES = [
   'zelt.config.ts',
@@ -33,16 +33,12 @@ function narrowConfig(value: unknown): unknown {
   return value;
 }
 
-class InvalidConfigExportError extends Error {
-  readonly type = 'INVALID_CONFIG_EXPORT' as const;
-  readonly path: string;
-  constructor(path: string) {
-    super(`Invalid config export: ${path}`);
-    this.name = 'InvalidConfigExportError';
-    this.path = path;
-  }
-}
+const ZeltInvalidConfigExportError = defineError(
+  'ZeltInvalidConfigExportError',
+  (ctx: { path: string }) => `Invalid config export: ${ctx.path}`,
+);
 
+/** @throws {ZeltInvalidConfigExportError} */
 export const loadConfig = async (
   path: string,
   cliConfig: CliConfig,
@@ -54,22 +50,24 @@ export const loadConfig = async (
   try {
     mod = await import(url);
   } catch {
-    throw new InvalidConfigExportError(path);
+    throw new ZeltInvalidConfigExportError({ path });
   }
 
   if (typeof mod !== 'object' || mod === null) {
-    throw new InvalidConfigExportError(path);
+    throw new ZeltInvalidConfigExportError({ path });
   }
 
   const namespace: Record<string, unknown> = { ...mod };
   const defaultKey = 'default';
   const cfg = namespace[defaultKey];
   if (cfg === undefined) {
-    throw new InvalidConfigExportError(path);
+    throw new ZeltInvalidConfigExportError({ path });
   }
 
   return narrowConfig(cfg);
 };
 
-export const isLoadConfigError = (error: unknown): error is ConfigError =>
-  error instanceof InvalidConfigExportError;
+export const isZeltLoadConfigError = (
+  error: unknown,
+): error is InstanceType<typeof ZeltInvalidConfigExportError> =>
+  error instanceof ZeltInvalidConfigExportError;

--- a/packages/contract/src/test/fixtures/validated.ts
+++ b/packages/contract/src/test/fixtures/validated.ts
@@ -1,14 +1,17 @@
 import type { ValidatedMarker, ValidationTarget } from '@zeltjs/core';
 import type { GenericSchema, InferOutput } from 'valibot';
 
+/** @throws {Error} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target?: 'json',
 ): ValidatedMarker<InferOutput<Schema>, 'json'>;
+/** @throws {Error} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target: 'form',
 ): ValidatedMarker<InferOutput<Schema>, 'form'>;
+/** @throws {Error} */
 export function validated<Schema extends GenericSchema>(
   _schema: Schema,
   _target: ValidationTarget = 'json',

--- a/packages/contract/src/watch.ts
+++ b/packages/contract/src/watch.ts
@@ -60,6 +60,7 @@ const formatError = (error: ContractError): string =>
 const isContractError = (error: unknown): error is ContractError =>
   typeof error === 'object' && error !== null && 'type' in error;
 
+/** @throws {ContractError} */
 export const watchClient = async (options: GenerateClientOptions): Promise<() => Promise<void>> => {
   const watchedPaths = fg.sync([...options.controllers], { absolute: true });
 

--- a/packages/contract/vitest.config.ts
+++ b/packages/contract/vitest.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { sharedConfig } from '../../vitest.shared';
 
@@ -8,8 +9,16 @@ export default mergeConfig(
       name: '@zeltjs/openapi',
       include: ['src/**/*.test.ts'],
       passWithNoTests: true,
-      // ts-morph project boot + emit pipelines are heavy; default 5s is tight under parallel load.
       testTimeout: 30_000,
+    },
+    resolve: {
+      alias: {
+        '@zeltjs/core/internal-bridge/errors': resolve(
+          __dirname,
+          '../core/src/internal-bridge/errors.ts',
+        ),
+        '@zeltjs/core': resolve(__dirname, '../core/src/index.ts'),
+      },
     },
   }),
 );

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,10 @@
     "./internal-bridge/testing": {
       "types": "./dist/internal-bridge/testing.d.ts",
       "import": "./dist/internal-bridge/testing.js"
+    },
+    "./internal-bridge/errors": {
+      "types": "./dist/internal-bridge/errors.d.ts",
+      "import": "./dist/internal-bridge/errors.js"
     }
   },
   "files": [

--- a/packages/core/src/app/create-app.ts
+++ b/packages/core/src/app/create-app.ts
@@ -72,6 +72,7 @@ type AppState = {
   disposed: boolean;
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const createReadyResult = (context: ReadyContext): ReadyResult => ({
   get: <T extends object>(cls: new (...args: never[]) => T): T => context.resolver.get(cls),
   getConfig: <T extends object>(configClass: ConfigClass<T>): T =>
@@ -133,6 +134,7 @@ type ReadyDeps = {
   configs: readonly ConfigClass<object>[];
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const createReady =
   (deps: ReadyDeps) =>
   async (readyOptions?: ReadyOptions): Promise<ReadyResult> => {
@@ -183,6 +185,7 @@ const createShutdown = (deps: ShutdownDeps) => async (): Promise<void> => {
 };
 
 const createSchedulerMethods = (schedulerModule: SchedulerModule): SchedulerCapabilities => {
+  /** @throws {ZeltLifecycleStateError} */
   const startScheduler = async (): Promise<void> => {
     const runner = schedulerModule.getRunner();
     if (runner && !runner.isRunning()) {
@@ -200,6 +203,7 @@ const createSchedulerMethods = (schedulerModule: SchedulerModule): SchedulerCapa
   return { startScheduler, stopScheduler };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const buildAppObject = (
   appModules: AppModules,
   state: AppState,
@@ -229,7 +233,9 @@ const buildAppObject = (
   return { ...baseApp, ...httpMethods, ...commandMethods, ...schedulerMethods };
 };
 
+/** @throws {ZeltAppConfigurationError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export function createApp<TOptions extends CreateAppOptions>(options: TOptions): App<TOptions>;
+/** @throws {ZeltAppConfigurationError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export function createApp(options: CreateAppOptions): App<CreateAppOptions> {
   if (!options.http && !options.commands?.length) {
     throw new ZeltAppConfigurationError({ reason: 'no_http_or_commands' });

--- a/packages/core/src/app/modules/command-module.ts
+++ b/packages/core/src/app/modules/command-module.ts
@@ -13,6 +13,7 @@ type CommandModuleState = {
   isDisposed: boolean;
 };
 
+/** @throws {ZeltAppConfigurationError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 const validateCommands = (commands: readonly CommandClass[]): Map<string, CommandClass> => {
   const commandMap = new Map<string, CommandClass>();
   for (const cls of commands) {
@@ -38,6 +39,7 @@ export const createCommandModule = (commands: readonly CommandClass[]): CommandM
     isDisposed: false,
   };
 
+  /** @throws {ZeltAppConfigurationError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
   const setup = (): void => {
     const validated = validateCommands(commands);
     for (const [name, cls] of validated) {

--- a/packages/core/src/app/modules/config-module.ts
+++ b/packages/core/src/app/modules/config-module.ts
@@ -25,12 +25,14 @@ const createState = (): ConfigModuleState => ({
   isDisposed: false,
 });
 
+/** @throws {ZeltLifecycleStateError} */
 const assertNotDisposed = (state: ConfigModuleState, operation: string): void => {
   if (state.isDisposed) {
     throw new ZeltLifecycleStateError({ operation, currentState: 'disposed' });
   }
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const assertNotReady = (state: ConfigModuleState, operation: string): void => {
   if (state.isReady) {
     throw new ZeltLifecycleStateError({ operation, currentState: 'ready' });
@@ -44,6 +46,7 @@ export const createConfigModule = (): ConfigModule => {
     // config module has no setup logic
   };
 
+  /** @throws {ZeltLifecycleStateError} */
   const ready = async (_context: ReadyContext): Promise<void> => {
     assertNotDisposed(state, 'ready');
     state.isReady = true;
@@ -53,12 +56,14 @@ export const createConfigModule = (): ConfigModule => {
     state.isDisposed = true;
   };
 
+  /** @throws {ZeltLifecycleStateError} */
   const addFallbackConfig = (config: ConfigClass<object>): void => {
     assertNotDisposed(state, 'addFallbackConfig');
     assertNotReady(state, 'addFallbackConfig');
     state.defaults.push(config);
   };
 
+  /** @throws {ZeltLifecycleStateError} */
   const overrideConfig = (config: ConfigClass<object>): void => {
     assertNotDisposed(state, 'overrideConfig');
     assertNotReady(state, 'overrideConfig');

--- a/packages/core/src/app/modules/http-module.ts
+++ b/packages/core/src/app/modules/http-module.ts
@@ -1,7 +1,11 @@
 import { Hono } from 'hono';
 import { match, P } from 'ts-pattern';
 import type { ResolverHandle } from '../../di/container';
-import { ZeltLifecycleStateError } from '../../errors';
+import {
+  ZeltContextNotAvailableError,
+  ZeltDecoratorUsageError,
+  ZeltLifecycleStateError,
+} from '../../errors';
 import { DefaultErrorHandler } from '../../http/default.error-handler';
 import { buildRoutes, warmupControllers } from '../../http/internal/route-builder';
 import type {
@@ -47,6 +51,7 @@ const createErrorHandler =
     );
   };
 
+/** @throws {ZeltLifecycleStateError} */
 const resolveErrorHandler = (
   cls: ErrorHandlerClass,
   resolver: ResolverHandle,
@@ -55,11 +60,13 @@ const resolveErrorHandler = (
   return instance;
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const resolveErrorHandlers = (
   classes: readonly ErrorHandlerClass[],
   resolver: ResolverHandle,
 ): ErrorHandlerInstance[] => classes.map((cls) => resolveErrorHandler(cls, resolver));
 
+/** @throws {ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 const setupHono = (
   httpOptions: HttpOptions,
   resolver: ResolverHandle,
@@ -79,56 +86,78 @@ const setupHono = (
   return hono;
 };
 
-type HttpResult = { hono: Hono } | { error: Error; cleanup: () => Promise<void> };
+type HttpModuleError =
+  | ZeltContextNotAvailableError
+  | ZeltDecoratorUsageError
+  | ZeltLifecycleStateError;
+type HttpResult = { hono: Hono } | { error: HttpModuleError; cleanup: () => Promise<void> };
 
-const toHttpError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)));
-
+/** @throws {HttpModuleError} */
 const initializeHttpSetup = (
   httpOptions: HttpOptions,
   resolver: ResolverHandle,
   lifecycle: LifecycleManager,
-): HttpResult =>
-  match(
-    (() => {
-      try {
-        return { hono: setupHono(httpOptions, resolver, lifecycle) };
-      } catch (e) {
-        return { error: toHttpError(e), cleanup: () => lifecycle.shutdown() };
-      }
-    })(),
-  )
-    .with({ hono: P._ }, (r) => r)
-    .with({ error: P._ }, (r) => r)
-    .exhaustive();
+): HttpResult => {
+  try {
+    return { hono: setupHono(httpOptions, resolver, lifecycle) };
+  } catch (e) {
+    if (e instanceof ZeltContextNotAvailableError) {
+      return { error: e, cleanup: () => lifecycle.shutdown() };
+    }
+    if (e instanceof ZeltDecoratorUsageError) {
+      return { error: e, cleanup: () => lifecycle.shutdown() };
+    }
+    if (e instanceof ZeltLifecycleStateError) {
+      return { error: e, cleanup: () => lifecycle.shutdown() };
+    }
+    throw e;
+  }
+};
 
+/** @throws {HttpModuleError} */
 const initializeHttpWarmup = async (
   httpOptions: HttpOptions,
   resolver: ResolverHandle,
   lifecycle: LifecycleManager,
-): Promise<HttpResult> =>
-  warmupControllers(httpOptions.controllers, resolver, lifecycle)
-    .then((): HttpResult => ({ hono: setupHono(httpOptions, resolver, lifecycle) }))
-    .catch((e): HttpResult => ({ error: toHttpError(e), cleanup: () => lifecycle.shutdown() }));
-
-const handleHttpSetupResult = async (result: HttpResult): Promise<Hono> =>
-  match(result)
-    .with({ hono: P._ }, (r) => r.hono)
-    .with({ error: P._ }, async (r) => {
-      await r.cleanup();
-      throw r.error;
-    })
-    .exhaustive();
-
-const handleHttpWarmupResult = async (result: HttpResult): Promise<void> => {
-  await match(result)
-    .with({ hono: P._ }, () => Promise.resolve())
-    .with({ error: P._ }, async (r) => {
-      await r.cleanup();
-      throw r.error;
-    })
-    .exhaustive();
+): Promise<HttpResult> => {
+  try {
+    await warmupControllers(httpOptions.controllers, resolver, lifecycle);
+    return { hono: setupHono(httpOptions, resolver, lifecycle) };
+  } catch (e) {
+    if (e instanceof ZeltContextNotAvailableError) {
+      return { error: e, cleanup: () => lifecycle.shutdown() };
+    }
+    if (e instanceof ZeltDecoratorUsageError) {
+      return { error: e, cleanup: () => lifecycle.shutdown() };
+    }
+    if (e instanceof ZeltLifecycleStateError) {
+      return { error: e, cleanup: () => lifecycle.shutdown() };
+    }
+    throw e;
+  }
 };
 
+/** @throws {HttpModuleError} */
+const handleHttpSetupResult = async (result: HttpResult): Promise<Hono> =>
+  match(result)
+    .with({ hono: P.select() }, (hono) => hono)
+    .with({ error: P._, cleanup: P._ }, async (r) => {
+      await r.cleanup();
+      throw r.error;
+    })
+    .exhaustive();
+
+/** @throws {HttpModuleError} */
+const handleHttpWarmupResult = async (result: HttpResult): Promise<void> =>
+  match(result)
+    .with({ hono: P._ }, () => undefined)
+    .with({ error: P._, cleanup: P._ }, async (r) => {
+      await r.cleanup();
+      throw r.error;
+    })
+    .exhaustive();
+
+/** @throws {HttpModuleError} */
 const initializeHttp = async (
   httpOptions: HttpOptions,
   resolver: ResolverHandle,
@@ -165,6 +194,7 @@ export const createHttpModule = (options: HttpOptions): HttpModule => {
     // http module has no sync setup logic
   };
 
+  /** @throws {HttpModuleError} */
   const ready = async (context: ReadyContext): Promise<void> => {
     state.hono = await initializeHttp(options, context.resolver, context.lifecycle, context.warmup);
     state.isReady = true;
@@ -174,6 +204,7 @@ export const createHttpModule = (options: HttpOptions): HttpModule => {
     state.isDisposed = true;
   };
 
+  /** @throws {ZeltLifecycleStateError} */
   const fetch = async (req: Request): Promise<Response> => {
     if (!state.hono) {
       throw new ZeltLifecycleStateError({ operation: 'fetch', currentState: 'not_ready' });

--- a/packages/core/src/command/command-context.ts
+++ b/packages/core/src/command/command-context.ts
@@ -11,6 +11,7 @@ const storage = new AsyncLocalStorage<CommandContextStore>();
 export const runInCommandContext = <T>(ctx: CommandContextStore, fn: () => T): T =>
   storage.run(ctx, fn);
 
+/** @throws {ZeltContextNotAvailableError} */
 export const getCommandContext = (): CommandContextStore => {
   const ctx = storage.getStore();
   if (!ctx) {

--- a/packages/core/src/command/metadata.ts
+++ b/packages/core/src/command/metadata.ts
@@ -9,5 +9,6 @@ export const setCommandMetadata = (cls: object, meta: CommandMetadata): void => 
   commandStore.set(cls, meta);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getCommandMetadata = (cls: object): CommandMetadata | undefined =>
   commandStore.get(cls);

--- a/packages/core/src/command/primitives/args.ts
+++ b/packages/core/src/command/primitives/args.ts
@@ -3,6 +3,7 @@ import type { InferSchema, SchemaDefinition } from '../schema';
 
 type CommandWithSchema = { schema: SchemaDefinition };
 
+/** @throws {ZeltContextNotAvailableError} */
 export const args = <T extends CommandWithSchema>(_commandClass: T): InferSchema<T['schema']> => {
   const ctx = getCommandContext();
   const result: InferSchema<T['schema']> = ctx.parsedArgs as InferSchema<T['schema']>;

--- a/packages/core/src/config/token.ts
+++ b/packages/core/src/config/token.ts
@@ -7,6 +7,7 @@ type AnyConfigClass = new (...args: never[]) => unknown;
 
 export { registerAsLeaf as registerConfigClass };
 
+/** @throws {ZeltLifecycleStateError} */
 export const overrideConfig = (
   container: ContainerType,
   config: AnyConfigClass,
@@ -15,10 +16,12 @@ export const overrideConfig = (
   overrideLeaf(container, config, options);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const resolveConfig = (container: ContainerType, config: AnyConfigClass): void => {
   resolveLeaf(container, config);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getConfig = <T extends object>(
   container: ContainerType,
   configClass: ConfigClass<T>,

--- a/packages/core/src/di/container.ts
+++ b/packages/core/src/di/container.ts
@@ -18,6 +18,7 @@ export type ResolverHandle = {
   readonly getConfig: <T extends object>(configClass: ConfigClass<T>) => T;
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const bindConfigs = (
   container: Container,
   configs: readonly Class<unknown>[],
@@ -28,12 +29,14 @@ const bindConfigs = (
   }
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const resolveConfigs = (container: Container, configs: readonly Class<unknown>[]): void => {
   for (const configClass of configs) {
     resolveConfig(container, configClass);
   }
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const createContainer = (options: CreateContainerOptions = {}): ResolverHandle => {
   const container = new Container();
   const configs = options.configs ?? [];
@@ -72,6 +75,7 @@ const bindOverrides = (container: Container, overrides: readonly Override<unknow
   }
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const createTestTargetBase = async <T extends object>(
   targetClass: Class<T>,
   options: CreateTestTargetOptions = {},
@@ -104,6 +108,7 @@ export const createTestTargetBase = async <T extends object>(
     await lifecycle.shutdown();
   };
 
+  /** @throws {ZeltLifecycleStateError} */
   const get = <U extends object>(cls: Class<U>): U => {
     if (disposed) {
       throw new ZeltLifecycleStateError({ operation: 'get', currentState: 'disposed' });

--- a/packages/core/src/di/inject.ts
+++ b/packages/core/src/di/inject.ts
@@ -8,6 +8,7 @@ const isClassToken = <T>(token: Token<T>): boolean =>
 
 const needleInject: typeof InjectFn = inject;
 
+/** @throws {ZeltLifecycleStateError} */
 function unifiedInject<T>(token: InjectionToken<T>): T;
 function unifiedInject<T>(token: Token<T>): T;
 function unifiedInject<T>(token: Token<T>, options: { multi: true }): T[];
@@ -26,6 +27,7 @@ function unifiedInject<T>(
   token: Token<T>,
   options: { lazy: true; multi: true; optional: true },
 ): () => T[] | undefined;
+/** @throws {ZeltLifecycleStateError} */
 function unifiedInject<T>(
   token: Token<T>,
   options?: { multi?: boolean; optional?: boolean; lazy?: boolean },

--- a/packages/core/src/di/leaf.ts
+++ b/packages/core/src/di/leaf.ts
@@ -30,6 +30,7 @@ export const registerAsLeaf = (cls: AnyClass): void => {
   leafCategoryCache.set(cls, 'direct');
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const isLeafClass = (cls: AnyClass): boolean => {
   const cached = leafCategoryCache.get(cls);
   if (cached !== undefined) return true;
@@ -65,6 +66,7 @@ export const findRootLeafClass = (cls: AnyClass): RootLeafClass => {
   return toRootLeafClass(root);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const getLeafToken = (rootClass: RootLeafClass): LeafInjectionToken => {
   const existing = leafTokenMap.get(rootClass);
   if (existing) return existing;
@@ -74,9 +76,11 @@ const getLeafToken = (rootClass: RootLeafClass): LeafInjectionToken => {
   return token;
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const isTokenBound = (container: ContainerType, token: LeafInjectionToken): boolean =>
   boundTokens.get(container)?.has(token) ?? false;
 
+/** @throws {ZeltLifecycleStateError} */
 const markTokenBound = (container: ContainerType, token: LeafInjectionToken): void => {
   const existing = boundTokens.get(container);
   if (existing) {
@@ -86,6 +90,7 @@ const markTokenBound = (container: ContainerType, token: LeafInjectionToken): vo
   boundTokens.set(container, new Set([token]));
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const bindLeafInternal = (
   container: ContainerType,
   token: LeafInjectionToken,
@@ -101,6 +106,7 @@ const bindLeafInternal = (
   markTokenBound(container, token);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const overrideLeaf = (
   container: ContainerType,
   cls: AnyClass,
@@ -120,6 +126,7 @@ export const overrideLeaf = (
   }
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const ensureLeafBound = (container: ContainerType, cls: AnyClass): LeafInjectionToken => {
   const rootClass = findRootLeafClass(cls);
   const token = getLeafToken(rootClass);
@@ -131,6 +138,7 @@ export const ensureLeafBound = (container: ContainerType, cls: AnyClass): LeafIn
   return token;
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getLeaf = <T extends object>(
   container: ContainerType,
   cls: new (...args: never[]) => T,

--- a/packages/core/src/errors/classes.ts
+++ b/packages/core/src/errors/classes.ts
@@ -1,9 +1,25 @@
 import { createErrorClass } from './factory';
 
 export const ZeltDecoratorUsageError = createErrorClass('ZeltDecoratorUsageError');
+export type ZeltDecoratorUsageError = InstanceType<typeof ZeltDecoratorUsageError>;
+
 export const ZeltLifecycleStateError = createErrorClass('ZeltLifecycleStateError');
+export type ZeltLifecycleStateError = InstanceType<typeof ZeltLifecycleStateError>;
+
 export const ZeltContextNotAvailableError = createErrorClass('ZeltContextNotAvailableError');
+export type ZeltContextNotAvailableError = InstanceType<typeof ZeltContextNotAvailableError>;
+
 export const ZeltAppConfigurationError = createErrorClass('ZeltAppConfigurationError');
+export type ZeltAppConfigurationError = InstanceType<typeof ZeltAppConfigurationError>;
+
 export const ZeltRouteConfigurationError = createErrorClass('ZeltRouteConfigurationError');
+export type ZeltRouteConfigurationError = InstanceType<typeof ZeltRouteConfigurationError>;
+
 export const ZeltMiddlewareExecutionError = createErrorClass('ZeltMiddlewareExecutionError');
+export type ZeltMiddlewareExecutionError = InstanceType<typeof ZeltMiddlewareExecutionError>;
+
 export const ZeltNotImplementedError = createErrorClass('ZeltNotImplementedError');
+export type ZeltNotImplementedError = InstanceType<typeof ZeltNotImplementedError>;
+
+export const ZeltSchemaValidationError = createErrorClass('ZeltSchemaValidationError');
+export type ZeltSchemaValidationError = InstanceType<typeof ZeltSchemaValidationError>;

--- a/packages/core/src/errors/define-error.test.ts
+++ b/packages/core/src/errors/define-error.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { defineError } from './define-error';
+
+describe('defineError', () => {
+  it('creates error class with correct name', () => {
+    const TestError = defineError('TestError', () => 'test message');
+    const err = new TestError({});
+    expect(err.name).toBe('TestError');
+  });
+
+  it('formats message using context', () => {
+    const TestError = defineError('TestError', (ctx: { id: number }) => `ID: ${ctx.id}`);
+    const err = new TestError({ id: 42 });
+    expect(err.message).toBe('ID: 42');
+  });
+
+  it('supports error cause', () => {
+    const TestError = defineError('TestError', () => 'wrapped');
+    const cause = new Error('original');
+    const err = new TestError({}, cause);
+    expect(err.cause).toBe(cause);
+  });
+
+  it('works with instanceof', () => {
+    const TestError = defineError('TestError', () => 'test');
+    const err = new TestError({});
+    expect(err instanceof TestError).toBe(true);
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it('exposes context property', () => {
+    const TestError = defineError('TestError', (ctx: { foo: string }) => ctx.foo);
+    const err = new TestError({ foo: 'bar' });
+    expect(err.context).toEqual({ foo: 'bar' });
+  });
+
+  it('creates distinct error classes for different names', () => {
+    const ErrorA = defineError('ErrorA', () => 'A');
+    const ErrorB = defineError('ErrorB', () => 'B');
+    const errA = new ErrorA({});
+    const errB = new ErrorB({});
+    expect(errA instanceof ErrorA).toBe(true);
+    expect(errA instanceof ErrorB).toBe(false);
+    expect(errB instanceof ErrorB).toBe(true);
+    expect(errB instanceof ErrorA).toBe(false);
+  });
+});

--- a/packages/core/src/errors/define-error.ts
+++ b/packages/core/src/errors/define-error.ts
@@ -1,0 +1,25 @@
+type ErrorClass<TCtx> = {
+  new (
+    context: TCtx,
+    cause?: unknown,
+  ): Error & {
+    readonly name: string;
+    readonly context: TCtx;
+  };
+};
+
+export const defineError = <TCtx>(
+  name: string,
+  messageFormatter: (ctx: TCtx) => string,
+): ErrorClass<TCtx> => {
+  return class extends Error {
+    override readonly name = name;
+    constructor(
+      public readonly context: TCtx,
+      cause?: unknown,
+    ) {
+      super(messageFormatter(context), { cause });
+      Object.setPrototypeOf(this, new.target.prototype);
+    }
+  } as ErrorClass<TCtx>;
+};

--- a/packages/core/src/errors/define-http-exception.test.ts
+++ b/packages/core/src/errors/define-http-exception.test.ts
@@ -1,0 +1,95 @@
+import { HTTPException } from 'hono/http-exception';
+import { describe, expect, it } from 'vitest';
+
+import { defineHttpException } from './define-http-exception';
+
+describe('defineHttpException', () => {
+  it('creates HTTPException subclass with correct name', () => {
+    const TestException = defineHttpException('TestException', 400, () => 'bad');
+    const err = new TestException({});
+    expect(err.name).toBe('TestException');
+  });
+
+  it('uses default status code', () => {
+    const TestException = defineHttpException('TestException', 429, () => 'limited');
+    const err = new TestException({});
+    expect(err.status).toBe(429);
+  });
+
+  it('allows status override', () => {
+    const TestException = defineHttpException('TestException', 429, () => 'limited');
+    const err = new TestException({}, { status: 503 });
+    expect(err.status).toBe(503);
+  });
+
+  it('works with instanceof HTTPException', () => {
+    const TestException = defineHttpException('TestException', 400, () => 'bad');
+    const err = new TestException({});
+    expect(err instanceof TestException).toBe(true);
+    expect(err instanceof HTTPException).toBe(true);
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it('exposes context property', () => {
+    const TestException = defineHttpException(
+      'TestException',
+      429,
+      (ctx: { limit: number }) => `Limit: ${ctx.limit}`,
+    );
+    const err = new TestException({ limit: 100 });
+    expect(err.context).toEqual({ limit: 100 });
+  });
+
+  it('formats message using context', () => {
+    const TestException = defineHttpException(
+      'TestException',
+      400,
+      (ctx: { field: string }) => `Invalid field: ${ctx.field}`,
+    );
+    const err = new TestException({ field: 'email' });
+    expect(err.message).toBe('Invalid field: email');
+  });
+
+  it('supports error cause', () => {
+    const TestException = defineHttpException('TestException', 500, () => 'wrapped');
+    const cause = new Error('original');
+    const err = new TestException({}, { cause });
+    expect(err.cause).toBe(cause);
+  });
+
+  it('builds response with custom body and headers', async () => {
+    const TestException = defineHttpException(
+      'TestException',
+      429,
+      (ctx: { retryAfter: number }) => `Retry after ${ctx.retryAfter}s`,
+      {
+        buildResponse: (ctx, status, message) =>
+          Response.json(
+            { code: 'RATE_LIMITED', message, retryAfterSec: ctx.retryAfter },
+            {
+              status,
+              headers: { 'Retry-After': String(ctx.retryAfter) },
+            },
+          ),
+      },
+    );
+    const err = new TestException({ retryAfter: 60 });
+    const res = err.getResponse();
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('60');
+    const body = await res.json();
+    expect(body.code).toBe('RATE_LIMITED');
+    expect(body.retryAfterSec).toBe(60);
+  });
+
+  it('creates distinct exception classes for different names', () => {
+    const ExceptionA = defineHttpException('ExceptionA', 400, () => 'A');
+    const ExceptionB = defineHttpException('ExceptionB', 401, () => 'B');
+    const errA = new ExceptionA({});
+    const errB = new ExceptionB({});
+    expect(errA instanceof ExceptionA).toBe(true);
+    expect(errA instanceof ExceptionB).toBe(false);
+    expect(errB instanceof ExceptionB).toBe(true);
+    expect(errB instanceof ExceptionA).toBe(false);
+  });
+});

--- a/packages/core/src/errors/define-http-exception.ts
+++ b/packages/core/src/errors/define-http-exception.ts
@@ -1,0 +1,45 @@
+import { HTTPException } from 'hono/http-exception';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
+
+type HttpExceptionOptions<TCtx> = {
+  buildResponse?: (ctx: TCtx, status: ContentfulStatusCode, message: string) => Response;
+};
+
+type HttpExceptionClass<TCtx> = {
+  new (
+    context: TCtx,
+    options?: { status?: ContentfulStatusCode; cause?: unknown },
+  ): HTTPException & {
+    readonly name: string;
+    readonly context: TCtx;
+  };
+};
+
+export const defineHttpException = <TCtx>(
+  errorName: string,
+  defaultStatus: ContentfulStatusCode,
+  messageFormatter: (ctx: TCtx) => string,
+  options?: HttpExceptionOptions<TCtx>,
+): HttpExceptionClass<TCtx> => {
+  const buildResponse = options?.buildResponse;
+
+  return class extends HTTPException {
+    declare readonly name: string;
+    readonly context: TCtx;
+
+    constructor(context: TCtx, opts?: { status?: ContentfulStatusCode; cause?: unknown }) {
+      const status = opts?.status ?? defaultStatus;
+      const message = messageFormatter(context);
+
+      if (buildResponse) {
+        super(status, { res: buildResponse(context, status, message), cause: opts?.cause });
+      } else {
+        super(status, { message, cause: opts?.cause });
+      }
+
+      (this as { name: string }).name = errorName;
+      this.context = context;
+      Object.setPrototypeOf(this, new.target.prototype);
+    }
+  } as HttpExceptionClass<TCtx>;
+};

--- a/packages/core/src/errors/definitions.ts
+++ b/packages/core/src/errors/definitions.ts
@@ -38,11 +38,16 @@ export const coreErrorDefinitions = {
       ? `path parameter "${ctx.paramName}" is not defined`
       : 'Invalid route configuration',
 
-  ZeltMiddlewareExecutionError: (_ctx: { reason: 'next_called_multiple_times' }) =>
-    'next() called multiple times',
+  ZeltMiddlewareExecutionError: (ctx: {
+    reason: 'next_called_multiple_times';
+    middlewareName: string;
+  }) => `next() called multiple times in middleware '${ctx.middlewareName}'`,
 
   ZeltNotImplementedError: (ctx: { className: string; methodName: string }) =>
     `${ctx.className}.${ctx.methodName}() not implemented`,
+
+  ZeltSchemaValidationError: (ctx: { schemaType: string; reason: string }) =>
+    `Invalid ${ctx.schemaType} schema: ${ctx.reason}`,
 } as const;
 
 export type CoreErrorContextMap = {

--- a/packages/core/src/errors/errors.test.ts
+++ b/packages/core/src/errors/errors.test.ts
@@ -137,13 +137,23 @@ describe('ZeltRouteConfigurationError', () => {
 });
 
 describe('ZeltMiddlewareExecutionError', () => {
-  it('formats next_called_multiple_times reason correctly', () => {
+  it('formats error with middleware name', () => {
     const error = new ZeltMiddlewareExecutionError({
       reason: 'next_called_multiple_times',
+      middlewareName: 'AuthMiddleware',
     });
-    expect(error.message).toBe('next() called multiple times');
+    expect(error.message).toBe("next() called multiple times in middleware 'AuthMiddleware'");
     expect(error.name).toBe('ZeltMiddlewareExecutionError');
+    expect(error.context.middlewareName).toBe('AuthMiddleware');
     expect(error).toBeInstanceOf(ZeltMiddlewareExecutionError);
+  });
+
+  it('formats error with anonymous middleware', () => {
+    const error = new ZeltMiddlewareExecutionError({
+      reason: 'next_called_multiple_times',
+      middlewareName: '<anonymous>',
+    });
+    expect(error.message).toBe("next() called multiple times in middleware '<anonymous>'");
   });
 });
 

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,3 +1,5 @@
 export * from './classes';
+export { defineError } from './define-error';
+export { defineHttpException } from './define-http-exception';
 export { type CoreErrorContextMap, coreErrorDefinitions } from './definitions';
 export { createErrorClass } from './factory';

--- a/packages/core/src/http/decorators/authorized.ts
+++ b/packages/core/src/http/decorators/authorized.ts
@@ -5,6 +5,7 @@ import type { RequestContextSchema } from '../primitives/get-context';
 
 type Roles = RequestContextSchema['authRoles'];
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Authorized =
   (roles: Roles = []) =>
   (...args: unknown[]): void => {

--- a/packages/core/src/http/decorators/controller.ts
+++ b/packages/core/src/http/decorators/controller.ts
@@ -10,6 +10,7 @@ import {
 } from '../internal/metadata';
 import { getCallerFile } from '../internal/source-file';
 
+/** @throws {ZeltLifecycleStateError} */
 export const Controller =
   (basePath: string) =>
   (...args: unknown[]): void => {

--- a/packages/core/src/http/decorators/http-method.ts
+++ b/packages/core/src/http/decorators/http-method.ts
@@ -3,6 +3,7 @@ import { resolveMethodArgs } from '../../internal/decorator-context';
 import type { HttpMethod } from '../internal/metadata';
 import { appendPendingRouteMetadata } from '../internal/metadata';
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 const makeDecorator =
   (method: HttpMethod) =>
   (path: string) =>

--- a/packages/core/src/http/decorators/skip-middleware.ts
+++ b/packages/core/src/http/decorators/skip-middleware.ts
@@ -3,6 +3,7 @@ import { resolveMethodArgs } from '../../internal/decorator-context';
 import { appendPendingSkipMiddlewareMetadata } from '../internal/metadata';
 import type { MiddlewareIdentifier } from '../middleware/types';
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const SkipMiddleware =
   (...middlewares: MiddlewareIdentifier[]) =>
   (...args: unknown[]): void => {

--- a/packages/core/src/http/decorators/use-middleware.ts
+++ b/packages/core/src/http/decorators/use-middleware.ts
@@ -10,6 +10,7 @@ import type { MiddlewareInput } from '../middleware/types';
 
 const tc39ClassPattern = P.shape({ kind: 'class', metadata: P.nonNullable });
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const UseMiddleware =
   (...middlewares: MiddlewareInput[]) =>
   (...args: unknown[]): void => {

--- a/packages/core/src/http/internal/entry-context.ts
+++ b/packages/core/src/http/internal/entry-context.ts
@@ -21,6 +21,7 @@ const storage = new AsyncLocalStorage<EntryContext>();
 
 export const runInEntryContext = <T>(ctx: EntryContext, fn: () => T): T => storage.run(ctx, fn);
 
+/** @throws {ZeltContextNotAvailableError} */
 export const getEntryContext = (): EntryContext => {
   const ctx = storage.getStore();
   if (!ctx)

--- a/packages/core/src/http/internal/metadata.ts
+++ b/packages/core/src/http/internal/metadata.ts
@@ -48,9 +48,11 @@ export const setControllerMetadata = (cls: object, meta: ControllerMetadata): vo
   controllerStore.set(cls, meta);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getControllerMetadata = (cls: object): ControllerMetadata | undefined =>
   controllerStore.get(cls);
 
+/** @throws {ZeltLifecycleStateError} */
 export const appendRouteMetadata = (cls: object, meta: RouteMetadata): void => {
   const existing = routeStore.get(cls) ?? [];
   const exists = existing.some(
@@ -60,6 +62,7 @@ export const appendRouteMetadata = (cls: object, meta: RouteMetadata): void => {
   routeStore.set(cls, [...existing, meta]);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getRouteMetadata = (cls: object): readonly RouteMetadata[] =>
   routeStore.get(cls) ?? [];
 
@@ -70,10 +73,12 @@ export const setControllerMiddlewareMetadata = (
   controllerMiddlewareStore.set(cls, { middlewares });
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getControllerMiddlewareMetadata = (
   cls: object,
 ): ControllerMiddlewareMetadata | undefined => controllerMiddlewareStore.get(cls);
 
+/** @throws {ZeltLifecycleStateError} */
 export const appendMethodMiddlewareMetadata = (
   cls: object,
   methodName: string | symbol,
@@ -83,9 +88,11 @@ export const appendMethodMiddlewareMetadata = (
   methodMiddlewareStore.set(cls, [...existing, { methodName, middlewares }]);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getMethodMiddlewareMetadata = (cls: object): readonly MethodMiddlewareMetadata[] =>
   methodMiddlewareStore.get(cls) ?? [];
 
+/** @throws {ZeltLifecycleStateError} */
 export const appendSkipMiddlewareMetadata = (
   cls: object,
   methodName: string | symbol,
@@ -95,9 +102,11 @@ export const appendSkipMiddlewareMetadata = (
   skipMiddlewareStore.set(cls, [...existing, { methodName, skipped }]);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getSkipMiddlewareMetadata = (cls: object): readonly SkipMiddlewareMetadata[] =>
   skipMiddlewareStore.get(cls) ?? [];
 
+/** @throws {ZeltLifecycleStateError} */
 export const setAuthorizedMetadata = (
   cls: object,
   methodName: string | symbol,
@@ -107,6 +116,7 @@ export const setAuthorizedMetadata = (
   authorizedStore.set(cls, [...existing, { methodName, roles }]);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getAuthorizedMetadata = (
   cls: object,
   methodName: string | symbol,
@@ -115,11 +125,13 @@ export const getAuthorizedMetadata = (
   return all.find((m) => m.methodName === methodName);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const appendPendingRouteMetadata = (pendingKey: object, meta: RouteMetadata): void => {
   const existing = pendingRouteStore.get(pendingKey) ?? [];
   pendingRouteStore.set(pendingKey, [...existing, meta]);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const resolveRouteMetadata = (pendingKey: object, cls: object): void => {
   const pending = pendingRouteStore.get(pendingKey) ?? [];
   for (const meta of pending) {
@@ -128,6 +140,7 @@ export const resolveRouteMetadata = (pendingKey: object, cls: object): void => {
   pendingRouteStore.delete(pendingKey);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const appendPendingMethodMiddlewareMetadata = (
   pendingKey: object,
   methodName: string | symbol,
@@ -137,6 +150,7 @@ export const appendPendingMethodMiddlewareMetadata = (
   pendingMethodMiddlewareStore.set(pendingKey, [...existing, { methodName, middlewares }]);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const resolveMethodMiddlewareMetadata = (pendingKey: object, cls: object): void => {
   const pending = pendingMethodMiddlewareStore.get(pendingKey) ?? [];
   for (const { methodName, middlewares } of pending) {
@@ -145,6 +159,7 @@ export const resolveMethodMiddlewareMetadata = (pendingKey: object, cls: object)
   pendingMethodMiddlewareStore.delete(pendingKey);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const appendPendingSkipMiddlewareMetadata = (
   pendingKey: object,
   methodName: string | symbol,
@@ -154,6 +169,7 @@ export const appendPendingSkipMiddlewareMetadata = (
   pendingSkipMiddlewareStore.set(pendingKey, [...existing, { methodName, skipped }]);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const resolveSkipMiddlewareMetadata = (pendingKey: object, cls: object): void => {
   const pending = pendingSkipMiddlewareStore.get(pendingKey) ?? [];
   for (const { methodName, skipped } of pending) {
@@ -162,6 +178,7 @@ export const resolveSkipMiddlewareMetadata = (pendingKey: object, cls: object): 
   pendingSkipMiddlewareStore.delete(pendingKey);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const appendPendingAuthorizedMetadata = (
   pendingKey: object,
   methodName: string | symbol,
@@ -171,6 +188,7 @@ export const appendPendingAuthorizedMetadata = (
   pendingAuthorizedStore.set(pendingKey, [...existing, { methodName, roles }]);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const resolveAuthorizedMetadata = (pendingKey: object, cls: object): void => {
   const pending = pendingAuthorizedStore.get(pendingKey) ?? [];
   for (const { methodName, roles } of pending) {

--- a/packages/core/src/http/internal/route-builder.ts
+++ b/packages/core/src/http/internal/route-builder.ts
@@ -48,6 +48,7 @@ type Route = {
   readonly controllerClass: ControllerClass;
 };
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const collectRoutes = (controllers: readonly ControllerClass[]): readonly Route[] => {
   const routes: Route[] = [];
   for (const cls of controllers) {
@@ -71,6 +72,7 @@ export const collectRoutes = (controllers: readonly ControllerClass[]): readonly
   return routes;
 };
 
+/** @throws {ZeltLifecycleStateError | ZeltRouteConfigurationError} */
 const resolveHandler = (instance: object, methodName: string | symbol): (() => unknown) => {
   // Reflect.get returns `any` for dynamic keys; pinning the local to `unknown`
   // forces narrowing before any call, keeping the handler invocation typesafe.
@@ -91,6 +93,7 @@ type ParsedBodies = {
   formBody: FormBody | undefined;
 };
 
+/** @throws {ZeltContextNotAvailableError} */
 const parseRequestBodies = async (
   c: Parameters<Parameters<Hono['on']>[2]>[0],
 ): Promise<ParsedBodies> => {
@@ -112,15 +115,18 @@ const parseRequestBodies = async (
   return { jsonBody: undefined, formBody: undefined };
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const hasUseMethod = (proto: unknown): boolean => {
   if (proto === null || proto === undefined) return false;
   if (typeof proto !== 'object') return false;
   return typeof Reflect.get(proto, 'use') === 'function';
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const checkMiddlewareClass = (input: MiddlewareInput): boolean =>
   typeof input === 'function' && input.prototype !== undefined && hasUseMethod(input.prototype);
 
+/** @throws {ZeltLifecycleStateError} */
 const checkMiddlewareWithOptions = (input: MiddlewareInput): boolean => {
   if (!Array.isArray(input)) return false;
   const tuple: MiddlewareInputWithOptions = input;
@@ -142,6 +148,7 @@ function narrowToFunction(middleware: MiddlewareInput): MiddlewareInput {
   return middleware;
 }
 
+/** @throws {ZeltLifecycleStateError} */
 const resolveMiddleware = (
   middleware: MiddlewareInput,
   resolver: ResolverHandle,
@@ -159,6 +166,7 @@ const resolveMiddleware = (
   return narrowToFunction(middleware);
 };
 
+/** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError} */
 const createAuthorizationMiddleware = (requiredRoles: readonly string[]): FunctionMiddleware => {
   return async (_c, next) => {
     const user = currentUser();
@@ -185,6 +193,7 @@ const createAuthorizationMiddleware = (requiredRoles: readonly string[]): Functi
   };
 };
 
+/** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError} */
 const collectRouteMiddlewares = (
   globalMiddlewares: readonly MiddlewareInput[],
   controllerClass: ControllerClass,
@@ -217,6 +226,7 @@ const collectRouteMiddlewares = (
   return resolvedMiddlewares;
 };
 
+/** @throws {ZeltMiddlewareExecutionError} */
 const composeHandler = (
   middlewares: readonly FunctionMiddleware[],
   finalHandler: (c: MiddlewareContext) => Promise<Response>,
@@ -229,9 +239,14 @@ const composeHandler = (
     let index = -1;
     let response: Response | undefined;
 
+    /** @throws {ZeltMiddlewareExecutionError} */
     const dispatch = async (i: number): Promise<void> => {
-      if (i <= index)
-        throw new ZeltMiddlewareExecutionError({ reason: 'next_called_multiple_times' });
+      if (i <= index) {
+        throw new ZeltMiddlewareExecutionError({
+          reason: 'next_called_multiple_times',
+          middlewareName: middlewares[index]?.name || '<anonymous>',
+        });
+      }
       index = i;
       if (i < middlewares.length) {
         const mw = middlewares[i];
@@ -259,6 +274,7 @@ type RouteBuilderContext = {
   readonly instanceCache: Map<ControllerClass, object>;
 };
 
+/** @throws {ZeltLifecycleStateError} */
 const getOrCreateInstance = (
   ctx: RouteBuilderContext,
   controllerClass: ControllerClass,
@@ -270,6 +286,7 @@ const getOrCreateInstance = (
   return instance;
 };
 
+/** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError} */
 const registerRoute = (
   hono: Hono,
   ctx: RouteBuilderContext,
@@ -283,6 +300,7 @@ const registerRoute = (
     ctx.resolver,
   );
 
+  /** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError | ZeltMiddlewareExecutionError | ZeltRouteConfigurationError} */
   const handler = async (c: MiddlewareContext): Promise<Response> => {
     const instance = getOrCreateInstance(ctx, route.controllerClass);
     await ctx.lifecycle.startupPending();
@@ -323,6 +341,7 @@ export type BuildRoutesOptions = {
   readonly globalMiddlewares?: readonly MiddlewareInput[];
 };
 
+/** @throws {ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const buildRoutes = (options: BuildRoutesOptions): void => {
   const ctx: RouteBuilderContext = {
     resolver: options.resolver,
@@ -335,6 +354,7 @@ export const buildRoutes = (options: BuildRoutesOptions): void => {
   }
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const warmupControllers = async (
   controllers: readonly ControllerClass[],
   resolver: ResolverHandle,

--- a/packages/core/src/http/primitives/auth.ts
+++ b/packages/core/src/http/primitives/auth.ts
@@ -1,6 +1,7 @@
 import type { RequestContextSchema } from './get-context';
 import { getContext, setContext } from './get-context';
 
+/** @throws {ZeltContextNotAvailableError} */
 export const setUser = <U extends RequestContextSchema['user']>(
   user: U,
   roles: RequestContextSchema['authRoles'] = [],
@@ -9,10 +10,18 @@ export const setUser = <U extends RequestContextSchema['user']>(
   setContext('authRoles', roles);
 };
 
+/**
+ * @throws {ZeltContextNotAvailableError}
+ * @throws {ZeltLifecycleStateError}
+ */
 export const currentUser = (): RequestContextSchema['user'] | undefined => {
   return getContext('user');
 };
 
+/**
+ * @throws {ZeltContextNotAvailableError}
+ * @throws {ZeltLifecycleStateError}
+ */
 export const currentRoles = (): RequestContextSchema['authRoles'] => {
   return getContext('authRoles') ?? [];
 };

--- a/packages/core/src/http/primitives/body.ts
+++ b/packages/core/src/http/primitives/body.ts
@@ -12,11 +12,19 @@ type BodyTypeMap = {
 
 type BodyType = keyof BodyTypeMap;
 
+/** @throws {ZeltContextNotAvailableError} */
 export function body(type: 'text'): Promise<string>;
+/** @throws {ZeltContextNotAvailableError} */
 export function body(type: 'json'): Promise<unknown>;
+/** @throws {ZeltContextNotAvailableError} */
 export function body(type: 'form'): Promise<FormData>;
+/** @throws {ZeltContextNotAvailableError} */
 export function body(type: 'arrayBuffer'): Promise<ArrayBuffer>;
+/** @throws {ZeltContextNotAvailableError} */
 export function body(type: 'blob'): Promise<Blob>;
+/**
+ * @throws {ZeltContextNotAvailableError}
+ */
 export function body(type: BodyType): Promise<BodyTypeMap[BodyType]> {
   const req = getEntryContext().honoContext.req;
   return match(type)

--- a/packages/core/src/http/primitives/cookie.ts
+++ b/packages/core/src/http/primitives/cookie.ts
@@ -2,6 +2,7 @@ import { getCookie } from 'hono/cookie';
 
 import { getEntryContext } from '../internal/entry-context';
 
+/** @throws {ZeltContextNotAvailableError} */
 export const cookie = (name: string): string | undefined => {
   return getCookie(getEntryContext().honoContext, name);
 };

--- a/packages/core/src/http/primitives/get-context.ts
+++ b/packages/core/src/http/primitives/get-context.ts
@@ -5,6 +5,10 @@ export interface RequestContextSchema {
   authRoles: string[];
 }
 
+/**
+ * @throws {ZeltContextNotAvailableError}
+ * @throws {ZeltLifecycleStateError}
+ */
 export const getContext = <K extends keyof RequestContextSchema>(
   key: K,
 ): RequestContextSchema[K] | undefined => {
@@ -13,6 +17,7 @@ export const getContext = <K extends keyof RequestContextSchema>(
   return value;
 };
 
+/** @throws {ZeltContextNotAvailableError} */
 export const setContext = <K extends keyof RequestContextSchema>(
   key: K,
   value: RequestContextSchema[K],

--- a/packages/core/src/http/primitives/header.ts
+++ b/packages/core/src/http/primitives/header.ts
@@ -1,5 +1,6 @@
 import { getEntryContext } from '../internal/entry-context';
 
+/** @throws {ZeltContextNotAvailableError} */
 export const header = (name: string): string | undefined => {
   return getEntryContext().honoContext.req.header(name);
 };

--- a/packages/core/src/http/primitives/ip.ts
+++ b/packages/core/src/http/primitives/ip.ts
@@ -1,5 +1,6 @@
 import { getEntryContext } from '../internal/entry-context';
 
+/** @throws {ZeltContextNotAvailableError} */
 export const ip = (): string => {
   const honoCtx = getEntryContext().honoContext;
   return (

--- a/packages/core/src/http/primitives/path-param.ts
+++ b/packages/core/src/http/primitives/path-param.ts
@@ -1,6 +1,10 @@
 import { ZeltRouteConfigurationError } from '../../errors';
 import { getEntryContext } from '../internal/entry-context';
 
+/**
+ * @throws {ZeltContextNotAvailableError}
+ * @throws {ZeltRouteConfigurationError}
+ */
 export const pathParam = (name: string): string => {
   const value = getEntryContext().input.pathParams[name];
   if (value === undefined) {

--- a/packages/core/src/http/primitives/query-param.ts
+++ b/packages/core/src/http/primitives/query-param.ts
@@ -1,9 +1,11 @@
 import { getEntryContext } from '../internal/entry-context';
 
+/** @throws {ZeltContextNotAvailableError} */
 export const queryParam = (name: string): string | undefined => {
   return getEntryContext().honoContext.req.query(name);
 };
 
+/** @throws {ZeltContextNotAvailableError} */
 export const queryParams = (name: string): string[] => {
   return getEntryContext().honoContext.req.queries(name) ?? [];
 };

--- a/packages/core/src/http/primitives/request-context.ts
+++ b/packages/core/src/http/primitives/request-context.ts
@@ -2,4 +2,5 @@ import type { Context } from 'hono';
 
 import { getEntryContext } from '../internal/entry-context';
 
+/** @throws {ZeltContextNotAvailableError} */
 export const requestContext = (): Context => getEntryContext().honoContext;

--- a/packages/core/src/http/primitives/response.ts
+++ b/packages/core/src/http/primitives/response.ts
@@ -120,6 +120,7 @@ const buildResponseBuilder = (c: Context): ResponseBuilder => {
   return builder;
 };
 
+/** @throws {ZeltContextNotAvailableError} */
 export const response = (): ResponseBuilder => {
   const ctx = getEntryContext();
   return buildResponseBuilder(ctx.honoContext);

--- a/packages/core/src/http/primitives/url.ts
+++ b/packages/core/src/http/primitives/url.ts
@@ -1,13 +1,16 @@
 import { getEntryContext } from '../internal/entry-context';
 
+/** @throws {ZeltContextNotAvailableError} */
 export const url = (): string => {
   return getEntryContext().honoContext.req.url;
 };
 
+/** @throws {ZeltContextNotAvailableError} */
 export const path = (): string => {
   return getEntryContext().honoContext.req.path;
 };
 
+/** @throws {ZeltContextNotAvailableError} */
 export const method = (): string => {
   return getEntryContext().honoContext.req.method;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export { Injectable } from './di/injectable';
 export type { CoreErrorContextMap } from './errors';
 // Errors
 export {
+  defineHttpException,
   ZeltAppConfigurationError,
   ZeltContextNotAvailableError,
   ZeltDecoratorUsageError,
@@ -45,6 +46,7 @@ export {
   ZeltMiddlewareExecutionError,
   ZeltNotImplementedError,
   ZeltRouteConfigurationError,
+  ZeltSchemaValidationError,
 } from './errors';
 // HTTP decorators
 export { Authorized } from './http/decorators/authorized';

--- a/packages/core/src/internal-bridge/errors.ts
+++ b/packages/core/src/internal-bridge/errors.ts
@@ -1,0 +1,1 @@
+export { defineError } from '../errors';

--- a/packages/core/src/scheduler/decorators/cron.ts
+++ b/packages/core/src/scheduler/decorators/cron.ts
@@ -6,6 +6,7 @@ type CronOptions = {
   readonly tz?: string;
 };
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Cron =
   (expression: string, options?: CronOptions) =>
   (...args: unknown[]): void => {

--- a/packages/core/src/scheduler/decorators/daily.ts
+++ b/packages/core/src/scheduler/decorators/daily.ts
@@ -8,6 +8,7 @@ type DailyOptions = {
   readonly tz?: string;
 };
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Daily =
   (options: DailyOptions) =>
   (...args: unknown[]): void => {

--- a/packages/core/src/scheduler/decorators/every.ts
+++ b/packages/core/src/scheduler/decorators/every.ts
@@ -6,6 +6,7 @@ type EveryOptions =
   | { readonly minutes: number; readonly seconds?: never }
   | { readonly seconds: number; readonly minutes?: never };
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Every =
   (options: EveryOptions) =>
   (...args: unknown[]): void => {

--- a/packages/core/src/scheduler/decorators/hourly.ts
+++ b/packages/core/src/scheduler/decorators/hourly.ts
@@ -7,6 +7,7 @@ type HourlyOptions = {
   readonly tz?: string;
 };
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Hourly =
   (options?: HourlyOptions) =>
   (...args: unknown[]): void => {

--- a/packages/core/src/scheduler/decorators/scheduled.ts
+++ b/packages/core/src/scheduler/decorators/scheduled.ts
@@ -3,6 +3,7 @@ import { injectable } from '@needle-di/core';
 import { resolveClassArgs } from '../../internal/decorator-context';
 import { resolveScheduleMetadata, setScheduledMetadata } from '../internal/scheduler-metadata';
 
+/** @throws {ZeltLifecycleStateError} */
 export const Scheduled =
   () =>
   (...args: unknown[]): void => {

--- a/packages/core/src/scheduler/decorators/weekly.ts
+++ b/packages/core/src/scheduler/decorators/weekly.ts
@@ -21,6 +21,7 @@ const dayToCron: Record<DayOfWeek, string> = {
   saturday: '6',
 };
 
+/** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Weekly =
   (options: WeeklyOptions) =>
   (...args: unknown[]): void => {

--- a/packages/core/src/scheduler/internal/scheduler-metadata.ts
+++ b/packages/core/src/scheduler/internal/scheduler-metadata.ts
@@ -12,13 +12,16 @@ export const setScheduledMetadata = (cls: object): void => {
   scheduledStore.set(cls, true);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getScheduledMetadata = (cls: object): true | undefined => scheduledStore.get(cls);
 
+/** @throws {ZeltLifecycleStateError} */
 export const appendPendingScheduleMetadata = (pendingKey: object, meta: ScheduleMetadata): void => {
   const existing = pendingScheduleStore.get(pendingKey) ?? [];
   pendingScheduleStore.set(pendingKey, [...existing, meta]);
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const resolveScheduleMetadata = (pendingKey: object, cls: object): void => {
   const pending = pendingScheduleStore.get(pendingKey);
   if (pending) {
@@ -28,5 +31,6 @@ export const resolveScheduleMetadata = (pendingKey: object, cls: object): void =
   }
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const getScheduleMetadata = (cls: object): readonly ScheduleMetadata[] =>
   scheduleStore.get(cls) ?? [];

--- a/packages/core/src/scheduler/runner.ts
+++ b/packages/core/src/scheduler/runner.ts
@@ -26,6 +26,7 @@ export const createSchedulerRunner = (
   const jobInfos: JobInfo[] = [];
   let running = false;
 
+  /** @throws {ZeltLifecycleStateError} */
   const startup = async (): Promise<void> => {
     if (running) return;
 

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     'src/modules/env/index.ts',
     'src/runtime/index.ts',
     'src/internal-bridge/testing.ts',
+    'src/internal-bridge/errors.ts',
   ],
   format: ['esm'],
   dts: true,

--- a/packages/kv/src/adaptor-memory/memory-kv.adaptor.ts
+++ b/packages/kv/src/adaptor-memory/memory-kv.adaptor.ts
@@ -1,7 +1,7 @@
 import type { Lifecycle } from '@zeltjs/core';
 import { Injectable, inject, LifecycleManager } from '@zeltjs/core';
 
-import { KVError } from '../errors';
+import { ZeltKVInvalidTtlError } from '../errors';
 import { joinPrefix } from '../namespace';
 import { deserialize, serialize } from '../serialize';
 import type { AtomicKVAdaptor, AtomicKVStore, Defined, NonEmptyString, SetOptions } from '../types';
@@ -12,8 +12,9 @@ type Entry = {
   expiresAt?: number;
 };
 
+/** @throws {ZeltKVInvalidTtlError} */
 function validateTtl(ttlSec: number | undefined): void {
-  if (ttlSec !== undefined && ttlSec <= 0) throw KVError.invalidTtl(ttlSec);
+  if (ttlSec !== undefined && ttlSec <= 0) throw new ZeltKVInvalidTtlError({ ttlSec });
 }
 
 function makeEntry(raw: string, ttlSec?: number): Entry {

--- a/packages/kv/src/adaptor-redis/redis-kv-store.ts
+++ b/packages/kv/src/adaptor-redis/redis-kv-store.ts
@@ -1,13 +1,14 @@
 import type Redis from 'ioredis';
-import { KVError } from '../errors';
+import { ZeltKVInvalidTtlError } from '../errors';
 import { joinPrefix } from '../namespace';
 import { deserialize, serialize } from '../serialize';
 import type { AtomicKVStore, Defined, NonEmptyString, SetOptions } from '../types';
 
 import { INCR_WITH_TTL_LUA } from './lua-scripts';
 
+/** @throws {ZeltKVInvalidTtlError} */
 const validateTtl = (ttlSec: number | undefined): void => {
-  if (ttlSec !== undefined && ttlSec <= 0) throw KVError.invalidTtl(ttlSec);
+  if (ttlSec !== undefined && ttlSec <= 0) throw new ZeltKVInvalidTtlError({ ttlSec });
 };
 
 const incrWithTtl = async (
@@ -31,53 +32,33 @@ export class RedisKVStore implements AtomicKVStore {
   }
 
   async get<T>(key: string): Promise<T | undefined> {
-    try {
-      const raw = await this.client.get(this.k(key));
-      return raw === null ? undefined : deserialize<T>(raw);
-    } catch (cause) {
-      throw KVError.storeOperationFailed('get', cause);
-    }
+    const raw = await this.client.get(this.k(key));
+    return raw === null ? undefined : deserialize<T>(raw);
   }
 
   async set<T extends Defined>(key: string, value: T, opts?: SetOptions): Promise<void> {
     validateTtl(opts?.ttlSec);
     const json = serialize(value);
-    try {
-      if (opts?.ttlSec !== undefined) {
-        await this.client.set(this.k(key), json, 'EX', opts.ttlSec);
-      } else {
-        await this.client.set(this.k(key), json);
-      }
-    } catch (cause) {
-      throw KVError.storeOperationFailed('set', cause);
+    if (opts?.ttlSec !== undefined) {
+      await this.client.set(this.k(key), json, 'EX', opts.ttlSec);
+    } else {
+      await this.client.set(this.k(key), json);
     }
   }
 
   async del(key: string): Promise<void> {
-    try {
-      await this.client.del(this.k(key));
-    } catch (cause) {
-      throw KVError.storeOperationFailed('del', cause);
-    }
+    await this.client.del(this.k(key));
   }
 
   async has(key: string): Promise<boolean> {
-    try {
-      const n = await this.client.exists(this.k(key));
-      return n === 1;
-    } catch (cause) {
-      throw KVError.storeOperationFailed('exists', cause);
-    }
+    const n = await this.client.exists(this.k(key));
+    return n === 1;
   }
 
   async expire(key: string, ttlSec: number): Promise<boolean> {
     validateTtl(ttlSec);
-    try {
-      const n = await this.client.expire(this.k(key), ttlSec);
-      return n === 1;
-    } catch (cause) {
-      throw KVError.storeOperationFailed('expire', cause);
-    }
+    const n = await this.client.expire(this.k(key), ttlSec);
+    return n === 1;
   }
 
   namespace<const S extends string>(sub: NonEmptyString<S>): AtomicKVStore {
@@ -86,25 +67,16 @@ export class RedisKVStore implements AtomicKVStore {
 
   async incr(key: string, by = 1, opts?: { ttlSec?: number }): Promise<number> {
     validateTtl(opts?.ttlSec);
-    try {
-      return await incrWithTtl(this.client, this.k(key), by, opts?.ttlSec);
-    } catch (cause) {
-      throw KVError.storeOperationFailed('incr', cause);
-    }
+    return incrWithTtl(this.client, this.k(key), by, opts?.ttlSec);
   }
 
   async setnx<T extends Defined>(key: string, value: T, opts?: SetOptions): Promise<boolean> {
     validateTtl(opts?.ttlSec);
     const json = serialize(value);
-    try {
-      const promise =
-        opts?.ttlSec !== undefined
-          ? this.client.set(this.k(key), json, 'EX', opts.ttlSec, 'NX')
-          : this.client.set(this.k(key), json, 'NX');
-      const result = await promise;
-      return result === 'OK';
-    } catch (cause) {
-      throw KVError.storeOperationFailed('setnx', cause);
-    }
+    const result =
+      opts?.ttlSec !== undefined
+        ? await this.client.set(this.k(key), json, 'EX', opts.ttlSec, 'NX')
+        : await this.client.set(this.k(key), json, 'NX');
+    return result === 'OK';
   }
 }

--- a/packages/kv/src/compliance.test.ts
+++ b/packages/kv/src/compliance.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { KVError } from './errors';
+import { ZeltKVInvalidTtlError } from './errors';
 import type { AtomicKVAdaptor, AtomicKVStore, KVAdaptor, KVStore } from './types';
 
 export type ComplianceOptions = {
@@ -58,17 +58,17 @@ const runKVStoreNamespaceTests = (getDriver: () => KVAdaptor, getStore: () => KV
 
 const runKVStoreValidationTests = (getStore: () => KVStore): void => {
   it('set with ttlSec=0 throws INVALID_TTL', async () => {
-    await expect(getStore().set('foo', 1, { ttlSec: 0 })).rejects.toThrow(KVError);
+    await expect(getStore().set('foo', 1, { ttlSec: 0 })).rejects.toThrow(ZeltKVInvalidTtlError);
   });
 
   it('set with negative ttlSec throws INVALID_TTL', async () => {
-    await expect(getStore().set('foo', 1, { ttlSec: -1 })).rejects.toThrow(KVError);
+    await expect(getStore().set('foo', 1, { ttlSec: -1 })).rejects.toThrow(ZeltKVInvalidTtlError);
   });
 
   it('expire with ttlSec=0 throws INVALID_TTL', async () => {
     const store = getStore();
     await store.set('foo', 1);
-    await expect(store.expire('foo', 0)).rejects.toThrow(KVError);
+    await expect(store.expire('foo', 0)).rejects.toThrow(ZeltKVInvalidTtlError);
   });
 };
 

--- a/packages/kv/src/errors.test.ts
+++ b/packages/kv/src/errors.test.ts
@@ -1,33 +1,37 @@
 import { describe, expect, it } from 'vitest';
 
-import { KVError } from './errors';
+import { isZeltKVInvalidTtlError, ZeltKVInvalidTtlError } from './errors';
 
-describe('errors', () => {
-  it('invalidTtl returns INVALID_TTL with correct fields', () => {
-    const e = KVError.invalidTtl(0);
-    expect(e.type).toBe('INVALID_TTL');
-    expect(e.details['ttlSec']).toBe(0);
-    expect(e.message).toContain('0');
+describe('ZeltKVInvalidTtlError', () => {
+  it('creates error with correct name and message', () => {
+    const err = new ZeltKVInvalidTtlError({ ttlSec: 0 });
+    expect(err.name).toBe('ZeltKVInvalidTtlError');
+    expect(err.message).toContain('0');
+    expect(err.context.ttlSec).toBe(0);
   });
 
-  it('invalidTtl with negative value', () => {
-    const e = KVError.invalidTtl(-5);
-    expect(e.type).toBe('INVALID_TTL');
-    expect(e.details['ttlSec']).toBe(-5);
+  it('works with negative value', () => {
+    const err = new ZeltKVInvalidTtlError({ ttlSec: -5 });
+    expect(err.context.ttlSec).toBe(-5);
+    expect(err.message).toContain('-5');
   });
 
-  it('storeOperationFailed returns STORE_OPERATION_FAILED with Error cause', () => {
-    const cause = new Error('redis down');
-    const e = KVError.storeOperationFailed('get', cause);
-    expect(e.type).toBe('STORE_OPERATION_FAILED');
-    expect(e.details['op']).toBe('get');
-    expect(e.details['cause']).toBe(cause);
-    expect(e.message).toContain('redis down');
+  it('works with instanceof', () => {
+    const err = new ZeltKVInvalidTtlError({ ttlSec: 0 });
+    expect(err instanceof ZeltKVInvalidTtlError).toBe(true);
+    expect(err instanceof Error).toBe(true);
+  });
+});
+
+describe('isZeltKVInvalidTtlError', () => {
+  it('returns true for ZeltKVInvalidTtlError', () => {
+    const err = new ZeltKVInvalidTtlError({ ttlSec: 0 });
+    expect(isZeltKVInvalidTtlError(err)).toBe(true);
   });
 
-  it('storeOperationFailed with non-Error cause uses String()', () => {
-    const e = KVError.storeOperationFailed('set', 'timeout');
-    expect(e.type).toBe('STORE_OPERATION_FAILED');
-    expect(e.message).toContain('timeout');
+  it('returns false for other errors', () => {
+    expect(isZeltKVInvalidTtlError(new Error('other'))).toBe(false);
+    expect(isZeltKVInvalidTtlError(null)).toBe(false);
+    expect(isZeltKVInvalidTtlError(undefined)).toBe(false);
   });
 });

--- a/packages/kv/src/errors.ts
+++ b/packages/kv/src/errors.ts
@@ -1,25 +1,12 @@
-export type KVErrorType = 'INVALID_TTL' | 'STORE_OPERATION_FAILED';
+import { defineError } from '@zeltjs/core/internal-bridge/errors';
 
-export class KVError extends Error {
-  override readonly name = 'KVError';
+export const ZeltKVInvalidTtlError = defineError(
+  'ZeltKVInvalidTtlError',
+  (ctx: { ttlSec: number }) => `ttlSec must be > 0, got ${ctx.ttlSec}`,
+);
 
-  private constructor(
-    readonly type: KVErrorType,
-    message: string,
-    readonly details: Record<string, unknown> = {},
-  ) {
-    super(message);
-  }
-
-  static invalidTtl(ttlSec: number): KVError {
-    return new KVError('INVALID_TTL', `ttlSec must be > 0, got ${ttlSec}`, { ttlSec });
-  }
-
-  static storeOperationFailed(op: string, cause: unknown): KVError {
-    return new KVError(
-      'STORE_OPERATION_FAILED',
-      `store operation '${op}' failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      { op, cause },
-    );
-  }
-}
+export const isZeltKVInvalidTtlError = (
+  err: unknown,
+): err is InstanceType<typeof ZeltKVInvalidTtlError> => {
+  return err instanceof ZeltKVInvalidTtlError;
+};

--- a/packages/kv/src/index.ts
+++ b/packages/kv/src/index.ts
@@ -3,7 +3,7 @@ export {
   MemoryKVAdaptor as MemoryKV,
   MemoryKVAdaptor as MemoryKVService,
 } from './adaptor-memory';
-export { KVError, type KVErrorType } from './errors';
+export { isZeltKVInvalidTtlError, ZeltKVInvalidTtlError } from './errors';
 export { joinPrefix } from './namespace';
 export { deserialize, serialize } from './serialize';
 export type {

--- a/packages/kv/vitest.config.ts
+++ b/packages/kv/vitest.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { sharedConfig } from '../../vitest.shared';
 
@@ -8,6 +9,15 @@ export default mergeConfig(
       name: '@zeltjs/kv',
       include: ['src/**/*.test.ts'],
       exclude: ['src/compliance.test.ts'],
+    },
+    resolve: {
+      alias: {
+        '@zeltjs/core/internal-bridge/errors': resolve(
+          __dirname,
+          '../core/src/internal-bridge/errors.ts',
+        ),
+        '@zeltjs/core': resolve(__dirname, '../core/src/index.ts'),
+      },
     },
   }),
 );

--- a/packages/rate-limit/src/errors.ts
+++ b/packages/rate-limit/src/errors.ts
@@ -1,5 +1,3 @@
-import type { KVError } from '@zeltjs/kv';
-
 import type { RateLimitResult } from './types';
 
 export const tooManyRequestsResponse = (result: RateLimitResult): Response =>
@@ -15,10 +13,10 @@ export const tooManyRequestsResponse = (result: RateLimitResult): Response =>
     },
   );
 
-export type RateLimitError = { type: 'KV_FAILED'; cause: KVError; message: string };
+export type RateLimitError = { type: 'KV_FAILED'; cause: unknown; message: string };
 
-export const kvFailed = (cause: KVError): RateLimitError => ({
+export const kvFailed = (cause: unknown): RateLimitError => ({
   type: 'KV_FAILED',
   cause,
-  message: `rate-limit KV operation failed: ${cause.message}`,
+  message: `rate-limit KV operation failed: ${cause instanceof Error ? cause.message : String(cause)}`,
 });

--- a/packages/rate-limit/src/exceptions.test.ts
+++ b/packages/rate-limit/src/exceptions.test.ts
@@ -1,0 +1,48 @@
+import { HTTPException } from '@zeltjs/core';
+import { describe, expect, it } from 'vitest';
+
+import { RateLimitExceededException, RateLimitUnavailableException } from './exceptions';
+
+describe('RateLimitExceededException', () => {
+  it('is instanceof HTTPException', () => {
+    const err = new RateLimitExceededException({
+      limit: 100,
+      remaining: 0,
+      retryAfterSec: 60,
+    });
+    expect(err instanceof HTTPException).toBe(true);
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it('has correct status', () => {
+    const err = new RateLimitExceededException({
+      limit: 100,
+      remaining: 0,
+      retryAfterSec: 60,
+    });
+    expect(err.status).toBe(429);
+  });
+
+  it('getResponse returns correct response', async () => {
+    const err = new RateLimitExceededException({
+      limit: 100,
+      remaining: 0,
+      retryAfterSec: 60,
+    });
+    const res = err.getResponse();
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('60');
+  });
+});
+
+describe('RateLimitUnavailableException', () => {
+  it('is instanceof HTTPException', () => {
+    const err = new RateLimitUnavailableException({});
+    expect(err instanceof HTTPException).toBe(true);
+  });
+
+  it('has correct status', () => {
+    const err = new RateLimitUnavailableException({});
+    expect(err.status).toBe(503);
+  });
+});

--- a/packages/rate-limit/src/exceptions.ts
+++ b/packages/rate-limit/src/exceptions.ts
@@ -1,0 +1,32 @@
+import { defineHttpException } from '@zeltjs/core';
+
+export const RateLimitExceededException = defineHttpException(
+  'RateLimitExceededException',
+  429,
+  (ctx: { limit: number; remaining: number; retryAfterSec: number }) =>
+    `Rate limit exceeded. Retry after ${ctx.retryAfterSec}s`,
+  {
+    buildResponse: (ctx, status, message) =>
+      Response.json(
+        { code: 'RATE_LIMIT_EXCEEDED', message, retryAfterSec: ctx.retryAfterSec },
+        {
+          status,
+          headers: {
+            'X-RateLimit-Limit': String(ctx.limit),
+            'X-RateLimit-Remaining': '0',
+            'Retry-After': String(ctx.retryAfterSec),
+          },
+        },
+      ),
+  },
+);
+
+export const RateLimitUnavailableException = defineHttpException(
+  'RateLimitUnavailableException',
+  503,
+  () => 'Rate limit service unavailable',
+  {
+    buildResponse: (_ctx, status, message) =>
+      Response.json({ code: 'RATE_LIMIT_UNAVAILABLE', message }, { status }),
+  },
+);

--- a/packages/rate-limit/src/index.ts
+++ b/packages/rate-limit/src/index.ts
@@ -1,4 +1,5 @@
 export { kvFailed, type RateLimitError, tooManyRequestsResponse } from './errors';
+export { RateLimitExceededException, RateLimitUnavailableException } from './exceptions';
 export { RateLimitConfig } from './rate-limit.config';
 export { RateLimit } from './rate-limit.decorator';
 export { RateLimitMiddleware } from './rate-limit.middleware';

--- a/packages/rate-limit/src/rate-limit.decorator.ts
+++ b/packages/rate-limit/src/rate-limit.decorator.ts
@@ -3,4 +3,5 @@ import { UseMiddleware } from '@zeltjs/core';
 import { RateLimitMiddleware } from './rate-limit.middleware';
 import type { RateLimitOptions } from './types';
 
+/** @throws {ZeltDecoratorUsageError} */
 export const RateLimit = (opts: RateLimitOptions) => UseMiddleware([RateLimitMiddleware, opts]);

--- a/packages/rate-limit/src/rate-limit.middleware.ts
+++ b/packages/rate-limit/src/rate-limit.middleware.ts
@@ -1,7 +1,7 @@
 import type { Next, RequestContext } from '@zeltjs/core';
 import { Injectable, inject } from '@zeltjs/core';
 
-import { tooManyRequestsResponse } from './errors';
+import { RateLimitExceededException, RateLimitUnavailableException } from './exceptions';
 import { RateLimitService } from './rate-limit.service';
 import type { RateLimitOptions } from './types';
 
@@ -9,6 +9,10 @@ import type { RateLimitOptions } from './types';
 export class RateLimitMiddleware {
   constructor(private readonly limiter = inject(RateLimitService)) {}
 
+  /**
+   * @throws {RateLimitExceededException} When rate limit is exceeded (429)
+   * @throws {RateLimitUnavailableException} When rate limit service is unavailable (503)
+   */
   async use(c: RequestContext, next: Next, opts: RateLimitOptions): Promise<Response | undefined> {
     const key = typeof opts.key === 'string' ? opts.key : opts.key();
     const r = await this.limiter.hit(key, {
@@ -17,7 +21,7 @@ export class RateLimitMiddleware {
     });
 
     if (!r.ok) {
-      return c.json({ code: 'RATE_LIMIT_UNAVAILABLE' }, 503);
+      throw new RateLimitUnavailableException({});
     }
 
     const result = r.value;
@@ -25,7 +29,11 @@ export class RateLimitMiddleware {
     c.header('X-RateLimit-Remaining', String(result.remaining));
 
     if (!result.allowed) {
-      return tooManyRequestsResponse(result);
+      throw new RateLimitExceededException({
+        limit: result.limit,
+        remaining: result.remaining,
+        retryAfterSec: result.retryAfterSec,
+      });
     }
 
     await next();

--- a/packages/rate-limit/src/rate-limit.service.ts
+++ b/packages/rate-limit/src/rate-limit.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, inject, Logger } from '@zeltjs/core';
-import { KVError } from '@zeltjs/kv';
 
 import type { RateLimitError } from './errors';
 import { kvFailed } from './errors';
@@ -28,7 +27,7 @@ export class RateLimitService {
       const count = await this.config.store.incr(key, 1, { ttlSec: windowSec });
       return { ok: true, value: this.buildResult(count, limit, windowSec) };
     } catch (err) {
-      return this.handleKVError(err, 'incr', key, limit);
+      return this.handleKVError(err, key, limit);
     }
   }
 
@@ -37,20 +36,13 @@ export class RateLimitService {
       await this.config.store.del(key);
       return { ok: true, value: this.openResult(this.config.defaultLimit) };
     } catch (err) {
-      const kvErr = err instanceof KVError ? err : KVError.storeOperationFailed('del', err);
-      return { ok: false, error: kvFailed(kvErr) };
+      return { ok: false, error: kvFailed(err) };
     }
   }
 
-  private handleKVError(
-    err: unknown,
-    op: string,
-    key: string,
-    limit: number,
-  ): RateLimiterHitResult {
-    const kvErr = err instanceof KVError ? err : KVError.storeOperationFailed(op, err);
+  private handleKVError(err: unknown, key: string, limit: number): RateLimiterHitResult {
     if (this.config.failureMode === 'closed') {
-      return { ok: false, error: kvFailed(kvErr) };
+      return { ok: false, error: kvFailed(err) };
     }
     this.logger.warn(`rate-limit: KV failure key=${key} error=${String(err)}`);
     return { ok: true, value: this.openResult(limit) };

--- a/packages/rate-limit/src/rate-limiter.service.test.ts
+++ b/packages/rate-limit/src/rate-limiter.service.test.ts
@@ -1,7 +1,7 @@
 import type { LoggerService } from '@zeltjs/core';
 import { createTestTargetBase } from '@zeltjs/core/internal-bridge/testing';
 import type { AtomicKVStore } from '@zeltjs/kv';
-import { KVError, MemoryKVService } from '@zeltjs/kv';
+import { MemoryKVService } from '@zeltjs/kv';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { RateLimitConfig } from './rate-limit.config';
@@ -71,7 +71,7 @@ describe('RateLimitService', () => {
     const failingConfig = new RateLimitConfig(memoryKv);
     Object.defineProperty(failingConfig, 'store', {
       value: {
-        incr: vi.fn().mockRejectedValue(KVError.storeOperationFailed('incr', new Error('boom'))),
+        incr: vi.fn().mockRejectedValue(new Error('redis connection refused')),
         del: vi.fn(),
       } as unknown as AtomicKVStore,
     });
@@ -86,7 +86,7 @@ describe('RateLimitService', () => {
     const failingConfig = new RateLimitConfig(memoryKv);
     Object.defineProperty(failingConfig, 'store', {
       value: {
-        incr: vi.fn().mockRejectedValue(KVError.storeOperationFailed('incr', new Error('boom'))),
+        incr: vi.fn().mockRejectedValue(new Error('redis connection refused')),
         del: vi.fn(),
       } as unknown as AtomicKVStore,
     });

--- a/packages/testing/src/test-target.ts
+++ b/packages/testing/src/test-target.ts
@@ -19,6 +19,7 @@ const mergeGlobalDefaults = (configs: readonly AnyConstructor[]): AnyConstructor
   return [...defaults.configs, ...configs];
 };
 
+/** @throws {ZeltLifecycleStateError} */
 export const createTestTarget = async <T extends object>(
   targetClass: new (...args: never[]) => T,
   options: CreateTestTargetOptions = {},

--- a/packages/validate-valibot/src/validated.ts
+++ b/packages/validate-valibot/src/validated.ts
@@ -4,14 +4,17 @@ import { HTTPException } from 'hono/http-exception';
 import type { GenericSchema, InferOutput } from 'valibot';
 import { safeParse } from 'valibot';
 
+/** @throws {HTTPException | ZeltContextNotAvailableError} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target?: 'json',
 ): ValidatedMarker<InferOutput<Schema>, 'json'>;
+/** @throws {HTTPException | ZeltContextNotAvailableError} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target: 'form',
 ): ValidatedMarker<InferOutput<Schema>, 'form'>;
+/** @throws {HTTPException | ZeltContextNotAvailableError} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target: ValidationTarget = 'json',


### PR DESCRIPTION
## Summary
- Add `defineError` and `defineHttpException` factory functions for type-safe error handling
- Rename all error classes to use `Zelt*Error` prefix for consistency
- Add `@throws` TSDoc declarations across packages
- Add ESLint rule to forbid raw `Error` throws
- Move `defineError` to internal-bridge export (FW packages only)
- Remove unnecessary error wrappers (let backend errors propagate transparently)
- Add `middlewareName` to `ZeltMiddlewareExecutionError` for better diagnostics

## Test plan
- [x] All existing tests pass
- [x] New unit tests for `defineError` and `defineHttpException`
- [x] Lint and type checks pass