### PR TITLE
docs: update status to alpha and soften portability claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Documentation](https://img.shields.io/badge/docs-zeltjs.com-blue)](https://zeltjs.com)
 
-> Portable application framework with DI — Node, Workers, Lambda... anywhere.
+> Portable application framework with DI — swap adapters for different runtimes.
 
-ZeltJS is a portable TypeScript application framework with built-in DI. It runs anywhere — Node.js, Bun, Cloudflare Workers, AWS Lambda.
+ZeltJS is a portable TypeScript application framework with built-in DI. Swap adapters to run on Node.js, Bun, Cloudflare Workers, or AWS Lambda.
 
 ```typescript
 import { Controller, Get, Post, validated, pathParam, createApp } from '@zeltjs/core';
@@ -52,7 +52,7 @@ export const handler = lambda.handler;
 
 ## Why ZeltJS?
 
-- **Run Anywhere** — Node, Bun, Workers, Lambda — portable across runtimes
+- **Portable** — Swap adapters for Node, Bun, Workers, Lambda
 - **DI Built-in** — First-class dependency injection, type-safe
 - **Fast Startup** — Minimal wake-up time, serverless-ready
 - **Future-proof Decorators** — TC39 & reflect-metadata dual support
@@ -61,7 +61,7 @@ export const handler = lambda.handler;
 
 ## Status
 
-**pre-alpha** — Breaking changes may occur in minor versions during 0.x.
+**alpha** — Breaking changes may occur in minor versions during 0.x.
 
 ## License
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -4,7 +4,7 @@ slug: /
 
 # Introduction
 
-ZeltJS is a portable TypeScript application framework with built-in DI. It runs anywhere — Node.js, Bun, Cloudflare Workers, AWS Lambda.
+ZeltJS is a portable TypeScript application framework with built-in DI. Swap adapters to run on Node.js, Bun, Cloudflare Workers, or AWS Lambda.
 Building large-scale applications that work across different infrastructure. That's what ZeltJS aims for.
 
 ## Philosophy

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -5,7 +5,7 @@ import kanagawa from './src/prism-theme-kanagawa';
 
 const config: Config = {
   title: 'ZeltJS',
-  tagline: 'Portable application framework with DI — runs anywhere',
+  tagline: 'Portable application framework with DI — swap adapters for different runtimes',
   favicon: 'img/favicon.png',
 
   future: {

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/introduction.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/introduction.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # イントロダクション
 
-ZeltJSは、DIを組み込んだポータブルなTypeScriptアプリケーションフレームワークです。Node.js、Bun、Cloudflare Workers、AWS Lambdaなど、どこでも動きます。
+ZeltJSは、DIを組み込んだポータブルなTypeScriptアプリケーションフレームワークです。アダプターを切り替えることで、Node.js、Bun、Cloudflare Workers、AWS Lambdaで動作します。
 大規模なアプリケーションを、インフラを変えても動くように書けること。これがZeltJSの目指すところです。
 
 ## 設計思想


### PR DESCRIPTION
## Summary

- Update project status from pre-alpha to alpha
- Replace "runs anywhere" messaging with "swap adapters" to accurately reflect current testing coverage
- Maintain portable design positioning while being honest about runtime verification status

## Changed Files

- README.md (EN)
- website/docs/introduction.md (EN)
- website/docusaurus.config.ts (tagline)
- website/i18n/ja/.../introduction.md (JA)