### PR TITLE
feat(ci): migrate website deploy from Workers to Pages

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -48,17 +48,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: website
           packageManager: 'pnpm'
-          command: versions upload --tag production --message "Production deploy from ${{ github.sha }}"
-
-      - name: Promote to Production
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: cloudflare/wrangler-action@v3.14.1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: website
-          packageManager: 'pnpm'
-          command: versions deploy --yes
+          command: deploy
 
       - name: Comment Preview URL on PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,26 +28,48 @@ jobs:
       - name: Build all packages (required for twoslash type resolution)
         run: pnpm build
 
-      - name: Deploy to Cloudflare Workers
-        id: deploy
+      - name: Deploy Preview (PR)
+        if: github.event_name == 'pull_request'
+        id: deploy-preview
         uses: cloudflare/wrangler-action@v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: website
           packageManager: 'pnpm'
-          command: deploy
+          command: versions upload
+
+      - name: Deploy Production (main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: deploy-production
+        uses: cloudflare/wrangler-action@v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: website
+          packageManager: 'pnpm'
+          command: versions upload --tag production --message "Production deploy from ${{ github.sha }}"
+
+      - name: Promote to Production
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: website
+          packageManager: 'pnpm'
+          command: versions deploy --yes
 
       - name: Comment Preview URL on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7.0.1
         with:
           script: |
-            const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
+            const deploymentUrl = '${{ steps.deploy-preview.outputs.deployment-url }}';
             const commitSha = '${{ github.event.pull_request.head.sha }}';
             const shortSha = commitSha.substring(0, 7);
 
-            const body = `## 🚀 Cloudflare Workers Deploy
+            const body = `## 🚀 Cloudflare Workers Preview
 
             | Status | Preview | Commit |
             |--------|---------|--------|
@@ -62,7 +84,7 @@ jobs:
 
             const botComment = comments.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('Cloudflare Workers Deploy')
+              comment.body.includes('Cloudflare Workers Preview')
             );
 
             if (botComment) {

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -29,7 +29,7 @@ jobs:
         run: pnpm build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@1.5.0
+        uses: cloudflare/pages-action@v1.5.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,11 +28,55 @@ jobs:
       - name: Build all packages (required for twoslash type resolution)
         run: pnpm build
 
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1.5.0
+      - name: Deploy to Cloudflare Workers
+        id: deploy
+        uses: cloudflare/wrangler-action@v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: zelt
-          directory: website/build
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          workingDirectory: website
+          packageManager: 'pnpm'
+          command: deploy
+
+      - name: Comment Preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
+            const commitSha = '${{ github.event.pull_request.head.sha }}';
+            const shortSha = commitSha.substring(0, 7);
+
+            const body = `## 🚀 Cloudflare Workers Deploy
+
+            | Status | Preview | Commit |
+            |--------|---------|--------|
+            | ✅ Deployed | [${deploymentUrl}](${deploymentUrl}) | ${shortSha} |
+            `;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Cloudflare Workers Deploy')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Build all packages (required for twoslash type resolution)
         run: pnpm build
 
-      - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@1.5.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: website
-          packageManager: 'pnpm'
-          command: deploy
+          projectName: zelt
+          directory: website/build
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Cloudflare Workers Assets から Cloudflare Pages へ移行
- PRごとに自動でpreview URLがコメントされるようになる
- `gitHubToken` を追加してGitHub連携を有効化

## Test plan
- [ ] PRでCIが実行され、Cloudflare Pagesへのデプロイが成功する
- [ ] PRコメントにpreview URLが自動的に表示される
- [ ] mainマージ後のproductionデプロイが正常に動作する

## Note
問題があれば元のWorkers構成に戻せます。