### PR TITLE
fix(docs): use import for RedisTestContainerConfig

### DIFF
--- a/website/docs/testing/e2e.md
+++ b/website/docs/testing/e2e.md
@@ -64,13 +64,13 @@ For complete E2E tests with real dependencies, combine with [Integration Testing
 ```typescript
 import { createApp, Controller, Get, Post, pathParam, response, HttpApp, ConfigClass } from '@zeltjs/core';
 import { validated } from '@zeltjs/validator-valibot';
+import { RedisTestContainerConfig } from '@zeltjs/testing/redis';
 import * as v from 'valibot';
 declare function hc<T>(baseUrl: string, options?: { fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> }): T;
 declare function describe(name: string, fn: () => void): void;
 declare function it(name: string, fn: () => void | Promise<void>): void;
 declare function beforeAll(fn: () => void | Promise<void>): void;
 declare function expect<T>(value: T): { toBe(expected: T): void; };
-declare const RedisTestContainerConfig: ConfigClass<object>;
 const UserBody = v.object({ name: v.string(), email: v.pipe(v.string(), v.email()) });
 @Controller('/users') class UserController {
   @Get('/:id') findOne(id = pathParam('id')) { return { id, name: 'Alice', email: 'alice@example.com' }; }

--- a/website/docs/testing/integration.md
+++ b/website/docs/testing/integration.md
@@ -15,11 +15,11 @@ pnpm add -D @zeltjs/testing testcontainers
 
 ```typescript
 import { ConfigClass } from '@zeltjs/core';
+import { RedisTestContainerConfig } from '@zeltjs/testing/redis';
 declare function describe(name: string, fn: () => void): void;
 declare function it(name: string, fn: () => void | Promise<void>): void;
 declare function expect<T>(value: T): { toBe(expected: T): void; };
 declare function createTestTarget<T extends object>(cls: new (...args: never[]) => T, opts?: { configs?: readonly ConfigClass<object>[] }): Promise<{ target: T; shutdown: () => Promise<void> }>;
-declare const RedisTestContainerConfig: ConfigClass<object>;
 declare class CacheService { set(key: string, value: string): Promise<void>; get(key: string): Promise<string>; }
 // ---cut---
 describe('CacheService', () => {
@@ -99,12 +99,12 @@ Integration tests with Testcontainers are ideal for "Sociable Unit Tests" — te
 
 ```typescript
 import { ConfigClass } from '@zeltjs/core';
+import { RedisTestContainerConfig } from '@zeltjs/testing/redis';
 declare function describe(name: string, fn: () => void): void;
 declare function it(name: string, fn: () => void | Promise<void>): void;
 declare function expect<T>(value: T): { toBe(expected: T): void; };
 type TestTargetResult<T> = { target: T; get: <U>(cls: new (...args: never[]) => U) => U; shutdown: () => Promise<void> };
 declare function createTestTarget<T extends object>(cls: new (...args: never[]) => T, opts?: { configs?: readonly ConfigClass<object>[] }): Promise<TestTargetResult<T>>;
-declare const RedisTestContainerConfig: ConfigClass<object>;
 declare class SessionService { create(data: { userId: string }): Promise<{ id: string }>; }
 declare class UserService { fromSession(sessionId: string): Promise<{ id: string }>; }
 // ---cut---


### PR DESCRIPTION
## Summary
- Replace `declare const RedisTestContainerConfig` with proper import from `@zeltjs/testing/redis` in testing documentation
- Fixed in `website/docs/testing/integration.md` (2 occurrences) and `website/docs/testing/e2e.md` (1 occurrence)

## Test plan
- [ ] Verify docs build correctly
- [ ] Check twoslash code blocks render properly with the import