### PR TITLE
docs(adapter-cloudflare-workers): use explicit fetch extraction pattern

### DIFF
--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -24,7 +24,9 @@ class HelloController {
 
 const app = createHttpApp({ controllers: [HelloController] });
 
-export default onCloudflareWorkers(app);
+const workers = await onCloudflareWorkers(app);
+
+export default { fetch: workers.fetch };
 ```
 
 ## Options
@@ -61,5 +63,7 @@ const app = createHttpApp({
   configs: [EnvConfig],
 });
 
-export default onCloudflareWorkers(app);
+const workers = await onCloudflareWorkers(app);
+
+export default { fetch: workers.fetch };
 ```

--- a/website/docs/getting-started/cloudflare-workers.md
+++ b/website/docs/getting-started/cloudflare-workers.md
@@ -78,10 +78,12 @@ Create `src/index.ts` as the Cloudflare Workers entry point:
 import { onCloudflareWorkers } from '@zeltjs/adapter-cloudflare-workers';
 import { app } from './app';
 
-export default await onCloudflareWorkers(app);
+const workers = await onCloudflareWorkers(app);
+
+export default { fetch: workers.fetch };
 ```
 
-The `onCloudflareWorkers()` function is async and prepares your app for the Workers runtime. By default, it uses **lazy initialization** (`warmup: false`) — controllers are resolved on the first request rather than at startup. This optimizes cold start times in serverless environments.
+The `onCloudflareWorkers()` function is async and prepares your app for the Workers runtime. The returned object contains the `fetch` handler along with other utilities like `shutdown` and `get` for accessing services. By default, it uses **lazy initialization** (`warmup: false`) — controllers are resolved on the first request rather than at startup. This optimizes cold start times in serverless environments.
 
 ### Step 4: Configure Wrangler
 
@@ -224,7 +226,9 @@ By default, `onCloudflareWorkers()` uses lazy initialization (`warmup: false`) t
 If you prefer to resolve all controllers at initialization (useful for debugging or when cold start time is less critical), set `warmup: true`:
 
 ```typescript
-export default await onCloudflareWorkers(app, { warmup: true });
+const workers = await onCloudflareWorkers(app, { warmup: true });
+
+export default { fetch: workers.fetch };
 ```
 
 | Option | Behavior | Use Case |

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/cloudflare-workers.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/cloudflare-workers.md
@@ -78,10 +78,12 @@ Cloudflare Workersのエントリーポイント`src/index.ts`を作成:
 import { onCloudflareWorkers } from '@zeltjs/adapter-cloudflare-workers';
 import { app } from './app';
 
-export default onCloudflareWorkers(app);
+const workers = await onCloudflareWorkers(app);
+
+export default { fetch: workers.fetch };
 ```
 
-`onCloudflareWorkers()`関数は、アプリをWorkersランタイム用にラップします。デフォルトでは**遅延初期化**を使用します — コントローラーは起動時ではなく最初のリクエスト時に解決されます。これにより、サーバーレス環境でのコールドスタート時間が最適化されます。
+`onCloudflareWorkers()`関数は非同期で、アプリをWorkersランタイム用に準備します。戻り値には`fetch`ハンドラーの他に、`shutdown`やサービスにアクセスするための`get`などのユーティリティが含まれます。デフォルトでは**遅延初期化**を使用します — コントローラーは起動時ではなく最初のリクエスト時に解決されます。これにより、サーバーレス環境でのコールドスタート時間が最適化されます。
 
 ### ステップ4: Wranglerの設定
 
@@ -224,7 +226,9 @@ npx wrangler deploy
 すべてのコントローラーを初期化時に解決したい場合（デバッグや、コールドスタート時間があまり重要でない場合に便利）、`warmup: true`を設定:
 
 ```typescript
-export default onCloudflareWorkers(app, { warmup: true });
+const workers = await onCloudflareWorkers(app, { warmup: true });
+
+export default { fetch: workers.fetch };
 ```
 
 | オプション | 動作 | ユースケース |


### PR DESCRIPTION
## Summary

- Update Cloudflare Workers adapter documentation to use explicit fetch extraction pattern
- Align API usage pattern with Lambda adapter for consistency across adapters

## Changes

```typescript
// Before
export default await onCloudflareWorkers(app);

// After
const workers = await onCloudflareWorkers(app);
export default { fetch: workers.fetch };
```

This pattern:
- Makes the API consistent with Lambda adapter (`const lambda = await onLambda(app); export const handler = lambda.handler;`)
- Allows access to other utilities like `shutdown` and `get` for accessing services
- Prepares for future additions like `scheduled` handler

## Files Changed

- `packages/adapter-cloudflare-workers/README.md`
- `website/docs/getting-started/cloudflare-workers.md` (EN)
- `website/i18n/ja/.../cloudflare-workers.md` (JA)