### PR TITLE
docs: add documentation for missing packages

### DIFF
--- a/website/docs/db.md
+++ b/website/docs/db.md
@@ -1,0 +1,220 @@
+---
+---
+
+# Database
+
+The `@zeltjs/db` package provides ORM-agnostic database abstraction with automatic transaction propagation using AsyncLocalStorage.
+
+## Installation
+
+```bash
+pnpm add @zeltjs/db
+```
+
+## Overview
+
+Zelt's database abstraction solves a common problem: propagating transactions through your service layer without passing transaction objects explicitly. Using Node.js AsyncLocalStorage, transactions automatically flow through async call chains.
+
+## Creating a Database Service
+
+Extend `DatabaseService` to integrate your ORM:
+
+```typescript
+// @noErrors
+import { DatabaseService } from '@zeltjs/db';
+import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+export class DrizzleService extends DatabaseService<PostgresJsDatabase> {
+  private sql!: postgres.Sql;
+
+  async setup(): Promise<PostgresJsDatabase> {
+    this.sql = postgres(process.env.DATABASE_URL!);
+    const db = drizzle(this.sql);
+
+    this.onShutdown(async () => {
+      await this.sql.end();
+    });
+
+    return db;
+  }
+
+  transaction<T>(
+    client: PostgresJsDatabase,
+    fn: (tx: PostgresJsDatabase) => Promise<T>,
+  ): Promise<T> {
+    return client.transaction(fn);
+  }
+}
+```
+
+Key points:
+
+- `setup()` — Initialize and return your database client
+- `transaction()` — Execute a function within a transaction
+- `onShutdown()` — Register cleanup handlers for graceful shutdown
+
+## Using the Database Service
+
+### Direct Usage
+
+Inject the service and access the client:
+
+```typescript
+// @noErrors
+import { Injectable, inject } from '@zeltjs/core';
+import { users } from './schema';
+// ---cut---
+@Injectable()
+export class UserRepository {
+  constructor(private db = inject(DrizzleService)) {}
+
+  async findAll() {
+    return this.db.client.select().from(users);
+  }
+
+  async create(name: string, email: string) {
+    return this.db.client.insert(users).values({ name, email });
+  }
+}
+```
+
+The `client` property automatically returns:
+- The transaction client if inside a transaction
+- The original client otherwise
+
+### Transaction Decorator
+
+Create a decorator for your database service:
+
+```typescript
+// @noErrors
+import { createTransactionDecorator } from '@zeltjs/db';
+
+export const Transaction = createTransactionDecorator(DrizzleService);
+```
+
+Apply it to methods that should run in a transaction:
+
+```typescript
+// @noErrors
+import { Injectable, inject } from '@zeltjs/core';
+
+@Injectable()
+export class OrderService {
+  constructor(
+    private orderRepo = inject(OrderRepository),
+    private inventoryRepo = inject(InventoryRepository),
+  ) {}
+
+  @Transaction()
+  async placeOrder(userId: string, items: OrderItem[]) {
+    const order = await this.orderRepo.create(userId, items);
+
+    for (const item of items) {
+      await this.inventoryRepo.decrement(item.productId, item.quantity);
+    }
+
+    return order;
+  }
+}
+```
+
+All repository calls within `placeOrder` automatically use the same transaction. If any operation fails, the entire transaction rolls back.
+
+### Transaction Middleware
+
+For request-scoped transactions, use middleware:
+
+```typescript
+// @noErrors
+import { createTransactionMiddleware } from '@zeltjs/db';
+
+export const TransactionMiddleware = createTransactionMiddleware(DrizzleService);
+```
+
+Apply to controllers:
+
+```typescript
+// @noErrors
+import { Controller, Post, body, UseMiddleware } from '@zeltjs/core';
+
+@Controller('/orders')
+@UseMiddleware(TransactionMiddleware)
+export class OrderController {
+  constructor(private orderService = inject(OrderService)) {}
+
+  @Post('/')
+  async create(data = body<CreateOrderDto>()) {
+    return this.orderService.placeOrder(data.userId, data.items);
+  }
+}
+```
+
+Every request to this controller runs in a transaction.
+
+## Transaction Propagation
+
+Transactions propagate through async call chains automatically:
+
+```typescript
+// @noErrors
+@Injectable()
+export class PaymentService {
+  @Transaction()
+  async processPayment(orderId: string, amount: number) {
+    await this.ledgerRepo.debit(orderId, amount);
+    await this.notificationService.sendReceipt(orderId);
+  }
+}
+
+@Injectable()
+export class OrderService {
+  @Transaction()
+  async completeOrder(orderId: string) {
+    await this.orderRepo.markComplete(orderId);
+    await this.paymentService.processPayment(orderId, 100);
+  }
+}
+```
+
+When `completeOrder` calls `processPayment`, both run in the same transaction — the inner `@Transaction()` joins the existing transaction rather than starting a new one.
+
+## Lifecycle Integration
+
+`DatabaseService` integrates with Zelt's lifecycle system:
+
+```typescript
+// @noErrors
+import { createApp } from '@zeltjs/core';
+
+const app = createApp({
+  http: {
+    controllers: [OrderController],
+  },
+  configs: [DrizzleService],
+});
+```
+
+The service:
+1. Calls `setup()` during app startup
+2. Calls `shutdown()` handlers during app shutdown
+
+## API Reference
+
+### DatabaseService
+
+| Property/Method | Description |
+|----------------|-------------|
+| `client` | Current database client (transaction-aware) |
+| `setup()` | Abstract: Initialize database connection |
+| `transaction(client, fn)` | Abstract: Execute function in transaction |
+| `withTransaction(fn)` | Run function in a new or existing transaction |
+| `onShutdown(fn)` | Register shutdown handler |
+
+### Factory Functions
+
+| Function | Description |
+|----------|-------------|
+| `createTransactionDecorator(Service)` | Create `@Transaction()` decorator |
+| `createTransactionMiddleware(Service)` | Create transaction middleware class |

