### PR TITLE
feat(cli): add plugin system for extensible build hooks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -385,6 +385,22 @@ export default tseslint.config(
     },
   },
   {
+    // hono-client plugin uses dynamic import for user app files.
+    // The imported module type is unknown at compile time.
+    files: ['packages/hono-client/src/plugin.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+    },
+  },
+  {
+    // openapi plugin uses dynamic import for user app files.
+    // The imported module type is unknown at compile time.
+    files: ['packages/openapi/src/plugin.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+    },
+  },
+  {
     // RedisService needs a private field to hold the Redis client instance.
     // This is necessary for stateful connection management.
     files: ['packages/redis/src/redis.service.ts'],

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -13,6 +13,7 @@ import {
   isZeltNoEntryError,
   ZeltNoEntryError,
 } from '../errors';
+import { runPreBuildHooks } from '../plugin/runner';
 
 const cliConfig = new NodeCliConfig();
 
@@ -37,6 +38,10 @@ const resolveBuildConfig = (args: BuildArgs, buildConfig: BuildConfig | undefine
 const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
   const configFile = typedArgs.config;
   const config = await loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd });
+
+  // Run preBuild hooks first
+  await runPreBuildHooks({ cwd, config });
+
   const buildConfig = resolveBuildConfig(typedArgs, config.build);
 
   if (buildConfig.entry === undefined) {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,3 +1,4 @@
+// packages/cli/src/commands/dev.ts
 import { NodeCliConfig } from '@zeltjs/adapter-node';
 import { defineCommand } from 'citty';
 import consola from 'consola';
@@ -40,7 +41,7 @@ const runDev = async (cwd: string, typedArgs: DevArgs): Promise<void> => {
     throw new ZeltNoEntryError({});
   }
 
-  await startDevServer({ cwd, config: { ...devConfig, entry: devConfig.entry } });
+  await startDevServer({ cwd, config, devConfig: { ...devConfig, entry: devConfig.entry } });
 };
 
 const handleError = (error: DevError): void => {

--- a/packages/cli/src/config/index.test.ts
+++ b/packages/cli/src/config/index.test.ts
@@ -95,21 +95,4 @@ describe('loadZeltConfig', () => {
 
     expect(config.cli?.entry).toBe('./src/cli.ts');
   });
-
-  it('loads legacy top-level fields for backward compatibility', async () => {
-    const configContent = `
-      export default {
-        controllers: ['./src/**/*.controller.ts'],
-        dist: './generated',
-        tsconfig: './tsconfig.json',
-      };
-    `;
-    await writeFile(join(testDir, 'zelt.config.ts'), configContent);
-
-    const config = await loadZeltConfig({ cwd: testDir });
-
-    expect(config.controllers).toEqual(['./src/**/*.controller.ts']);
-    expect(config.dist).toBe('./generated');
-    expect(config.tsconfig).toBe('./tsconfig.json');
-  });
 });

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,4 +1,4 @@
 export { isZeltConfigLoadError, ZeltConfigLoadError } from '../errors';
 export { defineConfig } from './define-config';
 export { type LoadConfigOptions, loadZeltConfig } from './loader';
-export type { BuildConfig, DevConfig, OpenApiConfig, ZeltConfig } from './schema';
+export type { BuildConfig, CliConfig, DevConfig, ZeltConfig } from './schema';

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1,10 +1,7 @@
+// packages/cli/src/config/schema.ts
 import * as v from 'valibot';
 
-const OpenApiConfigSchema = v.object({
-  controllers: v.optional(v.array(v.string())),
-  outDir: v.optional(v.string()),
-  tsconfig: v.optional(v.string()),
-});
+import type { ZeltPlugin } from '../plugin/types';
 
 const BuildConfigSchema = v.object({
   entry: v.optional(v.string()),
@@ -27,19 +24,16 @@ const CliConfigSchema = v.object({
 });
 
 export const ZeltConfigSchema = v.object({
-  openapi: v.optional(OpenApiConfigSchema),
+  entry: v.optional(v.string()),
+  plugins: v.optional(v.array(v.any())),
   build: v.optional(BuildConfigSchema),
   dev: v.optional(DevConfigSchema),
   cli: v.optional(CliConfigSchema),
-
-  // Legacy top-level fields for backward compatibility
-  controllers: v.optional(v.array(v.string())),
-  dist: v.optional(v.string()),
-  tsconfig: v.optional(v.string()),
 });
 
-export type ZeltConfig = v.InferOutput<typeof ZeltConfigSchema>;
+export type ZeltConfig = v.InferOutput<typeof ZeltConfigSchema> & {
+  readonly plugins?: readonly ZeltPlugin[];
+};
 export type BuildConfig = v.InferOutput<typeof BuildConfigSchema>;
 export type DevConfig = v.InferOutput<typeof DevConfigSchema>;
 export type CliConfig = v.InferOutput<typeof CliConfigSchema>;
-export type OpenApiConfig = v.InferOutput<typeof OpenApiConfigSchema>;

--- a/packages/cli/src/dev-server/server.ts
+++ b/packages/cli/src/dev-server/server.ts
@@ -1,3 +1,4 @@
+// packages/cli/src/dev-server/server.ts
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 
@@ -5,7 +6,8 @@ import { NodeCliConfig } from '@zeltjs/adapter-node';
 import type { SignalHandler } from '@zeltjs/core';
 import consola from 'consola';
 
-import type { DevConfig } from '../config/schema';
+import type { DevConfig, ZeltConfig } from '../config/schema';
+import { runPreBuildHooks } from '../plugin/runner';
 
 import type { WatcherHandle } from './watcher';
 import { createWatcher } from './watcher';
@@ -14,7 +16,8 @@ const cliConfig = new NodeCliConfig();
 
 export type DevServerOptions = {
   readonly cwd: string;
-  readonly config: DevConfig & { entry: string };
+  readonly config: ZeltConfig;
+  readonly devConfig: DevConfig & { entry: string };
 };
 
 type DevServerState = {
@@ -97,7 +100,12 @@ const createShutdownHandler = (state: DevServerState) => {
   };
 };
 
-const createRestartHandler = (state: DevServerState, cwd: string, entry: string) => {
+const createRestartHandler = (
+  state: DevServerState,
+  cwd: string,
+  entry: string,
+  config: ZeltConfig,
+) => {
   return async (): Promise<void> => {
     if (state.isShuttingDown) {
       return;
@@ -108,6 +116,9 @@ const createRestartHandler = (state: DevServerState, cwd: string, entry: string)
     if (state.childProcess !== undefined) {
       await killProcess(state.childProcess);
     }
+
+    // Run preBuild hooks before restarting
+    await runPreBuildHooks({ cwd, config });
 
     state.childProcess = startProcess(cwd, entry);
   };
@@ -128,7 +139,7 @@ const registerSignalHandlers = (onSignal: () => Promise<void>): SignalHandler =>
 };
 
 export const startDevServer = async (options: DevServerOptions): Promise<void> => {
-  const { cwd, config } = options;
+  const { cwd, config, devConfig } = options;
 
   const state: DevServerState = {
     childProcess: undefined,
@@ -136,12 +147,12 @@ export const startDevServer = async (options: DevServerOptions): Promise<void> =
     isShuttingDown: false,
   };
 
-  const watchPatterns = config.watch ?? DEFAULT_WATCH_PATTERNS;
-  const ignorePatterns = config.ignore ?? DEFAULT_IGNORE_PATTERNS;
-  const debounceMs = config.debounceMs ?? 300;
+  const watchPatterns = devConfig.watch ?? DEFAULT_WATCH_PATTERNS;
+  const ignorePatterns = devConfig.ignore ?? DEFAULT_IGNORE_PATTERNS;
+  const debounceMs = devConfig.debounceMs ?? 300;
 
   const shutdown = createShutdownHandler(state);
-  const restart = createRestartHandler(state, cwd, config.entry);
+  const restart = createRestartHandler(state, cwd, devConfig.entry, config);
 
   registerSignalHandlers(shutdown);
 
@@ -155,10 +166,13 @@ export const startDevServer = async (options: DevServerOptions): Promise<void> =
     },
   });
 
-  state.childProcess = startProcess(cwd, config.entry);
+  // Run preBuild hooks on initial start
+  await runPreBuildHooks({ cwd, config });
+
+  state.childProcess = startProcess(cwd, devConfig.entry);
 
   consola.success(`Dev server started. Watching for changes...`);
-  consola.info(`  Entry: ${config.entry}`);
+  consola.info(`  Entry: ${devConfig.entry}`);
   consola.info(`  Watch: ${watchPatterns.join(', ')}`);
   consola.info(`  Ignore: ${ignorePatterns.join(', ')}`);
 

--- a/packages/cli/src/dev-server/server.ts
+++ b/packages/cli/src/dev-server/server.ts
@@ -117,8 +117,11 @@ const createRestartHandler = (
       await killProcess(state.childProcess);
     }
 
-    // Run preBuild hooks before restarting
-    await runPreBuildHooks({ cwd, config });
+    try {
+      await runPreBuildHooks({ cwd, config });
+    } catch (error) {
+      consola.error('Plugin preBuild hook failed:', error);
+    }
 
     state.childProcess = startProcess(cwd, entry);
   };
@@ -166,8 +169,11 @@ export const startDevServer = async (options: DevServerOptions): Promise<void> =
     },
   });
 
