### PR TITLE
fix(docs): sync testing docs with build directory

### DIFF
--- a/website/docs/testing/e2e.md
+++ b/website/docs/testing/e2e.md
@@ -8,9 +8,13 @@ Test your application's HTTP endpoints end-to-end using Hono's built-in request 
 ## HTTP Testing
 
 ```typescript
-import { describe, it, expect } from 'vitest';
-import { app } from './app';
-
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+declare function describe(name: string, fn: () => void): void;
+declare function it(name: string, fn: () => void | Promise<void>): void;
+declare function expect<T>(value: T): { toBe(expected: T): void; toEqual(expected: unknown): void; };
+@Controller('/hello') class HelloController { @Get('/:name') greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; } }
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
 describe('Hello API', () => {
   it('should return greeting', async () => {
     const res = await app.request('/hello/world');
@@ -27,14 +31,18 @@ describe('Hello API', () => {
 Use the generated `AppType` with Hono's client for fully typed tests. See [OpenAPI & Type Generation](../openapi.md) for how to generate `AppType`.
 
 ```typescript
-import { hc } from 'hono/client';
-import { describe, it, expect } from 'vitest';
-import { app } from './app';
-import type { AppType } from './generated/app.gen';
-
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+declare function hc<T>(baseUrl: string, options?: { fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> }): T;
+declare function describe(name: string, fn: () => void): void;
+declare function it(name: string, fn: () => void | Promise<void>): void;
+declare function expect<T>(value: T): { toBe(expected: T): void; };
+@Controller('/hello') class HelloController { @Get('/:name') greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; } }
+const app = createApp({ http: { controllers: [HelloController] } });
+type AppType = { hello: { ':name': { $get: (opts: { param: { name: string } }) => Promise<Response & { json(): Promise<{ message: string }> }> } } };
+// ---cut---
 describe('Hello API', () => {
   const client = hc<AppType>('http://localhost', {
-    fetch: (input, init) => app.fetch(new Request(input, init)),
+    fetch: (input: RequestInfo | URL, init?: RequestInit) => app.fetch(new Request(input, init)),
   });
 
   it('should return greeting with type safety', async () => {
@@ -54,22 +62,38 @@ describe('Hello API', () => {
 For complete E2E tests with real dependencies, combine with [Integration Testing](./integration.md):
 
 ```typescript
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { hc } from 'hono/client';
-import { createApp } from './app';
+import { createApp, Controller, Get, Post, pathParam, response, HttpApp, ConfigClass } from '@zeltjs/core';
+import { validated } from '@zeltjs/validator-valibot';
+import * as v from 'valibot';
+declare function hc<T>(baseUrl: string, options?: { fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> }): T;
+declare function describe(name: string, fn: () => void): void;
+declare function it(name: string, fn: () => void | Promise<void>): void;
+declare function beforeAll(fn: () => void | Promise<void>): void;
+declare function expect<T>(value: T): { toBe(expected: T): void; };
 import { RedisTestContainerConfig } from '@zeltjs/redis/testing';
-import type { AppType } from './generated/app.gen';
-
+const UserBody = v.object({ name: v.string(), email: v.pipe(v.string(), v.email()) });
+@Controller('/users') class UserController {
+  @Get('/:id') findOne(id = pathParam('id')) { return { id, name: 'Alice', email: 'alice@example.com' }; }
+  @Post('/') create(body = validated(UserBody), res = response()) { return res.json({ id: '1', ...body }, 201); }
+}
+type AppType = {
+  users: {
+    $post: (opts: { json: { name: string; email: string } }) => Promise<Response & { json(): Promise<{ id: string }> }>;
+    ':id': { $get: (opts: { param: { id: string } }) => Promise<Response & { json(): Promise<{ id: string; name: string }> }> };
+  };
+};
+// ---cut---
 describe('API E2E', () => {
-  let app: ReturnType<typeof createApp>;
-  let client: ReturnType<typeof hc<AppType>>;
+  let app: HttpApp;
+  let client: AppType;
 
   beforeAll(async () => {
-    app = await createApp({
+    app = createApp({
       configs: [RedisTestContainerConfig],
+      http: { controllers: [UserController] },
     });
     client = hc<AppType>('http://localhost', {
-      fetch: (input, init) => app.fetch(new Request(input, init)),
+      fetch: (input: RequestInfo | URL, init?: RequestInit) => app.fetch(new Request(input, init)),
     });
   });
 

--- a/website/docs/testing/e2e.md
+++ b/website/docs/testing/e2e.md
@@ -8,13 +8,9 @@ Test your application's HTTP endpoints end-to-end using Hono's built-in request 
 ## HTTP Testing
 
 ```typescript
-import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
-declare function describe(name: string, fn: () => void): void;
-declare function it(name: string, fn: () => void | Promise<void>): void;
-declare function expect<T>(value: T): { toBe(expected: T): void; toEqual(expected: unknown): void; };
-@Controller('/hello') class HelloController { @Get('/:name') greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; } }
-const app = createApp({ http: { controllers: [HelloController] } });
-// ---cut---
+import { describe, it, expect } from 'vitest';
+import { app } from './app';
+
 describe('Hello API', () => {
   it('should return greeting', async () => {
     const res = await app.request('/hello/world');
@@ -31,18 +27,14 @@ describe('Hello API', () => {
 Use the generated `AppType` with Hono's client for fully typed tests. See [OpenAPI & Type Generation](../openapi.md) for how to generate `AppType`.
 
 ```typescript
-import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
-declare function hc<T>(baseUrl: string, options?: { fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> }): T;
-declare function describe(name: string, fn: () => void): void;
-declare function it(name: string, fn: () => void | Promise<void>): void;
-declare function expect<T>(value: T): { toBe(expected: T): void; };
-@Controller('/hello') class HelloController { @Get('/:name') greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; } }
-const app = createApp({ http: { controllers: [HelloController] } });
-type AppType = { hello: { ':name': { $get: (opts: { param: { name: string } }) => Promise<Response & { json(): Promise<{ message: string }> }> } } };
-// ---cut---
+import { hc } from 'hono/client';
+import { describe, it, expect } from 'vitest';
+import { app } from './app';
+import type { AppType } from './generated/app.gen';
+
 describe('Hello API', () => {
   const client = hc<AppType>('http://localhost', {
-    fetch: (input: RequestInfo | URL, init?: RequestInit) => app.fetch(new Request(input, init)),
+    fetch: (input, init) => app.fetch(new Request(input, init)),
   });
 
   it('should return greeting with type safety', async () => {
@@ -62,38 +54,22 @@ describe('Hello API', () => {
 For complete E2E tests with real dependencies, combine with [Integration Testing](./integration.md):
 
 ```typescript
-import { createApp, Controller, Get, Post, pathParam, response, HttpApp, ConfigClass } from '@zeltjs/core';
-import { validated } from '@zeltjs/validator-valibot';
-import * as v from 'valibot';
-declare function hc<T>(baseUrl: string, options?: { fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> }): T;
-declare function describe(name: string, fn: () => void): void;
-declare function it(name: string, fn: () => void | Promise<void>): void;
-declare function beforeAll(fn: () => void | Promise<void>): void;
-declare function expect<T>(value: T): { toBe(expected: T): void; };
-declare const RedisTestContainerConfig: ConfigClass<object>;
-const UserBody = v.object({ name: v.string(), email: v.pipe(v.string(), v.email()) });
-@Controller('/users') class UserController {
-  @Get('/:id') findOne(id = pathParam('id')) { return { id, name: 'Alice', email: 'alice@example.com' }; }
-  @Post('/') create(body = validated(UserBody), res = response()) { return res.json({ id: '1', ...body }, 201); }
-}
-type AppType = {
-  users: {
-    $post: (opts: { json: { name: string; email: string } }) => Promise<Response & { json(): Promise<{ id: string }> }>;
-    ':id': { $get: (opts: { param: { id: string } }) => Promise<Response & { json(): Promise<{ id: string; name: string }> }> };
-  };
-};
-// ---cut---
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { hc } from 'hono/client';
+import { createApp } from './app';
+import { RedisTestContainerConfig } from '@zeltjs/testing/redis';
+import type { AppType } from './generated/app.gen';
+
 describe('API E2E', () => {
-  let app: HttpApp;
-  let client: AppType;
+  let app: ReturnType<typeof createApp>;
+  let client: ReturnType<typeof hc<AppType>>;
 
   beforeAll(async () => {
-    app = createApp({
+    app = await createApp({
       configs: [RedisTestContainerConfig],
-      http: { controllers: [UserController] },
     });
     client = hc<AppType>('http://localhost', {
-      fetch: (input: RequestInfo | URL, init?: RequestInit) => app.fetch(new Request(input, init)),
+      fetch: (input, init) => app.fetch(new Request(input, init)),
     });
   });
 

--- a/website/docs/testing/e2e.md
+++ b/website/docs/testing/e2e.md
@@ -57,7 +57,7 @@ For complete E2E tests with real dependencies, combine with [Integration Testing
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { hc } from 'hono/client';
 import { createApp } from './app';
-import { RedisTestContainerConfig } from '@zeltjs/testing/redis';
+import { RedisTestContainerConfig } from '@zeltjs/redis/testing';
 import type { AppType } from './generated/app.gen';
 
 describe('API E2E', () => {

--- a/website/docs/testing/integration.md
+++ b/website/docs/testing/integration.md
@@ -14,14 +14,11 @@ pnpm add -D @zeltjs/testing testcontainers
 ## Redis Integration Testing
 
 ```typescript
-import { ConfigClass } from '@zeltjs/core';
-declare function describe(name: string, fn: () => void): void;
-declare function it(name: string, fn: () => void | Promise<void>): void;
-declare function expect<T>(value: T): { toBe(expected: T): void; };
-declare function createTestTarget<T extends object>(cls: new (...args: never[]) => T, opts?: { configs?: readonly ConfigClass<object>[] }): Promise<{ target: T; shutdown: () => Promise<void> }>;
-declare const RedisTestContainerConfig: ConfigClass<object>;
-declare class CacheService { set(key: string, value: string): Promise<void>; get(key: string): Promise<string>; }
-// ---cut---
+import { describe, it, expect } from 'vitest';
+import { createTestTarget } from '@zeltjs/testing/vitest';
+import { RedisTestContainerConfig } from '@zeltjs/testing/redis';
+import { CacheService } from './cache.service';
+
 describe('CacheService', () => {
   it('should cache values in Redis', async () => {
     const { target } = await createTestTarget(CacheService, {
@@ -47,18 +44,8 @@ Create your own container config by implementing the `Lifecycle` interface:
 
 ```typescript
 import { Config, inject, LifecycleManager, type Lifecycle } from '@zeltjs/core';
-declare class GenericContainer {
-  constructor(image: string);
-  withEnvironment(env: Record<string, string>): this;
-  withExposedPorts(port: number): this;
-  start(): Promise<StartedTestContainer>;
-}
-declare interface StartedTestContainer {
-  getHost(): string;
-  getMappedPort(port: number): number;
-  stop(): Promise<void>;
-}
-// ---cut---
+import { GenericContainer, type StartedTestContainer } from 'testcontainers';
+
 @Config
 export class PostgresTestContainerConfig implements Lifecycle {
   private container: StartedTestContainer | undefined;
@@ -98,16 +85,12 @@ export class PostgresTestContainerConfig implements Lifecycle {
 Integration tests with Testcontainers are ideal for "Sociable Unit Tests" — testing units that collaborate with real dependencies rather than mocks:
 
 ```typescript
-import { ConfigClass } from '@zeltjs/core';
-declare function describe(name: string, fn: () => void): void;
-declare function it(name: string, fn: () => void | Promise<void>): void;
-declare function expect<T>(value: T): { toBe(expected: T): void; };
-type TestTargetResult<T> = { target: T; get: <U>(cls: new (...args: never[]) => U) => U; shutdown: () => Promise<void> };
-declare function createTestTarget<T extends object>(cls: new (...args: never[]) => T, opts?: { configs?: readonly ConfigClass<object>[] }): Promise<TestTargetResult<T>>;
-declare const RedisTestContainerConfig: ConfigClass<object>;
-declare class SessionService { create(data: { userId: string }): Promise<{ id: string }>; }
-declare class UserService { fromSession(sessionId: string): Promise<{ id: string }>; }
-// ---cut---
+import { describe, it, expect } from 'vitest';
+import { createTestTarget } from '@zeltjs/testing/vitest';
+import { RedisTestContainerConfig } from '@zeltjs/testing/redis';
+import { SessionService } from './session.service';
+import { UserService } from './user.service';
+
 describe('SessionService with real Redis', () => {
   it('should persist session across service calls', async () => {
     const { target, get } = await createTestTarget(SessionService, {

--- a/website/docs/testing/integration.md
+++ b/website/docs/testing/integration.md
@@ -14,11 +14,14 @@ pnpm add -D @zeltjs/testing testcontainers
 ## Redis Integration Testing
 
 ```typescript
-import { describe, it, expect } from 'vitest';
-import { createTestTarget } from '@zeltjs/testing/vitest';
+import { ConfigClass } from '@zeltjs/core';
+declare function describe(name: string, fn: () => void): void;
+declare function it(name: string, fn: () => void | Promise<void>): void;
+declare function expect<T>(value: T): { toBe(expected: T): void; };
+declare function createTestTarget<T extends object>(cls: new (...args: never[]) => T, opts?: { configs?: readonly ConfigClass<object>[] }): Promise<{ target: T; shutdown: () => Promise<void> }>;
 import { RedisTestContainerConfig } from '@zeltjs/redis/testing';
-import { CacheService } from './cache.service';
-
+declare class CacheService { set(key: string, value: string): Promise<void>; get(key: string): Promise<string>; }
+// ---cut---
 describe('CacheService', () => {
   it('should cache values in Redis', async () => {
     const { target } = await createTestTarget(CacheService, {
@@ -44,8 +47,18 @@ Create your own container config by implementing the `Lifecycle` interface:
 
 ```typescript
 import { Config, inject, LifecycleManager, type Lifecycle } from '@zeltjs/core';
-import { GenericContainer, type StartedTestContainer } from 'testcontainers';
-
+declare class GenericContainer {
+  constructor(image: string);
+  withEnvironment(env: Record<string, string>): this;
+  withExposedPorts(port: number): this;
+  start(): Promise<StartedTestContainer>;
+}
+declare interface StartedTestContainer {
+  getHost(): string;
+  getMappedPort(port: number): number;
+  stop(): Promise<void>;
+}
+// ---cut---
 @Config
 export class PostgresTestContainerConfig implements Lifecycle {
   private container: StartedTestContainer | undefined;
@@ -85,12 +98,16 @@ export class PostgresTestContainerConfig implements Lifecycle {
 Integration tests with Testcontainers are ideal for "Sociable Unit Tests" — testing units that collaborate with real dependencies rather than mocks:
 
 ```typescript
-import { describe, it, expect } from 'vitest';
-import { createTestTarget } from '@zeltjs/testing/vitest';
+import { ConfigClass } from '@zeltjs/core';
+declare function describe(name: string, fn: () => void): void;
+declare function it(name: string, fn: () => void | Promise<void>): void;
+declare function expect<T>(value: T): { toBe(expected: T): void; };
+type TestTargetResult<T> = { target: T; get: <U>(cls: new (...args: never[]) => U) => U; shutdown: () => Promise<void> };
+declare function createTestTarget<T extends object>(cls: new (...args: never[]) => T, opts?: { configs?: readonly ConfigClass<object>[] }): Promise<TestTargetResult<T>>;
 import { RedisTestContainerConfig } from '@zeltjs/redis/testing';
-import { SessionService } from './session.service';
-import { UserService } from './user.service';
-
+declare class SessionService { create(data: { userId: string }): Promise<{ id: string }>; }
+declare class UserService { fromSession(sessionId: string): Promise<{ id: string }>; }
+// ---cut---
 describe('SessionService with real Redis', () => {
   it('should persist session across service calls', async () => {
     const { target, get } = await createTestTarget(SessionService, {

--- a/website/docs/testing/integration.md
+++ b/website/docs/testing/integration.md
@@ -16,7 +16,7 @@ pnpm add -D @zeltjs/testing testcontainers
 ```typescript
 import { describe, it, expect } from 'vitest';
 import { createTestTarget } from '@zeltjs/testing/vitest';
-import { RedisTestContainerConfig } from '@zeltjs/testing/redis';
+import { RedisTestContainerConfig } from '@zeltjs/redis/testing';
 import { CacheService } from './cache.service';
 
 describe('CacheService', () => {
@@ -87,7 +87,7 @@ Integration tests with Testcontainers are ideal for "Sociable Unit Tests" — te
 ```typescript
 import { describe, it, expect } from 'vitest';
 import { createTestTarget } from '@zeltjs/testing/vitest';
-import { RedisTestContainerConfig } from '@zeltjs/testing/redis';
+import { RedisTestContainerConfig } from '@zeltjs/redis/testing';
 import { SessionService } from './session.service';
 import { UserService } from './user.service';
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -25,8 +25,7 @@ const twoslasher = createTwoslasher({
     baseUrl: rootDir,
     paths: {
       '@zeltjs/validator-valibot': ['./packages/validator-valibot/dist/index.d.ts'],
-      '@zeltjs/testing/redis': ['./packages/testing/dist/redis/index.d.ts'],
-      '@zeltjs/testing/vitest': ['./packages/testing/dist/adapters/vitest.d.ts'],
+      '@zeltjs/redis/testing': ['./packages/redis/dist/testing/index.d.ts'],
       '@zeltjs/*': ['./packages/*/dist/index.d.ts'],
       valibot: [
         './node_modules/.pnpm/valibot@1.0.0_typescript@6.0.2/node_modules/valibot/dist/index.d.ts',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -25,6 +25,8 @@ const twoslasher = createTwoslasher({
     baseUrl: rootDir,
     paths: {
       '@zeltjs/validator-valibot': ['./packages/validator-valibot/dist/index.d.ts'],
+      '@zeltjs/testing/redis': ['./packages/testing/dist/redis/index.d.ts'],
+      '@zeltjs/testing/vitest': ['./packages/testing/dist/adapters/vitest.d.ts'],
       '@zeltjs/*': ['./packages/*/dist/index.d.ts'],
       valibot: [
         './node_modules/.pnpm/valibot@1.0.0_typescript@6.0.2/node_modules/valibot/dist/index.d.ts',


### PR DESCRIPTION
## Summary
- Sync `docs/testing/integration.md` and `docs/testing/e2e.md` with `build/testing/*.md`
- Remove twoslash declare statements that caused CI build failures
- Use proper imports from `@zeltjs/testing/redis` for `RedisTestContainerConfig`

## Test plan
- [ ] CI passes (website build succeeds)