### PR TITLE
feat(website): update navbar logo with new tent icon

### DIFF
--- a/website/static/img/logo.svg
+++ b/website/static/img/logo.svg
@@ -1,10 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-  <defs>
-    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#5b21b6;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#a78bfa;stop-opacity:1" />
-    </linearGradient>
-  </defs>
-  <rect x="10" y="10" width="80" height="80" rx="12" fill="url(#grad)"/>
-  <text x="50" y="68" font-family="Arial, sans-serif" font-size="48" font-weight="bold" fill="white" text-anchor="middle">K</text>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g transform="matrix(1,0,0,1,-488,-1808)">
+        <g transform="matrix(1.080169,0,0,1.080169,349.738397,1045.400844)">
+            <rect x="128" y="706" width="948" height="948" style="fill:none;"/>
+            <g transform="matrix(1,0,0,1,-367,182.5)">
+                <g transform="matrix(1,0,0,1,-14,16)">
+                    <path d="M924,614L983.144,726.498" style="fill:none;stroke:rgb(1,0,0);stroke-width:23.14px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,1952,15)">
+                    <path d="M924,614L983.144,726.498" style="fill:none;stroke:rgb(1,0,0);stroke-width:23.14px;"/>
+                </g>
+                <g transform="matrix(1.477273,-0,0,1.477273,-644.227273,-614.727273)">
+                    <path d="M1324.38,1310.84L1347.451,1282.642C1350.408,1279.027 1355.744,1278.494 1359.358,1281.451C1362.973,1284.408 1363.506,1289.744 1360.549,1293.358L1332.935,1327.109L1324.38,1310.84Z" style="fill:rgb(1,0,0);"/>
+                </g>
+                <g transform="matrix(1.015692,0,0,1.054517,-4.540656,-58.616822)">
+                    <path d="M796.001,1332L608,1332L930.044,742.122C935.602,731.942 946.559,725.568 958.5,725.568C970.441,725.568 981.398,731.942 986.956,742.122L1309,1332L1120.999,1332L969.739,1005.514C967.759,1001.242 963.357,998.491 958.5,998.491C953.643,998.491 949.241,1001.242 947.261,1005.514L796.001,1332Z" style="fill:rgb(238,86,73);"/>
+                </g>
+                <g transform="matrix(-1.727273,0,0,1.727273,2920.727273,-936.727273)">
+                    <path d="M1335.984,1321.448L1359.601,1292.583C1362.13,1289.491 1361.674,1284.928 1358.583,1282.399C1355.491,1279.87 1350.928,1280.326 1348.399,1283.417L1328.667,1307.534L1335.984,1321.448Z" style="fill:rgb(1,0,0);"/>
+                </g>
+                <g>
+                    <g transform="matrix(0.472827,0,0,0.578477,515.795058,607.660086)">
+                        <path d="M609.431,1276.352L934.358,681.194C938.61,673.407 948.067,668.392 958.5,668.392C968.933,668.392 978.39,673.407 982.642,681.194L1307.569,1276.352L609.431,1276.352Z" style="fill:white;"/>
+                    </g>
+                    <g transform="matrix(0.472827,0,0,0.578477,515.795058,638.660086)">
+                        <path d="M667.638,1222.763L958.5,690L1249.362,1222.763L667.638,1222.763Z"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
 </svg>


### PR DESCRIPTION
## Summary
- Replace placeholder logo.svg with new tent icon design

## Test plan
- [ ] Verify navbar logo displays correctly in light mode
- [ ] Verify navbar logo displays correctly in dark mode