-  // Run preBuild hooks on initial start
-  await runPreBuildHooks({ cwd, config });
+  try {
+    await runPreBuildHooks({ cwd, config });
+  } catch (error) {
+    consola.error('Plugin preBuild hook failed:', error);
+  }
 
   state.childProcess = startProcess(cwd, devConfig.entry);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,2 +1,3 @@
 export { defineConfig, loadZeltConfig } from './config/index';
 export type { ZeltConfig } from './config/schema';
+export type { BuildContext, ZeltPlugin } from './plugin/index';

--- a/packages/cli/src/plugin/index.ts
+++ b/packages/cli/src/plugin/index.ts
@@ -1,0 +1,1 @@
+export type { BuildContext, ZeltPlugin } from './types';

--- a/packages/cli/src/plugin/index.ts
+++ b/packages/cli/src/plugin/index.ts
@@ -1,1 +1,2 @@
+export { runPreBuildHooks } from './runner';
 export type { BuildContext, ZeltPlugin } from './types';

--- a/packages/cli/src/plugin/runner.test.ts
+++ b/packages/cli/src/plugin/runner.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ZeltConfig } from '../config/schema';
+
+import { runPreBuildHooks } from './runner';
+import type { ZeltPlugin } from './types';
+
+describe('runPreBuildHooks', () => {
+  const baseConfig: ZeltConfig = {
+    entry: './src/app.ts',
+    build: { entry: './src/index.ts' },
+  };
+
+  it('calls preBuild hooks in order', async () => {
+    const order: string[] = [];
+
+    const plugin1: ZeltPlugin = {
+      name: 'plugin1',
+      preBuild: async () => {
+        order.push('plugin1');
+      },
+    };
+
+    const plugin2: ZeltPlugin = {
+      name: 'plugin2',
+      preBuild: async () => {
+        order.push('plugin2');
+      },
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [plugin1, plugin2] };
+    await runPreBuildHooks({ cwd: '/test', config });
+
+    expect(order).toEqual(['plugin1', 'plugin2']);
+  });
+
+  it('skips plugins without preBuild hook', async () => {
+    const called = vi.fn();
+
+    const pluginWithHook: ZeltPlugin = {
+      name: 'with-hook',
+      preBuild: called,
+    };
+
+    const pluginWithoutHook: ZeltPlugin = {
+      name: 'without-hook',
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [pluginWithoutHook, pluginWithHook] };
+    await runPreBuildHooks({ cwd: '/test', config });
+
+    expect(called).toHaveBeenCalledOnce();
+  });
+
+  it('handles empty plugins array', async () => {
+    const config: ZeltConfig = { ...baseConfig, plugins: [] };
+    await expect(runPreBuildHooks({ cwd: '/test', config })).resolves.toBeUndefined();
+  });
+
+  it('handles undefined plugins', async () => {
+    const config: ZeltConfig = { ...baseConfig };
+    await expect(runPreBuildHooks({ cwd: '/test', config })).resolves.toBeUndefined();
+  });
+
+  it('passes correct context to plugin', async () => {
+    const receivedContext = vi.fn();
+
+    const plugin: ZeltPlugin = {
+      name: 'test',
+      preBuild: receivedContext,
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [plugin] };
+    await runPreBuildHooks({ cwd: '/my/cwd', config });
+
+    expect(receivedContext).toHaveBeenCalledWith({
+      cwd: '/my/cwd',
+      config,
+    });
+  });
+});

