### PR TITLE
fix(website): twoslash popup display improvements

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -100,6 +100,7 @@ const config: KnipConfig = {
         '@zeltjs/redis',
         '@zeltjs/testing',
         '@zeltjs/validator-valibot',
+        '@floating-ui/react',
         'better-sqlite3',
         'bullmq',
         'clsx',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,6 +540,9 @@ importers:
       '@easyops-cn/docusaurus-search-local':
         specifier: 0.48.0
         version: 0.48.0(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.17.19)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.17.19))(@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.17.19)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.17.19))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.17.19)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(@swc/core@1.15.33)(esbuild@0.17.19)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.17.19)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+      '@floating-ui/react':
+        specifier: 0.27.7
+        version: 0.27.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@heroicons/react':
         specifier: 2.2.0
         version: 2.2.0(react@19.2.5)
@@ -3050,6 +3053,27 @@ packages:
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.7':
+    resolution: {integrity: sha512-5V9pwFeiv+95Jlowq/7oiGISSrdXMTs2jfoSy8k+WM6oI/Skm1WWjPdJWeporN2O4UGcsaCJdirKffKayMoPgw==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -10201,6 +10225,9 @@ packages:
       '@swc/core': ^1.2.147
       webpack: '>=2'
 
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -13863,6 +13890,31 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@floating-ui/react@0.27.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tabbable: 6.4.0
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@grpc/grpc-js@1.14.3':
     dependencies:
       '@grpc/proto-loader': 0.8.0
@@ -15809,7 +15861,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -21706,6 +21758,8 @@ snapshots:
       '@swc/core': 1.15.33
       '@swc/counter': 0.1.3
       webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.17.19)
+
+  tabbable@6.4.0: {}
 
   tapable@2.3.3: {}
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 import type { Config } from '@docusaurus/types';
 import type { PluginOptions as SearchPluginOptions } from '@easyops-cn/docusaurus-search-local';
 import rehypeShiki from '@shikijs/rehype';
