### PR TITLE
feat(testing): export TestApp type

### DIFF
--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -3,6 +3,6 @@ export type {
   TestTargetResult,
 } from '@zeltjs/core/internal-bridge/testing';
 export { configureTestDefaults, getTestDefaults } from './global-config';
-export { onTest } from './on-test';
+export { onTest, type TestApp } from './on-test';
 export { shutdownAll } from './shutdown-registry';
 export { createTestTarget } from './test-target';

--- a/packages/testing/src/on-test.ts
+++ b/packages/testing/src/on-test.ts
@@ -9,7 +9,7 @@ type OnTestOptions = {
   readonly configs?: readonly AnyConfigClass[];
 };
 
-type TestApp = {
+export type TestApp = {
   readonly fetch: (request: Request) => Promise<Response>;
   readonly request: (input: string | Request, init?: RequestInit) => Promise<Response>;
   readonly shutdown: () => Promise<void>;

--- a/website/docs/testing/e2e.md
+++ b/website/docs/testing/e2e.md
@@ -64,7 +64,7 @@ For complete E2E tests with real dependencies, use `onTest()` to apply test conf
 ```typescript
 import { createApp, Controller, Get, Post, pathParam, response } from '@zeltjs/core';
 import { validated } from '@zeltjs/validator-valibot';
-import { onTest } from '@zeltjs/testing/vitest';
+import { onTest, type TestApp } from '@zeltjs/testing/vitest';
 import { RedisConfig } from '@zeltjs/redis';
 import { RedisTestContainerConfig } from '@zeltjs/redis/testing';
 import * as v from 'valibot';
@@ -73,7 +73,6 @@ declare function describe(name: string, fn: () => void): void;
 declare function it(name: string, fn: () => void | Promise<void>): void;
 declare function beforeAll(fn: () => void | Promise<void>): void;
 declare function expect<T>(value: T): { toBe(expected: T): void; };
-type TestApp = Awaited<ReturnType<typeof onTest>>;
 const UserBody = v.object({ name: v.string(), email: v.pipe(v.string(), v.email()) });
 @Controller('/users') class UserController {
   @Get('/:id') findOne(id = pathParam('id')) { return { id, name: 'Alice', email: 'alice@example.com' }; }

--- a/website/docs/testing/unit.md
+++ b/website/docs/testing/unit.md
@@ -20,7 +20,7 @@ Import from the adapter for your test runner. This auto-registers cleanup via `a
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget } from '@zeltjs/testing/vitest';
+import { onTest, createTestTarget, type TestApp } from '@zeltjs/testing/vitest';
 ```
 
 ### Jest
@@ -28,7 +28,7 @@ import { onTest, createTestTarget } from '@zeltjs/testing/vitest';
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget } from '@zeltjs/testing/jest';
+import { onTest, createTestTarget, type TestApp } from '@zeltjs/testing/jest';
 ```
 
 ### Bun
@@ -36,7 +36,7 @@ import { onTest, createTestTarget } from '@zeltjs/testing/jest';
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget } from '@zeltjs/testing/bun';
+import { onTest, createTestTarget, type TestApp } from '@zeltjs/testing/bun';
 ```
 
 ### Node.js Test Runner
@@ -44,7 +44,7 @@ import { onTest, createTestTarget } from '@zeltjs/testing/bun';
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget } from '@zeltjs/testing/node';
+import { onTest, createTestTarget, type TestApp } from '@zeltjs/testing/node';
 ```
 
 ### Manual Setup