--- a/packages/cli/src/plugin/runner.ts
+++ b/packages/cli/src/plugin/runner.ts
@@ -1,0 +1,24 @@
+import consola from 'consola';
+
+import type { ZeltConfig } from '../config/schema';
+
+import type { BuildContext, ZeltPlugin } from './types';
+
+export type RunPreBuildHooksOptions = {
+  readonly cwd: string;
+  readonly config: ZeltConfig;
+};
+
+export const runPreBuildHooks = async (options: RunPreBuildHooksOptions): Promise<void> => {
+  const { cwd, config } = options;
+  const plugins: readonly ZeltPlugin[] = config.plugins ?? [];
+
+  for (const plugin of plugins) {
+    if (plugin.preBuild !== undefined) {
+      consola.info(`[${plugin.name}] Running preBuild hook...`);
+      const context: BuildContext = { cwd, config };
+      await plugin.preBuild(context);
+      consola.success(`[${plugin.name}] preBuild completed`);
+    }
+  }
+};

--- a/packages/cli/src/plugin/types.ts
+++ b/packages/cli/src/plugin/types.ts
@@ -1,0 +1,11 @@
+import type { ZeltConfig } from '../config/schema';
+
+export type BuildContext = {
+  readonly cwd: string;
+  readonly config: ZeltConfig;
+};
+
+export type ZeltPlugin = {
+  readonly name: string;
+  readonly preBuild?: (context: BuildContext) => Promise<void>;
+};