--- a/website/docs/eventbus.md
+++ b/website/docs/eventbus.md
@@ -1,0 +1,205 @@
+---
+---
+
+# Event Bus
+
+The `@zeltjs/eventbus` package provides a type-safe event bus with memory and Redis adapters for pub/sub messaging.
+
+## Installation
+
+```bash
+pnpm add @zeltjs/eventbus
+```
+
+For Redis support:
+
+```bash
+pnpm add @zeltjs/eventbus @zeltjs/redis ioredis
+```
+
+## Overview
+
+The event bus enables decoupled communication between components through publish/subscribe messaging. Events are fully typed via TypeScript declaration merging.
+
+## Defining Events
+
+Extend the `EventBusSchema` interface to define your events:
+
+```typescript
+// @noErrors
+declare module '@zeltjs/eventbus' {
+  interface EventBusSchema {
+    'user.created': { userId: string; email: string };
+    'order.placed': { orderId: string; total: number };
+    'notification.send': { to: string; message: string };
+  }
+}
+```
+
+This provides full type safety for event names and payloads.
+
+## Memory Adapter
+
+For single-process applications, use the in-memory adapter:
+
+```typescript
+// @noErrors
+import { Injectable, inject } from '@zeltjs/core';
+import { MemoryEventBusAdaptor } from '@zeltjs/eventbus/adaptor-memory';
+
+@Injectable()
+export class NotificationService {
+  constructor(private eventBus = inject(MemoryEventBusAdaptor)) {}
+
+  async setup() {
+    this.eventBus.on('user.created', (data) => {
+      console.log(`Welcome email sent to ${data.email}`);
+    });
+  }
+}
+
+@Injectable()
+export class UserService {
+  constructor(private eventBus = inject(MemoryEventBusAdaptor)) {}
+
+  async createUser(email: string) {
+    const userId = crypto.randomUUID();
+    await this.eventBus.emit('user.created', { userId, email });
+    return { userId };
+  }
+}
+```
+
+## Redis Adapter
+
+For distributed applications, use the Redis adapter:
+
+```typescript
+// @noErrors
+import { Injectable, inject } from '@zeltjs/core';
+import { RedisEventBusAdaptor } from '@zeltjs/eventbus/adaptor-redis';
+
+@Injectable()
+export class OrderService {
+  constructor(private eventBus = inject(RedisEventBusAdaptor)) {}
+
+  async placeOrder(items: OrderItem[]) {
+    const orderId = crypto.randomUUID();
+    const total = items.reduce((sum, item) => sum + item.price, 0);
+
+    await this.eventBus.emit('order.placed', { orderId, total });
+    return { orderId };
+  }
+}
+```
+
+The Redis adapter requires `@zeltjs/redis` to be configured:
+
+```typescript
+// @noErrors
+import { createApp, EnvConfig } from '@zeltjs/core';
+import { RedisConfig } from '@zeltjs/redis';
+
+const app = createApp({
+  http: {
+    controllers: [OrderController],
+  },
+  configs: [EnvConfig, RedisConfig],
+});
+```
+
+## API Reference
+
+### EventBusAdaptor Interface
+
+Both adapters implement this interface:
+
+| Method | Description |
+|--------|-------------|
+| `emit(event, data)` | Publish an event with payload |
+| `on(event, handler)` | Subscribe to an event. Returns unsubscribe function |
+| `once(event, handler)` | Subscribe to an event once. Returns unsubscribe function |
+
+### MemoryEventBusAdaptor
+
+In-memory event bus using Node.js EventEmitter. Events are local to the process.
+
+```typescript
+// @noErrors
+import { MemoryEventBusAdaptor } from '@zeltjs/eventbus/adaptor-memory';
+```
+
+### RedisEventBusAdaptor
+
+Redis-backed event bus using pub/sub. Events are distributed across processes.
+
+```typescript
+// @noErrors
+import { RedisEventBusAdaptor } from '@zeltjs/eventbus/adaptor-redis';
+```
+
+## Unsubscribing
+
+Both `on()` and `once()` return an unsubscribe function:
+
+```typescript
+// @noErrors
+const unsubscribe = eventBus.on('user.created', (data) => {
+  console.log(data.email);
+});
+
+// Later, stop listening
+unsubscribe();
+```
+
+## Best Practices
+
+### Event Naming
+
+Use dot notation for event names: `domain.action`
+
+```typescript
+// @noErrors
+interface EventBusSchema {
+  'user.created': { userId: string };
+  'user.updated': { userId: string; changes: string[] };
+  'user.deleted': { userId: string };
+  'order.placed': { orderId: string };
+  'order.shipped': { orderId: string; trackingNumber: string };
+}
+```
+
+### Idempotent Handlers
+
+Design event handlers to be idempotent — safe to run multiple times with the same data:
+
+```typescript
+// @noErrors
+eventBus.on('order.placed', async (data) => {
+  const existing = await db.query.notifications.findFirst({
+    where: eq(notifications.orderId, data.orderId),
+  });
+
+  if (existing) return;
+
+  await db.insert(notifications).values({
+    orderId: data.orderId,
+    type: 'order_confirmation',
+  });
+});
+```
+
+### Error Handling
+
+Wrap handlers in try-catch to prevent errors from affecting other subscribers:
+
+```typescript
+// @noErrors
+eventBus.on('user.created', async (data) => {
+  try {
+    await sendWelcomeEmail(data.email);
+  } catch (error) {
+    console.error('Failed to send welcome email:', error);
+  }
+});
+```