@@ -54,7 +54,7 @@ If you prefer manual control or use a different test runner, import from the bas
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget, shutdownAll } from '@zeltjs/testing';
+import { onTest, createTestTarget, shutdownAll, type TestApp } from '@zeltjs/testing';
 import { afterAll } from 'your-test-runner';
 
 afterAll(shutdownAll);

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/testing/e2e.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/testing/e2e.md
@@ -59,18 +59,20 @@ describe('Hello API', () => {
 
 ## Full Application Testing
 
-For complete E2E tests with real dependencies, combine with [Integration Testing](./integration.md):
+For complete E2E tests with real dependencies, use `onTest()` to apply test config overrides to your production app:
 
 ```typescript
-import { createApp, Controller, Get, Post, pathParam, response, HttpApp, ConfigClass } from '@zeltjs/core';
+import { createApp, Controller, Get, Post, pathParam, response } from '@zeltjs/core';
 import { validated } from '@zeltjs/validator-valibot';
+import { onTest, type TestApp } from '@zeltjs/testing/vitest';
+import { RedisConfig } from '@zeltjs/redis';
+import { RedisTestContainerConfig } from '@zeltjs/redis/testing';
 import * as v from 'valibot';
 declare function hc<T>(baseUrl: string, options?: { fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> }): T;
 declare function describe(name: string, fn: () => void): void;
 declare function it(name: string, fn: () => void | Promise<void>): void;
 declare function beforeAll(fn: () => void | Promise<void>): void;
 declare function expect<T>(value: T): { toBe(expected: T): void; };
-declare const RedisTestContainerConfig: ConfigClass<object>;
 const UserBody = v.object({ name: v.string(), email: v.pipe(v.string(), v.email()) });
 @Controller('/users') class UserController {
   @Get('/:id') findOne(id = pathParam('id')) { return { id, name: 'Alice', email: 'alice@example.com' }; }
@@ -83,17 +85,24 @@ type AppType = {
   };
 };
 // ---cut---
+// Production app - same as your real application
+const app = createApp({
+  configs: [RedisConfig],
+  http: { controllers: [UserController] },
+});
+
 describe('API E2E', () => {
-  let app: HttpApp;
+  let testApp: TestApp;
   let client: AppType;
 
   beforeAll(async () => {
-    app = createApp({
+    // onTest() overrides RedisConfig with RedisTestContainerConfig
+    testApp = await onTest(app, {
       configs: [RedisTestContainerConfig],
-      http: { controllers: [UserController] },
     });
     client = hc<AppType>('http://localhost', {
-      fetch: (input: RequestInfo | URL, init?: RequestInit) => app.fetch(new Request(input, init)),
+      fetch: (input: RequestInfo | URL, init?: RequestInit) => 
+        testApp.fetch(new Request(input, init)),
     });
   });
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/testing/unit.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/testing/unit.md
@@ -20,7 +20,7 @@ Import from the adapter for your test runner. This auto-registers cleanup via `a
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget } from '@zeltjs/testing/vitest';
+import { onTest, createTestTarget, type TestApp } from '@zeltjs/testing/vitest';
 ```
 
 ### Jest
@@ -28,7 +28,7 @@ import { onTest, createTestTarget } from '@zeltjs/testing/vitest';
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget } from '@zeltjs/testing/jest';
+import { onTest, createTestTarget, type TestApp } from '@zeltjs/testing/jest';
 ```
 
 ### Bun
@@ -36,7 +36,7 @@ import { onTest, createTestTarget } from '@zeltjs/testing/jest';
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget } from '@zeltjs/testing/bun';
+import { onTest, createTestTarget, type TestApp } from '@zeltjs/testing/bun';
 ```
 
 ### Node.js Test Runner
@@ -44,7 +44,7 @@ import { onTest, createTestTarget } from '@zeltjs/testing/bun';
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget } from '@zeltjs/testing/node';
+import { onTest, createTestTarget, type TestApp } from '@zeltjs/testing/node';
 ```
 
 ### Manual Setup
@@ -54,7 +54,7 @@ If you prefer manual control or use a different test runner, import from the bas
 ```typescript
 // @noErrors
 // Reason: import-only example for test framework setup
-import { onTest, createTestTarget, shutdownAll } from '@zeltjs/testing';
+import { onTest, createTestTarget, shutdownAll, type TestApp } from '@zeltjs/testing';
 import { afterAll } from 'your-test-runner';
 
 afterAll(shutdownAll);


### PR DESCRIPTION
## Summary

- `TestApp`型を`@zeltjs/testing`からエクスポート
- ユーザーが`Awaited<ReturnType<typeof onTest>>`を自分で定義する必要がなくなる

## Changes

- `on-test.ts`: `TestApp`型をexport
- `index.ts`: `TestApp`をre-export
- `e2e.md`: `import { onTest, type TestApp }`パターンを使用

## Test plan

- [x] `pnpm --filter @zeltjs/testing build` 成功
- [x] `TestApp`がdist内でエクスポートされていることを確認