--- a/packages/hono-client/package.json
+++ b/packages/hono-client/package.json
@@ -30,12 +30,14 @@
   },
   "peerDependencies": {
     "@zeltjs/adapter-node": "workspace:*",
+    "@zeltjs/cli": "workspace:*",
     "@zeltjs/core": "workspace:*",
     "hono": "4.12.16"
   },
   "devDependencies": {
     "@types/node": "22.19.17",
     "@zeltjs/adapter-node": "workspace:*",
+    "@zeltjs/cli": "workspace:*",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/testing": "workspace:*",
     "hono": "4.12.16"

--- a/packages/hono-client/src/index.ts
+++ b/packages/hono-client/src/index.ts
@@ -17,3 +17,5 @@ export type {
 } from './generator';
 export { GeneratorService } from './generator';
 export { generateHonoAppType, generateHonoAppTypeFromApp } from './legacy';
+export type { HonoClientPluginOptions } from './plugin';
+export { honoClientPlugin } from './plugin';

--- a/packages/hono-client/src/plugin.ts
+++ b/packages/hono-client/src/plugin.ts
@@ -1,0 +1,50 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { ZeltPlugin } from '@zeltjs/cli';
+
+import type { HttpAppLike } from './generator';
+import { emitAppType } from './generator';
+
+type AppModule = {
+  app?: HttpAppLike;
+  default?: HttpAppLike;
+};
+
+export type HonoClientPluginOptions = {
+  readonly entry?: string;
+  readonly outDir?: string;
+  readonly output?: string;
+};
+
+const loadApp = async (cwd: string, entry: string): Promise<HttpAppLike> => {
+  const absPath = resolve(cwd, entry);
+  const fileUrl = pathToFileURL(absPath).href;
+  const mod: AppModule = await import(fileUrl);
+  const app = mod.app ?? mod.default;
+  if (app === undefined || typeof app.getMetadata !== 'function') {
+    throw new Error(`[hono-client] Could not find app with getMetadata() in ${entry}`);
+  }
+  return app;
+};
+
+export const honoClientPlugin = (options: HonoClientPluginOptions = {}): ZeltPlugin => ({
+  name: 'hono-client',
+  async preBuild(ctx) {
+    const entry = options.entry ?? ctx.config.entry;
+    if (entry === undefined) {
+      throw new Error('[hono-client] entry is required. Set it in plugin options or config.entry');
+    }
+
+    const app = await loadApp(ctx.cwd, entry);
+    const distDir = options.outDir ?? './generated';
+    const outputFilename = options.output ?? 'app-type.ts';
+    const outputPath = resolve(ctx.cwd, distDir, outputFilename);
+
+    const content = emitAppType(app.getMetadata(), resolve(ctx.cwd, distDir));
+
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, content, 'utf-8');
+  },
+});

