### PR TITLE
fix(ci): use explicit package paths for release-please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check release-please config sync
+        run: ./scripts/check-release-please-config.sh
+
       - name: Format check
         run: pnpm format:check
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,3 +35,5 @@ pre-push:
             fi
           fi
         done
+    check-release-please:
+      run: ./scripts/check-release-please-config.sh

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,26 @@
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": true,
   "packages": {
-    "packages/*": {}
+    "packages/adapter-bun": {},
+    "packages/adapter-cloudflare-workers": {},
+    "packages/adapter-electron": {},
+    "packages/adapter-lambda": {},
+    "packages/adapter-node": {},
+    "packages/auth-jwt": {},
+    "packages/auth-session": {},
+    "packages/cli": {},
+    "packages/core": {},
+    "packages/db": {},
+    "packages/decorator-metadata": {},
+    "packages/eslint-plugin": {},
+    "packages/eventbus": {},
+    "packages/hono-client": {},
+    "packages/kv": {},
+    "packages/openapi": {},
+    "packages/rate-limit": {},
+    "packages/redis": {},
+    "packages/testing": {},
+    "packages/validator-valibot": {}
   },
   "plugins": [
     {

--- a/scripts/check-release-please-config.sh
+++ b/scripts/check-release-please-config.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="release-please-config.json"
+MANIFEST_FILE=".release-please-manifest.json"
+
+errors=0
+
+# Get packages from filesystem (excluding private packages)
+fs_packages=()
+for pkg in packages/*/package.json; do
+  dir=$(dirname "$pkg")
+  name=$(basename "$dir")
+  private=$(jq -r '.private // false' "$pkg")
+  if [ "$private" != "true" ]; then
+    fs_packages+=("$name")
+  fi
+done
+
+# Check release-please-config.json packages
+config_packages=$(jq -r '.packages | keys[]' "$CONFIG_FILE" | sed 's|packages/||' | sort)
+for pkg in "${fs_packages[@]}"; do
+  if ! echo "$config_packages" | grep -qx "$pkg"; then
+    echo "ERROR: packages/$pkg missing from $CONFIG_FILE packages"
+    errors=1
+  fi
+done
+
+# Check linked-versions components
+linked_components=$(jq -r '.plugins[] | select(.type == "linked-versions") | .components[]' "$CONFIG_FILE" | sort)
+for pkg in "${fs_packages[@]}"; do
+  if ! echo "$linked_components" | grep -qx "$pkg"; then
+    echo "ERROR: $pkg missing from linked-versions components in $CONFIG_FILE"
+    errors=1
+  fi
+done
+
+# Check manifest
+manifest_packages=$(jq -r 'keys[]' "$MANIFEST_FILE" | sed 's|packages/||' | sort)
+for pkg in "${fs_packages[@]}"; do
+  if ! echo "$manifest_packages" | grep -qx "$pkg"; then
+    echo "ERROR: packages/$pkg missing from $MANIFEST_FILE"
+    errors=1
+  fi
+done
+
+if [ $errors -eq 0 ]; then
+  echo "✓ release-please config is in sync with packages/"
+fi
+
+exit $errors


### PR DESCRIPTION
## Summary
- Replace `packages/*` wildcard with explicit package paths (wildcard not supported by release-please)
- Fixes: `Missing required file: packages/*/package.json` error

## Context
Wildcard patterns like `packages/*` are not supported in release-please config. Each package path must be explicitly listed.