-import { transformerTwoslash } from '@shikijs/twoslash';
+import { rendererRich, transformerTwoslash } from '@shikijs/twoslash';
 import { createTwoslasher } from 'twoslash';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -68,7 +68,7 @@ const shikiBaseConfig = {
 
 const shikiWithTwoslash = {
   ...shikiBaseConfig,
-  transformers: [transformerTwoslash({ twoslasher })],
+  transformers: [transformerTwoslash({ twoslasher, renderer: rendererRich() })],
 };
 
 const shikiOnly = {

--- a/website/package.json
+++ b/website/package.json
@@ -21,6 +21,7 @@
     "@docusaurus/preset-classic": "3.10.1",
     "@docusaurus/theme-common": "3.10.1",
     "@easyops-cn/docusaurus-search-local": "0.48.0",
+    "@floating-ui/react": "0.27.7",
     "@heroicons/react": "2.2.0",
     "@mdx-js/react": "^3.0.0",
     "@shikijs/rehype": "3.7.0",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -109,9 +109,29 @@ pre:hover .twoslash-hover {
   border-radius: 4px;
   box-shadow: var(--twoslash-popup-shadow);
   max-width: 500px;
-  white-space: normal;
+  white-space: pre;
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.875rem;
+}
+
+.twoslash-floating-popup pre {
+  margin: 0 !important;
+  padding: 6px 8px !important;
+  background: transparent !important;
+  white-space: pre !important;
+  line-height: 1.4 !important;
+}
+
+.twoslash-floating-popup pre pre {
+  padding: 0 !important;
+}
+
+.twoslash-floating-popup code {
+  background: transparent !important;
+}
+
+.twoslash-floating-popup .line {
+  display: block;
 }
 
 .twoslash-popup-code,

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -78,14 +78,10 @@
 }
 
 /* ===== Twoslash Styles =====
-   Adapted from @shikijs/twoslash/style-rich.css
-   Modified to work without .twoslash parent class wrapper.
-   Note: Popup cannot escape parent overflow:hidden - this is a known limitation
-   that requires JS (floating-vue) to fix properly. See: github.com/antfu/shikiji/issues/60 */
+   Using FloatingPortal to render popups outside code block overflow boundaries */
 
 @media (prefers-reduced-motion: reduce) {
-  .twoslash-hover,
-  .twoslash-popup-container {
+  .twoslash-hover {
     transition: none !important;
   }
 }
@@ -100,37 +96,22 @@ pre:hover .twoslash-hover {
   position: relative;
 }
 
+/* Hide original popup - FloatingPortal handles display */
 .twoslash-popup-container {
-  position: absolute;
-  opacity: 0;
-  display: none;
-  flex-direction: column;
-  bottom: 100%;
-  left: 0;
-  margin-bottom: 4px;
+  display: none !important;
+}
+
+/* Floating popup rendered via portal */
+.twoslash-floating-popup {
   background: var(--twoslash-popup-bg);
   color: var(--twoslash-popup-color);
   border: 1px solid var(--twoslash-border-color);
-  transition: opacity 0.3s;
   border-radius: 4px;
-  pointer-events: none;
-  z-index: 100;
-  user-select: none;
-  text-align: left;
   box-shadow: var(--twoslash-popup-shadow);
   max-width: 500px;
   white-space: normal;
-}
-
-.twoslash-hover:hover .twoslash-popup-container,
-.twoslash-query-presisted .twoslash-popup-container {
-  display: inline-flex;
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.twoslash-popup-container:hover {
-  user-select: auto;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.875rem;
 }
 
 .twoslash-popup-code,

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,5 +1,3 @@
-@import '@shikijs/twoslash/style-rich.css';
-
 :root {
   /* Typography */
   --ifm-font-family-base: 'Zen Kaku Gothic New', 'Inter', system-ui, sans-serif;
@@ -34,6 +32,19 @@
 
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(234, 88, 12, 0.1);
+
+  /* Twoslash variables */
+  --twoslash-border-color: #8888;
+  --twoslash-underline-color: currentColor;
+  --twoslash-popup-bg: #1a1614;
+  --twoslash-popup-color: #e8e0d8;
+  --twoslash-popup-shadow: rgba(0, 0, 0, 0.3) 0px 4px 12px;
+  --twoslash-docs-color: #a0a0a0;
+  --twoslash-docs-font: sans-serif;
+  --twoslash-code-font: inherit;
+  --twoslash-code-font-size: 0.9em;
+  --twoslash-error-color: #d45656;
+  --twoslash-error-bg: #d4565620;
 }
 
 [data-theme='dark'] {
@@ -66,10 +77,175 @@
   --docusaurus-highlighted-code-line-bg: rgba(251, 146, 60, 0.2);
 }
 
-/* Sidebar styling */
+/* ===== Twoslash Styles =====
+   Adapted from @shikijs/twoslash/style-rich.css
+   Modified to work without .twoslash parent class wrapper.
+   Note: Popup cannot escape parent overflow:hidden - this is a known limitation
+   that requires JS (floating-vue) to fix properly. See: github.com/antfu/shikiji/issues/60 */
+
+@media (prefers-reduced-motion: reduce) {
+  .twoslash-hover,
+  .twoslash-popup-container {
+    transition: none !important;
+  }
+}
+
+pre:hover .twoslash-hover {
+  border-color: var(--twoslash-underline-color);
+}
+
+.twoslash-hover {
+  border-bottom: 1px dotted transparent;
+  transition: border-color 0.3s ease;
+  position: relative;
+}
+
+.twoslash-popup-container {
+  position: absolute;
+  opacity: 0;
+  display: none;
+  flex-direction: column;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 4px;
+  background: var(--twoslash-popup-bg);
+  color: var(--twoslash-popup-color);
+  border: 1px solid var(--twoslash-border-color);
+  transition: opacity 0.3s;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 100;
+  user-select: none;
+  text-align: left;
+  box-shadow: var(--twoslash-popup-shadow);
+  max-width: 500px;
+  white-space: normal;
+}
+
+.twoslash-hover:hover .twoslash-popup-container,
+.twoslash-query-presisted .twoslash-popup-container {
+  display: inline-flex;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.twoslash-popup-container:hover {
+  user-select: auto;
+}
+
+.twoslash-popup-code,
+.twoslash-popup-error,
+.twoslash-popup-docs {
+  padding: 6px 8px !important;
+}
+
+.twoslash-popup-code {
+  font-family: var(--twoslash-code-font);
+  font-size: var(--twoslash-code-font-size);
+  background: transparent !important;
+  border: none !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+  white-space: pre-wrap !important;
+  line-height: 1.4 !important;
+}
+
+.twoslash-popup-code code {
+  background: transparent !important;
+  overflow: visible !important;
+}
+
+.twoslash-popup-container pre,
+.twoslash-popup-container pre.thin-scrollbar,
+.twoslash-popup-container pre[class*="codeBlock"] {
+  overflow: visible !important;
+  margin: 0 !important;
+  padding: 6px 8px !important;
+  min-height: auto !important;
+  max-height: none !important;
+  scrollbar-width: none !important;
+}
+
+.twoslash-popup-container pre::-webkit-scrollbar {
+  display: none !important;
+}
+
+.twoslash-popup-docs {
+  color: var(--twoslash-docs-color);
+  font-family: var(--twoslash-docs-font);
+  font-size: 0.8em;
+  border-top: 1px solid var(--twoslash-border-color);
+}
+
+.twoslash-popup-docs-tags {
+  display: flex;
+  flex-direction: column;
+  font-family: var(--twoslash-docs-font);
+  padding: 4px 8px;
+  font-size: 0.75em;
+  color: var(--twoslash-docs-color);
+  border-top: 1px solid var(--twoslash-border-color);
+}
+
+.twoslash-popup-docs-tag {
+  display: flex;
+  gap: 0.5em;
+}
+
+.twoslash-popup-docs-tag-name {
+  font-family: var(--twoslash-code-font);
+  color: var(--ifm-color-primary);
+}
+
+.twoslash-error {
+  background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+    repeat-x bottom left;
+  padding-bottom: 2px;
+}
+
+.twoslash-error-line {
+  position: relative;
+  background-color: var(--twoslash-error-bg);
+  border-left: 3px solid var(--twoslash-error-color);
+  color: var(--twoslash-error-color);
+  padding: 6px 12px;
+  margin: 0.2em 0;
+}
+
+.twoslash-popup-error {
+  color: var(--twoslash-error-color);
+  background-color: var(--twoslash-error-bg);
+  font-family: var(--twoslash-docs-font);
+  font-size: 0.8em;
+}
+
+.twoslash-completion-cursor {
+  position: relative;
+}
+
+.twoslash-completion-list {
+  user-select: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(0, 1.2em);
+  margin: 3px 0 0 -1px;
+  display: inline-block;
+  z-index: 8;
+  box-shadow: var(--twoslash-popup-shadow);
+  background: var(--twoslash-popup-bg);
+  border: 1px solid var(--twoslash-border-color);
+  width: 240px;
+  font-size: 0.8rem;
+  padding: 4px;
+}
+
+/* ===== Sidebar Styling ===== */
+
 .theme-doc-sidebar-menu {
   font-size: 0.875rem;
   padding: 0;
+  padding-bottom: 8rem;
 }
 
 .theme-doc-sidebar-menu > .theme-doc-sidebar-item-category > .menu__list-item-collapsible {
@@ -91,7 +267,6 @@
   line-height: 1.4;
 }
 
-/* Collapse arrow - hide default and add inline */
 .menu__link--sublist-caret::after {
   display: none !important;
 }
@@ -122,7 +297,8 @@
   background-color: rgba(251, 146, 60, 0.15);
 }
 
-/* Headings */
+/* ===== Headings ===== */
+
 .markdown h1 {
   font-size: 2rem;
   font-weight: 700;
@@ -161,7 +337,8 @@
   margin-top: 0.5rem;
 }
 
-/* Code blocks */
+/* ===== Code Blocks ===== */
+
 pre {
   background-color: #1a1614 !important;
   border-radius: 0.5rem;
@@ -170,7 +347,6 @@ pre {
   line-height: 1.7;
 }
 
-/* Inline code */
 code:not(pre code) {
   background-color: rgba(234, 88, 12, 0.08);
   padding: 0.125rem 0.375rem;
@@ -188,21 +364,17 @@ code:not(pre code)::after {
   background-color: rgba(251, 146, 60, 0.12);
 }
 
-/* Bottom spacing for scroll comfort */
-.theme-doc-sidebar-menu {
-  padding-bottom: 8rem;
-}
+/* ===== Layout ===== */
 
 .pagination-nav {
   margin-bottom: 8rem;
 }
 
-/* Hide breadcrumbs */
 .theme-doc-breadcrumbs {
   display: none;
 }
 
-/* ===== Navbar link colors ===== */
+/* ===== Navbar ===== */
 
 .navbar__link {
   color: var(--ifm-font-color-base);
@@ -213,15 +385,11 @@ code:not(pre code)::after {
   color: var(--ifm-font-color-base);
 }
 
-/* ===== VitePress-style navbar right items ===== */
-
-/* Navbar right items layout with separators */
 .navbar__items--right {
   align-items: center;
   gap: 0;
 }
 
-/* Navbar right items - unified spacing */
 .navbar__items--right > .dropdown,
 .navbar__items--right > .navbar__github,
 .navbar__items--right > button[class*="colorModeToggle"] {
@@ -233,7 +401,6 @@ code:not(pre code)::after {
   padding: 0 12px;
 }
 
-/* Separator after dropdown and github */
 .navbar__items--right > .dropdown::after,
 .navbar__items--right > .navbar__github::after {
   content: '';
@@ -245,7 +412,6 @@ code:not(pre code)::after {
   background-color: var(--ifm-color-emphasis-300);
 }
 
-/* GitHub icon-only link */
 .navbar__github {
   font-size: 0;
   justify-content: center;
@@ -265,7 +431,6 @@ code:not(pre code)::after {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23e8e0d8'%3E%3Cpath d='M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z'/%3E%3C/svg%3E");
 }
 
-/* Locale dropdown - match sidebar arrow style */
 .navbar__items--right > .dropdown > .navbar__link::after {
   width: 1rem;
   height: 1rem;
@@ -333,13 +498,12 @@ article .markdown header h1 {
   }
 }
 
-/* ===== Landing Page Styles ===== */
+/* ===== Landing Page ===== */
 
 .landing {
   --section-padding: 5rem 1.5rem;
 }
 
-/* Hero Section */
 .hero {
   padding: 6rem 1.5rem;
   text-align: center;
@@ -412,7 +576,6 @@ article .markdown header h1 {
   text-decoration: none;
 }
 
-/* Code Showcase */
 .code-showcase {
   padding: var(--section-padding);
   background-color: var(--ifm-background-surface-color);
@@ -440,7 +603,6 @@ article .markdown header h1 {
   color: #e8e0d8;
 }
 
-/* Features Section */
 .features {
   padding: var(--section-padding);
 }
@@ -501,7 +663,6 @@ article .markdown header h1 {
   margin: 0;
 }
 
-/* Install Section */
 .install {
   padding: var(--section-padding);
   text-align: center;
@@ -543,7 +704,6 @@ article .markdown header h1 {
   color: var(--ifm-color-primary-dark);
 }
 
-/* Landing Page Responsive */
 @media (max-width: 768px) {
   .hero {
     padding: 4rem 1.5rem;

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,6 +1,7 @@
 import Head from '@docusaurus/Head';
 import { useLocation } from '@docusaurus/router';
 import type { ReactNode } from 'react';
+import { TwoslashPortalManager } from './TwoslashPortal';
 
 type RootProps = {
   children: ReactNode;
@@ -16,6 +17,7 @@ const Root = ({ children }: RootProps): ReactNode => {
         <link rel="alternate" type="text/markdown" href={mdUrl} title="Markdown version" />
       </Head>
       {children}
+      <TwoslashPortalManager />
     </>
   );
 };

--- a/website/src/theme/TwoslashPortal.tsx
+++ b/website/src/theme/TwoslashPortal.tsx
@@ -1,0 +1,108 @@
+import {
+  FloatingPortal,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useFloating,
+} from '@floating-ui/react';
+import { useEffect, useState, type ReactNode } from 'react';
+
+type PopupData = {
+  id: string;
+  trigger: HTMLElement;
+  content: HTMLElement;
+};
+
+const TwoslashPopup = ({ trigger, content }: { trigger: HTMLElement; content: HTMLElement }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { refs, floatingStyles } = useFloating({
+    open: isOpen,
+    placement: 'top-start',
+    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  });
+
+  useEffect(() => {
+    refs.setReference(trigger);
+
+    const handleMouseEnter = () => setIsOpen(true);
+    const handleMouseLeave = () => setIsOpen(false);
+
+    trigger.addEventListener('mouseenter', handleMouseEnter);
+    trigger.addEventListener('mouseleave', handleMouseLeave);
+
+    return () => {
+      trigger.removeEventListener('mouseenter', handleMouseEnter);
+      trigger.removeEventListener('mouseleave', handleMouseLeave);
+    };
+  }, [trigger, refs]);
+
+  if (!isOpen) return null;
+
+  return (
+    <FloatingPortal>
+      <div
+        ref={refs.setFloating}
+        style={{
+          ...floatingStyles,
+          zIndex: 9999,
+        }}
+        dangerouslySetInnerHTML={{ __html: content.innerHTML }}
+        className="twoslash-floating-popup"
+      />
+    </FloatingPortal>
+  );
+};
+
+export const TwoslashPortalManager = (): ReactNode => {
+  const [popups, setPopups] = useState<PopupData[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const processPopups = () => {
+      const hovers = document.querySelectorAll('.twoslash-hover');
+      const newPopups: PopupData[] = [];
+
+      hovers.forEach((hover, index) => {
+        const container = hover.querySelector('.twoslash-popup-container');
+        if (container && container instanceof HTMLElement) {
+          const id = `twoslash-popup-${index}`;
+          container.style.display = 'none';
+          newPopups.push({
+            id,
+            trigger: hover as HTMLElement,
+            content: container,
+          });
+        }
+      });
+
+      setPopups(newPopups);
+    };
+
+    const observer = new MutationObserver(() => {
+      processPopups();
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    processPopups();
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <>
+      {popups.map((popup) => (
+        <TwoslashPopup key={popup.id} trigger={popup.trigger} content={popup.content} />
+      ))}
+    </>
+  );
+};
+
+export default TwoslashPortalManager;

--- a/website/src/theme/TwoslashPortal.tsx
+++ b/website/src/theme/TwoslashPortal.tsx
@@ -14,8 +14,16 @@ type PopupData = {
   content: HTMLElement;
 };
 
+const normalizePopupHtml = (html: string): string => {
+  return html
+    .replace(/>\s+</g, '><')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+};
+
 const TwoslashPopup = ({ trigger, content }: { trigger: HTMLElement; content: HTMLElement }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [normalizedHtml, setNormalizedHtml] = useState('');
 
   const { refs, floatingStyles } = useFloating({
     open: isOpen,
@@ -27,7 +35,10 @@ const TwoslashPopup = ({ trigger, content }: { trigger: HTMLElement; content: HT
   useEffect(() => {
     refs.setReference(trigger);
 
-    const handleMouseEnter = () => setIsOpen(true);
+    const handleMouseEnter = () => {
+      setNormalizedHtml(normalizePopupHtml(content.innerHTML));
+      setIsOpen(true);
+    };
     const handleMouseLeave = () => setIsOpen(false);
 
     trigger.addEventListener('mouseenter', handleMouseEnter);
@@ -37,7 +48,7 @@ const TwoslashPopup = ({ trigger, content }: { trigger: HTMLElement; content: HT
       trigger.removeEventListener('mouseenter', handleMouseEnter);
       trigger.removeEventListener('mouseleave', handleMouseLeave);
     };
-  }, [trigger, refs]);
+  }, [trigger, content, refs]);
 
   if (!isOpen) return null;
 
@@ -49,7 +60,7 @@ const TwoslashPopup = ({ trigger, content }: { trigger: HTMLElement; content: HT
           ...floatingStyles,
           zIndex: 9999,
         }}
-        dangerouslySetInnerHTML={{ __html: content.innerHTML }}
+        dangerouslySetInnerHTML={{ __html: normalizedHtml }}
         className="twoslash-floating-popup"
       />
     </FloatingPortal>


### PR DESCRIPTION
## Summary

- Add twoslash popup styles for hover type info display
- Use FloatingPortal to render popups outside overflow:hidden containers
- Normalize whitespace in popup content to fix excessive spacing

## Test plan

- [ ] Verify code blocks with twoslash render correctly
- [ ] Hover over underlined code to see type popups
- [ ] Confirm popups escape code block boundaries
- [ ] Check multi-line type info displays without excessive whitespace