--- a/packages/hono-client/tsconfig.json
+++ b/packages/hono-client/tsconfig.json
@@ -12,5 +12,10 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../core" }, { "path": "../adapter-node" }, { "path": "../testing" }]
+  "references": [
+    { "path": "../cli" },
+    { "path": "../core" },
+    { "path": "../adapter-node" },
+    { "path": "../testing" }
+  ]
 }

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -26,6 +26,7 @@
     "typecheck": "tsc -b"
   },
   "peerDependencies": {
+    "@zeltjs/cli": "workspace:*",
     "@zeltjs/core": "workspace:*"
   },
   "dependencies": {

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -33,6 +33,7 @@
     "ts-json-schema-generator": "2.9.0"
   },
   "devDependencies": {
-    "@types/node": "22.19.17"
+    "@types/node": "22.19.17",
+    "@zeltjs/cli": "workspace:*"
   }
 }

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -1,9 +1,4 @@
-export type {
-  ControllerRouteInfo,
-  GenerateOpenApiOptions,
-  GenerateOpenApiResult,
-  HttpMetadata,
-  RouteInfo,
-} from './generate-openapi';
+export type { GenerateOpenApiOptions, GenerateOpenApiResult } from './generate-openapi';
 export { generateOpenApi } from './generate-openapi';
-export type { JsonSchema, SchemaAdapter } from './schema-adapter';
+export type { OpenApiPluginOptions } from './plugin';
+export { openapiPlugin } from './plugin';

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -2,3 +2,4 @@ export type { GenerateOpenApiOptions, GenerateOpenApiResult } from './generate-o
 export { generateOpenApi } from './generate-openapi';
 export type { OpenApiPluginOptions } from './plugin';
 export { openapiPlugin } from './plugin';
+export type { JsonSchema, SchemaAdapter } from './schema-adapter';

--- a/packages/openapi/src/plugin.ts
+++ b/packages/openapi/src/plugin.ts
@@ -1,0 +1,47 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { ZeltPlugin } from '@zeltjs/cli';
+
+import type { GenerateOpenApiOptions, HttpMetadata } from './generate-openapi';
+import { generateOpenApi } from './generate-openapi';
+
+type HttpAppLike = {
+  getMetadata: () => HttpMetadata;
+};
+
+export type OpenApiPluginOptions = {
+  readonly entry?: string;
+  readonly outDir?: string;
+  readonly tsconfig?: string;
+  readonly title?: string;
+  readonly version?: string;
+};
+
+export const openapiPlugin = (options: OpenApiPluginOptions = {}): ZeltPlugin => ({
+  name: 'openapi',
+  async preBuild(ctx) {
+    const entry = options.entry ?? ctx.config.entry;
+    if (entry === undefined) {
+      throw new Error('[openapi] entry is required. Set it in plugin options or config.entry');
+    }
+
+    const absPath = resolve(ctx.cwd, entry);
+    const fileUrl = pathToFileURL(absPath).href;
+    const mod: { app?: HttpAppLike; default?: HttpAppLike } = await import(fileUrl);
+    const app = mod.app ?? mod.default;
+
+    if (app === undefined || typeof app.getMetadata !== 'function') {
+      throw new Error(`[openapi] Could not find app with getMetadata() in ${entry}`);
+    }
+
+    const generateOptions: GenerateOpenApiOptions = {
+      distDir: options.outDir ?? './dist',
+      ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
+      ...(options.title !== undefined && { title: options.title }),
+      ...(options.version !== undefined && { version: options.version }),
+    };
+
+    await generateOpenApi(app, generateOptions);
+  },
+});

--- a/packages/openapi/src/plugin.ts
+++ b/packages/openapi/src/plugin.ts
@@ -10,6 +10,11 @@ type HttpAppLike = {
   getMetadata: () => HttpMetadata;
 };
 
