### PR TITLE
feat(core): add getMetadata API to HttpApp

### DIFF
--- a/packages/adapter-cloudflare-workers/src/index.ts
+++ b/packages/adapter-cloudflare-workers/src/index.ts
@@ -2,7 +2,8 @@ export { CloudflareWorkersEnvConfig } from './cloudflare-workers-env.config';
 export type {
   CloudflareWorkersApp,
   CloudflareWorkersOptions,
-  DynamicControllerMeta,
+  ControllerRouteInfo,
   DynamicMeta,
+  HttpMetadata,
 } from './on-cloudflare-workers';
 export { onCloudflareWorkers } from './on-cloudflare-workers';

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.ts
@@ -1,17 +1,16 @@
-import type { HttpApp, ReadyOptions, ReadyResult } from '@zeltjs/core';
-import { getControllerMetadata } from '@zeltjs/core';
+import type {
+  ControllerRouteInfo,
+  HttpApp,
+  HttpMetadata,
+  ReadyOptions,
+  ReadyResult,
+} from '@zeltjs/core';
 
 import { CloudflareWorkersEnvConfig } from './cloudflare-workers-env.config';
 
-export type DynamicControllerMeta = {
-  readonly basePath: string;
-  readonly name: string;
-  readonly sourceFile: string | undefined;
-};
+export type { ControllerRouteInfo, HttpMetadata };
 
