### PR TITLE
fix(eslint-plugin): add repository field for npm provenance

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -3,6 +3,12 @@
   "version": "0.3.0",
   "description": "ESLint plugin for Zelt DI naming conventions",
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zeltjs/zelt.git",
+    "directory": "packages/eslint-plugin"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -37,7 +43,6 @@
     "di",
     "naming-conventions"
   ],
-  "license": "MIT",
   "volta": {
     "extends": "../../package.json"
   }


### PR DESCRIPTION
## Summary
- Add missing `repository` field to eslint-plugin package.json
- Fixes npm provenance verification error during publish

## Context
npm publish failed with:
```
Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/zeltjs/zelt"
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->