+type AppModule = {
+  app?: HttpAppLike;
+  default?: HttpAppLike;
+};
+
 export type OpenApiPluginOptions = {
   readonly entry?: string;
   readonly outDir?: string;
@@ -18,6 +23,24 @@ export type OpenApiPluginOptions = {
   readonly version?: string;
 };
 
+const loadApp = async (cwd: string, entry: string): Promise<HttpAppLike> => {
+  const absPath = resolve(cwd, entry);
+  const fileUrl = pathToFileURL(absPath).href;
+  const mod: AppModule = await import(fileUrl);
+  const app = mod.app ?? mod.default;
+  if (app === undefined || typeof app.getMetadata !== 'function') {
+    throw new Error(`[openapi] Could not find app with getMetadata() in ${entry}`);
+  }
+  return app;
+};
+
+const buildGenerateOptions = (options: OpenApiPluginOptions): GenerateOpenApiOptions => ({
+  distDir: options.outDir ?? './dist',
+  ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
+  ...(options.title !== undefined && { title: options.title }),
+  ...(options.version !== undefined && { version: options.version }),
+});
+
 export const openapiPlugin = (options: OpenApiPluginOptions = {}): ZeltPlugin => ({
   name: 'openapi',
   async preBuild(ctx) {
@@ -25,23 +48,7 @@ export const openapiPlugin = (options: OpenApiPluginOptions = {}): ZeltPlugin =>
     if (entry === undefined) {
       throw new Error('[openapi] entry is required. Set it in plugin options or config.entry');
     }
-
-    const absPath = resolve(ctx.cwd, entry);
-    const fileUrl = pathToFileURL(absPath).href;
-    const mod: { app?: HttpAppLike; default?: HttpAppLike } = await import(fileUrl);
-    const app = mod.app ?? mod.default;
-
-    if (app === undefined || typeof app.getMetadata !== 'function') {
-      throw new Error(`[openapi] Could not find app with getMetadata() in ${entry}`);
-    }
-
-    const generateOptions: GenerateOpenApiOptions = {
-      distDir: options.outDir ?? './dist',
-      ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
-      ...(options.title !== undefined && { title: options.title }),
-      ...(options.version !== undefined && { version: options.version }),
-    };
-
-    await generateOpenApi(app, generateOptions);
+    const app = await loadApp(ctx.cwd, entry);
+    await generateOpenApi(app, buildGenerateOptions(options));
   },
 });

--- a/packages/openapi/tsconfig.json
+++ b/packages/openapi/tsconfig.json
@@ -12,5 +12,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../cli" }, { "path": "../core" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,9 +408,6 @@ importers:
 
   packages/openapi:
     dependencies:
-      '@zeltjs/cli':
-        specifier: workspace:*
-        version: link:../cli
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
@@ -421,6 +418,9 @@ importers:
       '@types/node':
         specifier: 22.19.17
         version: 22.19.17
+      '@zeltjs/cli':
+        specifier: workspace:*
+        version: link:../cli
 
   packages/rate-limit:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,9 @@ importers:
       '@zeltjs/adapter-node':
         specifier: workspace:*
         version: link:../adapter-node
+      '@zeltjs/cli':
+        specifier: workspace:*
+        version: link:../cli
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
@@ -405,6 +408,9 @@ importers:
 
   packages/openapi:
     dependencies:
+      '@zeltjs/cli':
+        specifier: workspace:*
+        version: link:../cli
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

- Add `ZeltPlugin` interface with `preBuild` hook for CLI extensibility
- Plugins run before tsdown build in both `zelt build` and `zelt dev` commands
- Implement `openapiPlugin` and `honoClientPlugin` as first-party plugins

## Changes

### @zeltjs/cli
- New `plugin/` module with `ZeltPlugin`, `BuildContext` types and `runPreBuildHooks` runner
- Config schema updated with `entry` and `plugins` fields
- Build command integrates preBuild hooks before tsdown
- Dev server runs preBuild hooks on initial start and file-change restart

### @zeltjs/openapi
- New `openapiPlugin` for generating OpenAPI schema via CLI

### @zeltjs/hono-client  
- New `honoClientPlugin` for generating Hono client types via CLI

## Usage

```ts
// zelt.config.ts
import { defineConfig } from '@zeltjs/cli'
import { openapiPlugin } from '@zeltjs/openapi'
import { honoClientPlugin } from '@zeltjs/hono-client'

export default defineConfig({
  entry: './src/app.ts',
  plugins: [
    openapiPlugin({ outDir: './dist' }),
    honoClientPlugin({ outDir: './generated' }),
  ],
  build: { entry: './src/index.ts' }
})
```

## Test plan

- [x] Typecheck passes across monorepo
- [x] 507 tests pass
- [x] All 20 packages build successfully
- [x] CLI exports verified