-export type DynamicMeta = {
-  readonly controllers: readonly DynamicControllerMeta[];
-};
+export type DynamicMeta = HttpMetadata;
 
 export type CloudflareWorkersOptions = {
   readonly warmup?: boolean;
@@ -25,20 +24,6 @@ type BaseCloudflareWorkersApp = ReadyResult & {
 
 export type CloudflareWorkersApp = BaseCloudflareWorkersApp & {
   readonly __dynamicMeta?: DynamicMeta;
-};
-
-const collectDynamicMeta = (
-  controllers: readonly (new (...args: never[]) => object)[],
-): DynamicMeta => {
-  const controllerMetas = controllers.map((ctrl) => {
-    const meta = getControllerMetadata(ctrl);
-    return {
-      basePath: meta?.basePath ?? '/',
-      name: ctrl.name,
-      sourceFile: meta?.sourceFile,
-    };
-  });
-  return { controllers: controllerMetas };
 };
 
 export const onCloudflareWorkers = async (
@@ -63,7 +48,7 @@ export const onCloudflareWorkers = async (
   const base: BaseCloudflareWorkersApp = { ...resolver, fetch, shutdown: app.shutdown };
 
   if (options.dynamic) {
-    const __dynamicMeta = collectDynamicMeta(app.getControllers());
+    const __dynamicMeta = app.getMetadata();
     return { ...base, __dynamicMeta };
   }
 

--- a/packages/core/src/app/create-app.ts
+++ b/packages/core/src/app/create-app.ts
@@ -9,7 +9,7 @@ import type { CommandModule } from './modules/command-module';
 import { createCommandModule } from './modules/command-module';
 import type { ConfigModule } from './modules/config-module';
 import { createConfigModule } from './modules/config-module';
-import type { ControllerClass, HttpModule, HttpOptions } from './modules/http-module';
+import type { ControllerClass, HttpMetadata, HttpModule, HttpOptions } from './modules/http-module';
 import { createHttpModule } from './modules/http-module';
 import type { SchedulerClass, SchedulerModule } from './modules/scheduler-module';
 import { createSchedulerModule } from './modules/scheduler-module';
@@ -43,6 +43,7 @@ type HttpCapabilities = {
   readonly fetch: (request: Request) => Promise<Response>;
   readonly request: (input: string | Request, init?: RequestInit) => Promise<Response>;
   readonly getControllers: () => readonly ControllerClass[];
+  readonly getMetadata: () => HttpMetadata;
 };
 
 type CommandCapabilities = {
@@ -223,6 +224,7 @@ const buildAppObject = (
         fetch: httpModule.fetch,
         request: httpModule.request,
         getControllers: httpModule.getControllers,
+        getMetadata: httpModule.getMetadata,
       }
     : {};
   const commandMethods = commandModule

--- a/packages/core/src/app/modules/http-module.ts
+++ b/packages/core/src/app/modules/http-module.ts
@@ -7,6 +7,8 @@ import {
   ZeltLifecycleStateError,
 } from '../../errors';
 import { DefaultErrorHandler } from '../../http/default.error-handler';
+import type { ControllerRouteInfo } from '../../http/internal/metadata';
+import { collectControllerRouteInfo } from '../../http/internal/metadata';
 import { buildRoutes, warmupControllers } from '../../http/internal/route-builder';
 import type {
   ErrorHandlerClass,
@@ -25,10 +27,15 @@ export type HttpOptions = {
   readonly errorHandlers?: readonly ErrorHandlerClass[];
 };
 
+export type HttpMetadata = {
+  readonly controllers: readonly ControllerRouteInfo[];
+};
+
 export type HttpModule = Module & {
   fetch: (req: Request) => Promise<Response>;
   request: (input: string | Request, init?: RequestInit) => Promise<Response>;
   getControllers: () => readonly ControllerClass[];
+  getMetadata: () => HttpMetadata;
 };
 
 type HttpModuleState = {
@@ -216,6 +223,10 @@ export const createHttpModule = (options: HttpOptions): HttpModule => {
 
   const getControllers = (): readonly ControllerClass[] => options.controllers;
 
+  const getMetadata = (): HttpMetadata => ({
+    controllers: options.controllers.map(collectControllerRouteInfo),
+  });
+
   return {
     setup,
     ready,
@@ -223,5 +234,6 @@ export const createHttpModule = (options: HttpOptions): HttpModule => {
     fetch,
     request,
     getControllers,
+    getMetadata,
   };
 };

--- a/packages/core/src/http/internal/metadata.ts
+++ b/packages/core/src/http/internal/metadata.ts
@@ -32,6 +32,20 @@ type AuthorizedMetadata = {
   readonly roles: readonly string[];
 };
 
+export type RouteInfo = {
+  readonly method: HttpMethod;
+  readonly path: string;
+  readonly fullPath: string;
+  readonly methodName: string;
+};
+
+export type ControllerRouteInfo = {
+  readonly basePath: string;
+  readonly sourceFile: string | undefined;
+  readonly name: string;
+  readonly routes: readonly RouteInfo[];
+};
+
 const controllerStore = new WeakMap<object, ControllerMetadata>();
 const routeStore = new WeakMap<object, RouteMetadata[]>();
 const controllerMiddlewareStore = new WeakMap<object, ControllerMiddlewareMetadata>();
@@ -195,4 +209,39 @@ export const resolveAuthorizedMetadata = (pendingKey: object, cls: object): void
     setAuthorizedMetadata(cls, methodName, roles);
   }
   pendingAuthorizedStore.delete(pendingKey);
+};
+
+const joinPath = (base: string, sub: string): string => {
+  const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  const normalizedSub = sub.startsWith('/') ? sub : `/${sub}`;
+  const joined = `${normalizedBase}${normalizedSub}`;
+  return joined === '' ? '/' : joined;
+};
+
+export const collectControllerRouteInfo = (
+  cls: new (...args: never[]) => object,
+): ControllerRouteInfo => {
+  const controllerMeta = controllerStore.get(cls);
+  const basePath = controllerMeta?.basePath ?? '/';
+  const routeMeta = routeStore.get(cls) ?? [];
+
+  const routes = routeMeta.flatMap((r) =>
+    typeof r.methodName === 'string'
+      ? [
+          {
+            method: r.method,
+            path: r.path,
+            fullPath: joinPath(basePath, r.path),
+            methodName: r.methodName,
+          },
+        ]
+      : [],
+  );
+
+  return {
+    basePath,
+    sourceFile: controllerMeta?.sourceFile,
+    name: cls.name,
+    routes,
+  };
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export {
   type ReadyResult,
   type SchedulerApp,
 } from './app/create-app';
-export type { ControllerClass } from './app/modules/http-module';
+export type { ControllerClass, HttpMetadata } from './app/modules/http-module';
 export type { CommandContextStore } from './command/command-context';
 export { runInCommandContext } from './command/command-context';
 export { Command } from './command/decorator';
@@ -62,6 +62,7 @@ export type {
   ValidationErrorBody,
   ValidationIssue,
 } from './http/error-schema';
+export type { ControllerRouteInfo, RouteInfo } from './http/internal/metadata';
 export { getControllerMetadata } from './http/internal/metadata';
 export type {
   ErrorHandlerClass,


### PR DESCRIPTION
## Summary

- Add `getMetadata()` method to `HttpApp` that returns controller route information
- Integrates metadata collection directly into `createApp` flow
- Simplifies `onCloudflareWorkers` by using `app.getMetadata()` instead of manual collection

## Motivation

This enables downstream tools (hono client type generation, OpenAPI) to access route metadata at runtime without AST analysis. The `__dynamicMeta` in Cloudflare Workers adapter now uses this unified API.

## Changes

- `packages/core/src/http/internal/metadata.ts`: Add `RouteInfo`, `ControllerRouteInfo` types and `collectControllerRouteInfo()` function
- `packages/core/src/app/modules/http-module.ts`: Add `HttpMetadata` type and `getMetadata()` method
- `packages/core/src/app/create-app.ts`: Expose `getMetadata` in `HttpCapabilities`
- `packages/adapter-cloudflare-workers/src/on-cloudflare-workers.ts`: Use `app.getMetadata()` instead of manual metadata collection

## Test plan

- [x] Existing tests pass
- [x] Precommit checks pass