### PR TITLE
fix: exclude private packages from npm trust setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "typescript-eslint": "8.59.1",
     "unplugin-swc": "1.5.9",
     "vitest": "4.1.5"
+  },
+  "volta": {
+    "node": "26.1.0"
   }
 }

--- a/scripts/setup-npm-trust.sh
+++ b/scripts/setup-npm-trust.sh
@@ -76,7 +76,7 @@ check_npm_version() {
 }
 
 get_zeltjs_packages() {
-  pnpm -r exec -- node -p "require('./package.json').name" 2>/dev/null \
+  pnpm -r exec -- node -p "const p=require('./package.json'); p.private ? '' : p.name" 2>/dev/null \
     | grep "^${SCOPE}/" \
     | sort
 }


### PR DESCRIPTION
## Summary
- Skip packages with `"private": true` in `package.json` when running npm trusted publisher setup
- Pin Node.js version via Volta (`26.1.0`)

## Test plan
- [x] `pnpm run precommit` passes