--- a/website/docs/getting-started/bun.md
+++ b/website/docs/getting-started/bun.md
@@ -1,0 +1,204 @@
+---
+sidebar_label: Bun
+---
+
+# Getting Started with Bun
+
+This guide walks you through building a Zelt application on Bun from scratch.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) v1.0 or higher
+
+## Installation
+
+```bash
+bun add @zeltjs/core @zeltjs/adapter-bun
+```
+
+## Project Structure
+
+```
+my-app/
+├── src/
+│   ├── app.ts
+│   ├── index.ts
+│   └── controllers/
+│       └── hello.controller.ts
+├── package.json
+└── tsconfig.json
+```
+
+## Hello World
+
+### Step 1: Create the Controller
+
+Create `src/controllers/hello.controller.ts`:
+
+```typescript
+// @noErrors
+import { Controller, Get, pathParam } from '@zeltjs/core';
+// ---cut---
+@Controller('/hello')
+export class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) {
+    return { message: `Hello, ${name}!` };
+  }
+}
+```
+
+### Step 2: Create the Application
+
+Create `src/app.ts`:
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+// ---cut---
+export const app = createApp({
+  http: {
+    controllers: [HelloController],
+  },
+});
+```
+
+### Step 3: Create the Entry Point
+
+Create `src/index.ts`:
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onBun } from '@zeltjs/adapter-bun';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const bunApp = await onBun(app);
+
+const server = bunApp.serve({ port: 3000 });
+console.log(`Server running at http://${server.address.hostname}:${server.address.port}`);
+```
+
+The `onBun()` function prepares your app for the Bun runtime. It returns an object with:
+
+- `serve(options?)` — Starts an HTTP server using `Bun.serve()`
+- `shutdown()` — Gracefully shuts down the application
+- `get<T>(Class)` — Resolves a service from the DI container
+- `args` — Command-line arguments (`Bun.argv.slice(2)`)
+
+### Step 4: Run the Server
+
+```bash
+bun run src/index.ts
+```
+
+Visit `http://localhost:3000/hello/world` to see:
+
+```json
+{ "message": "Hello, world!" }
+```
+
+## Server Options
+
+The `serve()` method accepts options for port and hostname:
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onBun } from '@zeltjs/adapter-bun';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+const bunApp = await onBun(app);
+// ---cut---
+const server = bunApp.serve({
+  port: 8080,
+  hostname: '127.0.0.1',
+});
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `port` | `3000` | Port to listen on |
+| `hostname` | `'0.0.0.0'` | Hostname to bind to |
+
+## Command Support
+
+If your app includes commands, `onBun()` returns `execCommand()` for CLI execution:
+
+```typescript
+// @noErrors
+import { createApp, Command, Arg, Controller, Get } from '@zeltjs/core';
+import { onBun } from '@zeltjs/adapter-bun';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/') greet() { return { message: 'Hello!' }; }
+}
+
+@Command('greet')
+class GreetCommand {
+  constructor(private name = Arg(0)) {}
+  run() { console.log(`Hello, ${this.name}!`); }
+}
+
+const app = createApp({
+  http: { controllers: [HelloController] },
+  commands: [GreetCommand],
+});
+// ---cut---
+const bunApp = await onBun(app);
+
+const result = await bunApp.execCommand(['greet', 'world']);
+console.log(result.exitCode); // 0 or 1
+```
+
+## Warmup Option
+
+By default, `onBun()` uses eager initialization (`warmup: true`) — all controllers are resolved at startup.
+
+For lazy initialization (controllers resolved on first request):
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onBun } from '@zeltjs/adapter-bun';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const bunApp = await onBun(app, { warmup: false });
+```
+
+| Option | Behavior | Use Case |
+|--------|----------|----------|
+| `warmup: true` (default) | All controllers resolved at startup | Long-running servers |
+| `warmup: false` | Controllers resolved on first request | Optimized cold starts |
+
+## What's Next?
+
+- [Controllers](../controllers) — Route handling and HTTP methods
+- [Services](../services) — Business logic and dependency injection
+- [Commands](../command) — CLI commands

--- a/website/docs/getting-started/electron.md
+++ b/website/docs/getting-started/electron.md
@@ -1,0 +1,133 @@
+---
+sidebar_label: Electron
+---
+
+# Getting Started with Electron
+
+This guide walks you through embedding a Zelt application in an Electron app for local API handling.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) v20 or higher
+- [Electron](https://www.electronjs.org/) v28 or higher
+
+## Installation
+
+```bash
+pnpm add @zeltjs/core @zeltjs/adapter-electron
+pnpm add -D electron
+```
+
+## Use Case
+
+The Electron adapter allows you to handle HTTP requests within your Electron app without running a separate server. This is useful for:
+
+- Local API endpoints for the renderer process
+- Offline-capable applications
+- Desktop apps with embedded backends
+
+## Hello World
+
+### Step 1: Create the Application
+
+Create `src/api/app.ts`:
+
+```typescript
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+// ---cut---
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) {
+    return { message: `Hello, ${name}!` };
+  }
+}
+
+export const app = createApp({
+  http: {
+    controllers: [HelloController],
+  },
+});
+```
+
+### Step 2: Initialize in Main Process
+
+Create `src/main.ts`:
+
+```typescript
+// @noErrors
+import { app as electronApp, BrowserWindow, protocol } from 'electron';
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onElectron } from '@zeltjs/adapter-electron';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const electronZelt = await onElectron(app);
+
+electronApp.whenReady().then(() => {
+  protocol.handle('api', async (request) => {
+    return electronZelt.fetch(request);
+  });
+
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+});
+
+electronApp.on('window-all-closed', async () => {
+  await electronZelt.shutdown();
+  electronApp.quit();
+});
+```
+
+The `onElectron()` function prepares your app for the Electron runtime. It returns:
+
+- `fetch(request)` — Handles a Request and returns a Response
+- `shutdown()` — Gracefully shuts down the application
+- `get<T>(Class)` — Resolves a service from the DI container
+
+### Step 3: Call API from Renderer
+
+In your renderer process or preload script:
+
+```typescript
+const response = await fetch('api://localhost/hello/world');
+const data = await response.json();
+console.log(data.message); // "Hello, world!"
+```
+
+## Warmup Option
+
+By default, `onElectron()` uses eager initialization (`warmup: true`) — all controllers are resolved at startup.
+
+For lazy initialization:
+
+```typescript
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onElectron } from '@zeltjs/adapter-electron';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const electronZelt = await onElectron(app, { warmup: false });
+```
+
+| Option | Behavior | Use Case |
+|--------|----------|----------|
+| `warmup: true` (default) | All controllers resolved at startup | Desktop apps |
+| `warmup: false` | Controllers resolved on first request | Faster startup |
+
+## What's Next?
+
+- [Controllers](../controllers) — Route handling and HTTP methods
+- [Services](../services) — Business logic and dependency injection

--- a/website/docs/getting-started/lambda.md
+++ b/website/docs/getting-started/lambda.md
@@ -1,0 +1,242 @@
+---
+sidebar_label: AWS Lambda
+---
+
+# Getting Started with AWS Lambda
+
+This guide walks you through building a Zelt application on AWS Lambda from scratch.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) v20 or higher
+- An [AWS account](https://aws.amazon.com/)
+- [AWS CLI](https://aws.amazon.com/cli/) or [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
+
+## Installation
+
+```bash
+pnpm add @zeltjs/core @zeltjs/adapter-lambda
+pnpm add -D @types/aws-lambda esbuild
+```
+
+## Project Structure
+
+```
+my-lambda/
+├── src/
+│   ├── app.ts
+│   ├── handler.ts
+│   └── controllers/
+│       └── hello.controller.ts
+├── package.json
+├── tsconfig.json
+└── template.yaml
+```
+
+## Hello World
+
+### Step 1: Create the Controller
+
+Create `src/controllers/hello.controller.ts`:
+
+```typescript
+// @noErrors
+import { Controller, Get, pathParam } from '@zeltjs/core';
+// ---cut---
+@Controller('/hello')
+export class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) {
+    return { message: `Hello, ${name}!` };
+  }
+}
+```
+
+### Step 2: Create the Application
+
+Create `src/app.ts`:
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+// ---cut---
+export const app = createApp({
+  http: {
+    controllers: [HelloController],
+  },
+});
+```
+
+### Step 3: Create the Lambda Handler
+
+Create `src/handler.ts`:
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onLambda } from '@zeltjs/adapter-lambda';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const lambdaApp = await onLambda(app);
+
+export const handler = lambdaApp.handler;
+```
+
+The `onLambda()` function prepares your app for the Lambda runtime. It returns:
+
+- `handler` — API Gateway v2 (HTTP API) handler
+- `handlerV1` — API Gateway v1 (REST API) handler
+- `shutdown()` — Gracefully shuts down the application
+- `get<T>(Class)` — Resolves a service from the DI container
+
+### Step 4: Configure SAM Template
+
+Create `template.yaml`:
+
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 30
+    Runtime: nodejs20.x
+
+Resources:
+  HelloFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: dist/
+      Handler: handler.handler
+      Events:
+        Api:
+          Type: HttpApi
+          Properties:
+            Path: /{proxy+}
+            Method: ANY
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: es2022
+        EntryPoints:
+          - src/handler.ts
+
+Outputs:
+  ApiEndpoint:
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com"
+```
+
+### Step 5: Deploy
+
+```bash
+sam build
+sam deploy --guided
+```
+
+## API Gateway Versions
+
+The adapter supports both API Gateway versions:
+
+### HTTP API (v2) — Recommended
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onLambda } from '@zeltjs/adapter-lambda';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+const lambdaApp = await onLambda(app);
+// ---cut---
+export const handler = lambdaApp.handler;
+```
+
+### REST API (v1)
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onLambda } from '@zeltjs/adapter-lambda';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+const lambdaApp = await onLambda(app);
+// ---cut---
+export const handler = lambdaApp.handlerV1;
+```
+
+## Warmup Option
+
+By default, `onLambda()` uses lazy initialization (`warmup: false`) to minimize cold start time. Controllers are resolved on the first request.
+
+For eager initialization:
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onLambda } from '@zeltjs/adapter-lambda';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const lambdaApp = await onLambda(app, { warmup: true });
+```
+
+| Option | Behavior | Use Case |
+|--------|----------|----------|
+| `warmup: false` (default) | Controllers resolved on first request | Optimized cold starts |
+| `warmup: true` | All controllers resolved at initialization | Provisioned concurrency |
+
+## Binary Responses
+
+The adapter automatically handles binary responses (images, audio, video, octet-stream) by encoding them as base64.
+
+```typescript
+// @noErrors
+import { Controller, Get, response } from '@zeltjs/core';
+// ---cut---
+@Controller('/files')
+export class FileController {
+  @Get('/image')
+  getImage() {
+    const imageBuffer = new Uint8Array([/* ... */]);
+    return response()
+      .header('Content-Type', 'image/png')
+      .body(imageBuffer);
+  }
+}
+```
+
+## What's Next?
+
+- [Controllers](../controllers) — Route handling and HTTP methods
+- [Services](../services) — Business logic and dependency injection
+- [Configuration](../configuration) — Environment variables and secrets

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/db.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/db.md
@@ -1,0 +1,220 @@
+---
+---
+
+# データベース
+
+`@zeltjs/db` パッケージは、AsyncLocalStorage を使用した自動トランザクション伝播を備えた ORM 非依存のデータベース抽象化を提供します。
+
+## インストール
+
+```bash
+pnpm add @zeltjs/db
+```
+
+## 概要
+
+Zelt のデータベース抽象化は、トランザクションオブジェクトを明示的に渡すことなくサービスレイヤー全体にトランザクションを伝播させるという一般的な問題を解決します。Node.js の AsyncLocalStorage を使用して、トランザクションは非同期呼び出しチェーンを通じて自動的に流れます。
+
+## データベースサービスの作成
+
+`DatabaseService` を拡張して ORM を統合します：
+
+```typescript
+// @noErrors
+import { DatabaseService } from '@zeltjs/db';
+import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+export class DrizzleService extends DatabaseService<PostgresJsDatabase> {
+  private sql!: postgres.Sql;
+
+  async setup(): Promise<PostgresJsDatabase> {
+    this.sql = postgres(process.env.DATABASE_URL!);
+    const db = drizzle(this.sql);
+
+    this.onShutdown(async () => {
+      await this.sql.end();
+    });
+
+    return db;
+  }
+
+  transaction<T>(
+    client: PostgresJsDatabase,
+    fn: (tx: PostgresJsDatabase) => Promise<T>,
+  ): Promise<T> {
+    return client.transaction(fn);
+  }
+}
+```
+
+ポイント：
+
+- `setup()` — データベースクライアントを初期化して返す
+- `transaction()` — トランザクション内で関数を実行
+- `onShutdown()` — グレースフルシャットダウン用のクリーンアップハンドラーを登録
+
+## データベースサービスの使用
+
+### 直接使用
+
+サービスを注入してクライアントにアクセスします：
+
+```typescript
+// @noErrors
+import { Injectable, inject } from '@zeltjs/core';
+import { users } from './schema';
+// ---cut---
+@Injectable()
+export class UserRepository {
+  constructor(private db = inject(DrizzleService)) {}
+
+  async findAll() {
+    return this.db.client.select().from(users);
+  }
+
+  async create(name: string, email: string) {
+    return this.db.client.insert(users).values({ name, email });
+  }
+}
+```
+
+`client` プロパティは自動的に以下を返します：
+- トランザクション内の場合はトランザクションクライアント
+- それ以外の場合は元のクライアント
+
+### トランザクションデコレーター
+
+データベースサービス用のデコレーターを作成します：
+
+```typescript
+// @noErrors
+import { createTransactionDecorator } from '@zeltjs/db';
+
+export const Transaction = createTransactionDecorator(DrizzleService);
+```
+
+トランザクション内で実行すべきメソッドに適用します：
+
+```typescript
+// @noErrors
+import { Injectable, inject } from '@zeltjs/core';
+
+@Injectable()
+export class OrderService {
+  constructor(
+    private orderRepo = inject(OrderRepository),
+    private inventoryRepo = inject(InventoryRepository),
+  ) {}
+
+  @Transaction()
+  async placeOrder(userId: string, items: OrderItem[]) {
+    const order = await this.orderRepo.create(userId, items);
+
+    for (const item of items) {
+      await this.inventoryRepo.decrement(item.productId, item.quantity);
+    }
+
+    return order;
+  }
+}
+```
+
+`placeOrder` 内のすべてのリポジトリ呼び出しは自動的に同じトランザクションを使用します。いずれかの操作が失敗すると、トランザクション全体がロールバックされます。
+
+### トランザクションミドルウェア
+
+リクエストスコープのトランザクションにはミドルウェアを使用します：
+
+```typescript
+// @noErrors
+import { createTransactionMiddleware } from '@zeltjs/db';
+
+export const TransactionMiddleware = createTransactionMiddleware(DrizzleService);
+```
+
+コントローラーに適用します：
+
+```typescript
+// @noErrors
+import { Controller, Post, body, UseMiddleware } from '@zeltjs/core';
+
+@Controller('/orders')
+@UseMiddleware(TransactionMiddleware)
+export class OrderController {
+  constructor(private orderService = inject(OrderService)) {}
+
+  @Post('/')
+  async create(data = body<CreateOrderDto>()) {
+    return this.orderService.placeOrder(data.userId, data.items);
+  }
+}
+```
+
+このコントローラーへのすべてのリクエストがトランザクション内で実行されます。
+
+## トランザクション伝播
+
+トランザクションは非同期呼び出しチェーンを通じて自動的に伝播します：
+
+```typescript
+// @noErrors
+@Injectable()
+export class PaymentService {
+  @Transaction()
+  async processPayment(orderId: string, amount: number) {
+    await this.ledgerRepo.debit(orderId, amount);
+    await this.notificationService.sendReceipt(orderId);
+  }
+}
+
+@Injectable()
+export class OrderService {
+  @Transaction()
+  async completeOrder(orderId: string) {
+    await this.orderRepo.markComplete(orderId);
+    await this.paymentService.processPayment(orderId, 100);
+  }
+}
+```
+
+`completeOrder` が `processPayment` を呼び出すと、両方が同じトランザクション内で実行されます — 内側の `@Transaction()` は新しいトランザクションを開始するのではなく、既存のトランザクションに参加します。
+
+## ライフサイクル統合
+
+`DatabaseService` は Zelt のライフサイクルシステムと統合されます：
+
+```typescript
+// @noErrors
+import { createApp } from '@zeltjs/core';
+
+const app = createApp({
+  http: {
+    controllers: [OrderController],
+  },
+  configs: [DrizzleService],
+});
+```
+
+サービスは：
+1. アプリ起動時に `setup()` を呼び出す
+2. アプリシャットダウン時に `shutdown()` ハンドラーを呼び出す
+
+## API リファレンス
+
+### DatabaseService
+
+| プロパティ/メソッド | 説明 |
+|-------------------|------|
+| `client` | 現在のデータベースクライアント（トランザクション対応） |
+| `setup()` | 抽象: データベース接続を初期化 |
+| `transaction(client, fn)` | 抽象: トランザクション内で関数を実行 |
+| `withTransaction(fn)` | 新規または既存のトランザクション内で関数を実行 |
+| `onShutdown(fn)` | シャットダウンハンドラーを登録 |
+
+### ファクトリ関数
+
+| 関数 | 説明 |
+|-----|------|
+| `createTransactionDecorator(Service)` | `@Transaction()` デコレーターを作成 |
+| `createTransactionMiddleware(Service)` | トランザクションミドルウェアクラスを作成 |

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/eventbus.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/eventbus.md
@@ -1,0 +1,205 @@
+---
+---
+
+# イベントバス
+
+`@zeltjs/eventbus` パッケージは、メモリおよび Redis アダプターを備えた型安全なイベントバスを pub/sub メッセージング用に提供します。
+
+## インストール
+
+```bash
+pnpm add @zeltjs/eventbus
+```
+
+Redis サポートの場合：
+
+```bash
+pnpm add @zeltjs/eventbus @zeltjs/redis ioredis
+```
+
+## 概要
+
+イベントバスは、publish/subscribe メッセージングを通じてコンポーネント間の疎結合な通信を可能にします。イベントは TypeScript の宣言マージを通じて完全に型付けされます。
+
+## イベントの定義
+
+`EventBusSchema` インターフェースを拡張してイベントを定義します：
+
+```typescript
+// @noErrors
+declare module '@zeltjs/eventbus' {
+  interface EventBusSchema {
+    'user.created': { userId: string; email: string };
+    'order.placed': { orderId: string; total: number };
+    'notification.send': { to: string; message: string };
+  }
+}
+```
+
+これにより、イベント名とペイロードの完全な型安全性が提供されます。
+
+## メモリアダプター
+
+単一プロセスアプリケーションには、インメモリアダプターを使用します：
+
+```typescript
+// @noErrors
+import { Injectable, inject } from '@zeltjs/core';
+import { MemoryEventBusAdaptor } from '@zeltjs/eventbus/adaptor-memory';
+
+@Injectable()
+export class NotificationService {
+  constructor(private eventBus = inject(MemoryEventBusAdaptor)) {}
+
+  async setup() {
+    this.eventBus.on('user.created', (data) => {
+      console.log(`Welcome email sent to ${data.email}`);
+    });
+  }
+}
+
+@Injectable()
+export class UserService {
+  constructor(private eventBus = inject(MemoryEventBusAdaptor)) {}
+
+  async createUser(email: string) {
+    const userId = crypto.randomUUID();
+    await this.eventBus.emit('user.created', { userId, email });
+    return { userId };
+  }
+}
+```
+
+## Redis アダプター
+
+分散アプリケーションには、Redis アダプターを使用します：
+
+```typescript
+// @noErrors
+import { Injectable, inject } from '@zeltjs/core';
+import { RedisEventBusAdaptor } from '@zeltjs/eventbus/adaptor-redis';
+
+@Injectable()
+export class OrderService {
+  constructor(private eventBus = inject(RedisEventBusAdaptor)) {}
+
+  async placeOrder(items: OrderItem[]) {
+    const orderId = crypto.randomUUID();
+    const total = items.reduce((sum, item) => sum + item.price, 0);
+
+    await this.eventBus.emit('order.placed', { orderId, total });
+    return { orderId };
+  }
+}
+```
+
+Redis アダプターには `@zeltjs/redis` の設定が必要です：
+
+```typescript
+// @noErrors
+import { createApp, EnvConfig } from '@zeltjs/core';
+import { RedisConfig } from '@zeltjs/redis';
+
+const app = createApp({
+  http: {
+    controllers: [OrderController],
+  },
+  configs: [EnvConfig, RedisConfig],
+});
+```
+
+## API リファレンス
+
+### EventBusAdaptor インターフェース
+
+両方のアダプターがこのインターフェースを実装しています：
+
+| メソッド | 説明 |
+|--------|------|
+| `emit(event, data)` | ペイロード付きでイベントを発行 |
+| `on(event, handler)` | イベントを購読。購読解除関数を返す |
+| `once(event, handler)` | イベントを一度だけ購読。購読解除関数を返す |
+
+### MemoryEventBusAdaptor
+
+Node.js EventEmitter を使用したインメモリイベントバス。イベントはプロセス内でローカルです。
+
+```typescript
+// @noErrors
+import { MemoryEventBusAdaptor } from '@zeltjs/eventbus/adaptor-memory';
+```
+
+### RedisEventBusAdaptor
+
+pub/sub を使用した Redis バックエンドのイベントバス。イベントはプロセス間で分散されます。
+
+```typescript
+// @noErrors
+import { RedisEventBusAdaptor } from '@zeltjs/eventbus/adaptor-redis';
+```
+
+## 購読解除
+
+`on()` と `once()` の両方が購読解除関数を返します：
+
+```typescript
+// @noErrors
+const unsubscribe = eventBus.on('user.created', (data) => {
+  console.log(data.email);
+});
+
+// 後で、リッスンを停止
+unsubscribe();
+```
+
+## ベストプラクティス
+
+### イベント命名
+
+イベント名にはドット記法を使用します：`domain.action`
+
+```typescript
+// @noErrors
+interface EventBusSchema {
+  'user.created': { userId: string };
+  'user.updated': { userId: string; changes: string[] };
+  'user.deleted': { userId: string };
+  'order.placed': { orderId: string };
+  'order.shipped': { orderId: string; trackingNumber: string };
+}
+```
+
+### べき等なハンドラー
+
+イベントハンドラーはべき等に設計します — 同じデータで複数回実行しても安全：
+
+```typescript
+// @noErrors
+eventBus.on('order.placed', async (data) => {
+  const existing = await db.query.notifications.findFirst({
+    where: eq(notifications.orderId, data.orderId),
+  });
+
+  if (existing) return;
+
+  await db.insert(notifications).values({
+    orderId: data.orderId,
+    type: 'order_confirmation',
+  });
+});
+```
+
+### エラーハンドリング
+
+エラーが他の購読者に影響を与えないように、ハンドラーを try-catch でラップします：
+
+```typescript
+// @noErrors
+eventBus.on('user.created', async (data) => {
+  try {
+    await sendWelcomeEmail(data.email);
+  } catch (error) {
+    console.error('Failed to send welcome email:', error);
+  }
+});
+```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/bun.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/bun.md
@@ -1,0 +1,204 @@
+---
+sidebar_label: Bun
+---
+
+# Bun で始める
+
+このガイドでは、Bun 上で Zelt アプリケーションを構築する方法を説明します。
+
+## 前提条件
+
+- [Bun](https://bun.sh/) v1.0 以上
+
+## インストール
+
+```bash
+bun add @zeltjs/core @zeltjs/adapter-bun
+```
+
+## プロジェクト構成
+
+```
+my-app/
+├── src/
+│   ├── app.ts
+│   ├── index.ts
+│   └── controllers/
+│       └── hello.controller.ts
+├── package.json
+└── tsconfig.json
+```
+
+## Hello World
+
+### Step 1: コントローラーの作成
+
+`src/controllers/hello.controller.ts` を作成します：
+
+```typescript
+// @noErrors
+import { Controller, Get, pathParam } from '@zeltjs/core';
+// ---cut---
+@Controller('/hello')
+export class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) {
+    return { message: `Hello, ${name}!` };
+  }
+}
+```
+
+### Step 2: アプリケーションの作成
+
+`src/app.ts` を作成します：
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+// ---cut---
+export const app = createApp({
+  http: {
+    controllers: [HelloController],
+  },
+});
+```
+
+### Step 3: エントリーポイントの作成
+
+`src/index.ts` を作成します：
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onBun } from '@zeltjs/adapter-bun';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const bunApp = await onBun(app);
+
+const server = bunApp.serve({ port: 3000 });
+console.log(`Server running at http://${server.address.hostname}:${server.address.port}`);
+```
+
+`onBun()` 関数は Bun ランタイム用にアプリを準備します。以下のオブジェクトを返します：
+
+- `serve(options?)` — `Bun.serve()` を使用して HTTP サーバーを起動
+- `shutdown()` — アプリケーションをグレースフルにシャットダウン
+- `get<T>(Class)` — DI コンテナからサービスを解決
+- `args` — コマンドライン引数 (`Bun.argv.slice(2)`)
+
+### Step 4: サーバーの起動
+
+```bash
+bun run src/index.ts
+```
+
+`http://localhost:3000/hello/world` にアクセスすると：
+
+```json
+{ "message": "Hello, world!" }
+```
+
+## サーバーオプション
+
+`serve()` メソッドはポートとホスト名のオプションを受け付けます：
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onBun } from '@zeltjs/adapter-bun';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+const bunApp = await onBun(app);
+// ---cut---
+const server = bunApp.serve({
+  port: 8080,
+  hostname: '127.0.0.1',
+});
+```
+
+| オプション | デフォルト | 説明 |
+|-----------|-----------|------|
+| `port` | `3000` | リッスンするポート |
+| `hostname` | `'0.0.0.0'` | バインドするホスト名 |
+
+## コマンドサポート
+
+アプリにコマンドが含まれている場合、`onBun()` は CLI 実行用の `execCommand()` を返します：
+
+```typescript
+// @noErrors
+import { createApp, Command, Arg, Controller, Get } from '@zeltjs/core';
+import { onBun } from '@zeltjs/adapter-bun';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/') greet() { return { message: 'Hello!' }; }
+}
+
+@Command('greet')
+class GreetCommand {
+  constructor(private name = Arg(0)) {}
+  run() { console.log(`Hello, ${this.name}!`); }
+}
+
+const app = createApp({
+  http: { controllers: [HelloController] },
+  commands: [GreetCommand],
+});
+// ---cut---
+const bunApp = await onBun(app);
+
+const result = await bunApp.execCommand(['greet', 'world']);
+console.log(result.exitCode); // 0 or 1
+```
+
+## ウォームアップオプション
+
+デフォルトでは、`onBun()` は即時初期化（`warmup: true`）を使用します — すべてのコントローラーが起動時に解決されます。
+
+遅延初期化（最初のリクエストでコントローラーを解決）の場合：
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onBun } from '@zeltjs/adapter-bun';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const bunApp = await onBun(app, { warmup: false });
+```
+
+| オプション | 動作 | ユースケース |
+|-----------|------|-------------|
+| `warmup: true`（デフォルト） | 起動時にすべてのコントローラーを解決 | 長時間稼働サーバー |
+| `warmup: false` | 最初のリクエストでコントローラーを解決 | コールドスタート最適化 |
+
+## 次のステップ
+
+- [コントローラー](../controllers) — ルート処理と HTTP メソッド
+- [サービス](../services) — ビジネスロジックと依存性注入
+- [コマンド](../command) — CLI コマンド

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/electron.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/electron.md
@@ -1,0 +1,133 @@
+---
+sidebar_label: Electron
+---
+
+# Electron で始める
+
+このガイドでは、Electron アプリに Zelt アプリケーションを組み込んでローカル API を処理する方法を説明します。
+
+## 前提条件
+
+- [Node.js](https://nodejs.org/) v20 以上
+- [Electron](https://www.electronjs.org/) v28 以上
+
+## インストール
+
+```bash
+pnpm add @zeltjs/core @zeltjs/adapter-electron
+pnpm add -D electron
+```
+
+## ユースケース
+
+Electron アダプターを使用すると、別のサーバーを起動せずに Electron アプリ内で HTTP リクエストを処理できます。これは以下の用途に便利です：
+
+- レンダラープロセス向けのローカル API エンドポイント
+- オフライン対応アプリケーション
+- バックエンドを組み込んだデスクトップアプリ
+
+## Hello World
+
+### Step 1: アプリケーションの作成
+
+`src/api/app.ts` を作成します：
+
+```typescript
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+// ---cut---
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) {
+    return { message: `Hello, ${name}!` };
+  }
+}
+
+export const app = createApp({
+  http: {
+    controllers: [HelloController],
+  },
+});
+```
+
+### Step 2: メインプロセスでの初期化
+
+`src/main.ts` を作成します：
+
+```typescript
+// @noErrors
+import { app as electronApp, BrowserWindow, protocol } from 'electron';
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onElectron } from '@zeltjs/adapter-electron';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const electronZelt = await onElectron(app);
+
+electronApp.whenReady().then(() => {
+  protocol.handle('api', async (request) => {
+    return electronZelt.fetch(request);
+  });
+
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+});
+
+electronApp.on('window-all-closed', async () => {
+  await electronZelt.shutdown();
+  electronApp.quit();
+});
+```
+
+`onElectron()` 関数は Electron ランタイム用にアプリを準備します。以下を返します：
+
+- `fetch(request)` — Request を処理して Response を返す
+- `shutdown()` — アプリケーションをグレースフルにシャットダウン
+- `get<T>(Class)` — DI コンテナからサービスを解決
+
+### Step 3: レンダラーからの API 呼び出し
+
+レンダラープロセスまたはプリロードスクリプトで：
+
+```typescript
+const response = await fetch('api://localhost/hello/world');
+const data = await response.json();
+console.log(data.message); // "Hello, world!"
+```
+
+## ウォームアップオプション
+
+デフォルトでは、`onElectron()` は即時初期化（`warmup: true`）を使用します — すべてのコントローラーが起動時に解決されます。
+
+遅延初期化の場合：
+
+```typescript
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onElectron } from '@zeltjs/adapter-electron';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const electronZelt = await onElectron(app, { warmup: false });
+```
+
+| オプション | 動作 | ユースケース |
+|-----------|------|-------------|
+| `warmup: true`（デフォルト） | 起動時にすべてのコントローラーを解決 | デスクトップアプリ |
+| `warmup: false` | 最初のリクエストでコントローラーを解決 | 高速起動 |
+
+## 次のステップ
+
+- [コントローラー](../controllers) — ルート処理と HTTP メソッド
+- [サービス](../services) — ビジネスロジックと依存性注入

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/lambda.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/lambda.md
@@ -1,0 +1,242 @@
+---
+sidebar_label: AWS Lambda
+---
+
+# AWS Lambda で始める
+
+このガイドでは、AWS Lambda 上で Zelt アプリケーションを構築する方法を説明します。
+
+## 前提条件
+
+- [Node.js](https://nodejs.org/) v20 以上
+- [AWS アカウント](https://aws.amazon.com/)
+- [AWS CLI](https://aws.amazon.com/cli/) または [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
+
+## インストール
+
+```bash
+pnpm add @zeltjs/core @zeltjs/adapter-lambda
+pnpm add -D @types/aws-lambda esbuild
+```
+
+## プロジェクト構成
+
+```
+my-lambda/
+├── src/
+│   ├── app.ts
+│   ├── handler.ts
+│   └── controllers/
+│       └── hello.controller.ts
+├── package.json
+├── tsconfig.json
+└── template.yaml
+```
+
+## Hello World
+
+### Step 1: コントローラーの作成
+
+`src/controllers/hello.controller.ts` を作成します：
+
+```typescript
+// @noErrors
+import { Controller, Get, pathParam } from '@zeltjs/core';
+// ---cut---
+@Controller('/hello')
+export class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) {
+    return { message: `Hello, ${name}!` };
+  }
+}
+```
+
+### Step 2: アプリケーションの作成
+
+`src/app.ts` を作成します：
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+// ---cut---
+export const app = createApp({
+  http: {
+    controllers: [HelloController],
+  },
+});
+```
+
+### Step 3: Lambda ハンドラーの作成
+
+`src/handler.ts` を作成します：
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onLambda } from '@zeltjs/adapter-lambda';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const lambdaApp = await onLambda(app);
+
+export const handler = lambdaApp.handler;
+```
+
+`onLambda()` 関数は Lambda ランタイム用にアプリを準備します。以下を返します：
+
+- `handler` — API Gateway v2（HTTP API）ハンドラー
+- `handlerV1` — API Gateway v1（REST API）ハンドラー
+- `shutdown()` — アプリケーションをグレースフルにシャットダウン
+- `get<T>(Class)` — DI コンテナからサービスを解決
+
+### Step 4: SAM テンプレートの設定
+
+`template.yaml` を作成します：
+
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 30
+    Runtime: nodejs20.x
+
+Resources:
+  HelloFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: dist/
+      Handler: handler.handler
+      Events:
+        Api:
+          Type: HttpApi
+          Properties:
+            Path: /{proxy+}
+            Method: ANY
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: es2022
+        EntryPoints:
+          - src/handler.ts
+
+Outputs:
+  ApiEndpoint:
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com"
+```
+
+### Step 5: デプロイ
+
+```bash
+sam build
+sam deploy --guided
+```
+
+## API Gateway バージョン
+
+アダプターは両方の API Gateway バージョンをサポートしています：
+
+### HTTP API (v2) — 推奨
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onLambda } from '@zeltjs/adapter-lambda';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+const lambdaApp = await onLambda(app);
+// ---cut---
+export const handler = lambdaApp.handler;
+```
+
+### REST API (v1)
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onLambda } from '@zeltjs/adapter-lambda';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+const lambdaApp = await onLambda(app);
+// ---cut---
+export const handler = lambdaApp.handlerV1;
+```
+
+## ウォームアップオプション
+
+デフォルトでは、`onLambda()` は遅延初期化（`warmup: false`）を使用してコールドスタート時間を最小化します。コントローラーは最初のリクエストで解決されます。
+
+即時初期化の場合：
+
+```typescript
+// @noErrors
+import { createApp, Controller, Get, pathParam } from '@zeltjs/core';
+import { onLambda } from '@zeltjs/adapter-lambda';
+
+@Controller('/hello')
+class HelloController {
+  @Get('/:name')
+  greet(name = pathParam('name')) { return { message: `Hello, ${name}!` }; }
+}
+
+const app = createApp({ http: { controllers: [HelloController] } });
+// ---cut---
+const lambdaApp = await onLambda(app, { warmup: true });
+```
+
+| オプション | 動作 | ユースケース |
+|-----------|------|-------------|
+| `warmup: false`（デフォルト） | 最初のリクエストでコントローラーを解決 | コールドスタート最適化 |
+| `warmup: true` | 初期化時にすべてのコントローラーを解決 | プロビジョンドコンカレンシー |
+
+## バイナリレスポンス
+
+アダプターは画像、音声、動画、octet-stream などのバイナリレスポンスを自動的に base64 エンコードして処理します。
+
+```typescript
+// @noErrors
+import { Controller, Get, response } from '@zeltjs/core';
+// ---cut---
+@Controller('/files')
+export class FileController {
+  @Get('/image')
+  getImage() {
+    const imageBuffer = new Uint8Array([/* ... */]);
+    return response()
+      .header('Content-Type', 'image/png')
+      .body(imageBuffer);
+  }
+}
+```
+
+## 次のステップ
+
+- [コントローラー](../controllers) — ルート処理と HTTP メソッド
+- [サービス](../services) — ビジネスロジックと依存性注入
+- [設定](../configuration) — 環境変数とシークレット


### PR DESCRIPTION
## Summary

- Add documentation for `@zeltjs/adapter-bun` (Bun runtime adapter)
- Add documentation for `@zeltjs/adapter-lambda` (AWS Lambda adapter)
- Add documentation for `@zeltjs/adapter-electron` (Electron adapter)
- Add documentation for `@zeltjs/db` (Database abstraction with ALS transaction propagation)
- Add documentation for `@zeltjs/eventbus` (Type-safe event bus with memory/Redis adapters)

All documentation includes both English and Japanese (i18n) versions.

## Test plan

- [ ] Verify website builds successfully
- [ ] Check documentation renders correctly on the website
- [ ] Verify code examples in docs are accurate