### PR TITLE
feat(ci): use wildcard pattern for release-please packages

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,22 @@
 {
-  "packages/core": "0.1.1",
+  "packages/adapter-bun": "0.1.0",
+  "packages/adapter-cloudflare-workers": "0.1.0",
+  "packages/adapter-electron": "0.1.0",
+  "packages/adapter-lambda": "0.1.0",
   "packages/adapter-node": "0.1.1",
-  "packages/contract": "0.1.1",
+  "packages/auth-jwt": "0.1.0",
+  "packages/auth-session": "0.1.0",
+  "packages/cli": "0.0.1",
+  "packages/core": "0.1.1",
+  "packages/db": "0.1.0",
+  "packages/decorator-metadata": "0.0.1",
+  "packages/eslint-plugin": "0.0.1",
+  "packages/eventbus": "0.1.0",
+  "packages/hono-client": "0.1.0",
+  "packages/kv": "0.1.0",
+  "packages/openapi": "0.2.0",
+  "packages/rate-limit": "0.1.0",
+  "packages/redis": "0.1.0",
   "packages/testing": "0.1.1",
-  "packages/cli": "0.0.1"
+  "packages/validator-valibot": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,31 +5,12 @@
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": true,
   "packages": {
-    "packages/core": {
-      "component": "core"
-    },
-    "packages/adapter-node": {
-      "component": "adapter-node"
-    },
-    "packages/contract": {
-      "component": "openapi"
-    },
-    "packages/testing": {
-      "component": "testing"
-    },
-    "packages/cli": {
-      "component": "cli"
-    }
+    "packages/*": {}
   },
   "plugins": [
     {
       "type": "node-workspace",
       "merge": false
-    },
-    {
-      "type": "linked-versions",
-      "groupName": "zeltjs",
-      "components": ["core", "adapter-node", "openapi", "testing", "cli"]
     }
   ]
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,32 @@
     {
       "type": "node-workspace",
       "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "zeltjs",
+      "components": [
+        "adapter-bun",
+        "adapter-cloudflare-workers",
+        "adapter-electron",
+        "adapter-lambda",
+        "adapter-node",
+        "auth-jwt",
+        "auth-session",
+        "cli",
+        "core",
+        "db",
+        "decorator-metadata",
+        "eslint-plugin",
+        "eventbus",
+        "hono-client",
+        "kv",
+        "openapi",
+        "rate-limit",
+        "redis",
+        "testing",
+        "validator-valibot"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Switch from explicit package listing to `packages/*` wildcard for automatic detection
- Remove `linked-versions` plugin (no longer needed with wildcard)
- Add all 20 packages to manifest (was only 5)
- Fixes workflow failure from `packages/contract` → `packages/openapi` rename

## Test plan
- [ ] Verify release-please workflow runs successfully after merge
- [ ] Confirm PR #24 gets updated or recreated properly