### PR TITLE
fix(build): transform TC39 decorators with SWC at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@9wick/eslint-plugin-strict-type-rules": "1.2.0",
     "@biomejs/biome": "2.4.14",
     "@eslint-community/eslint-plugin-eslint-comments": "4.7.1",
+    "@rollup/plugin-swc": "0.4.0",
     "@swc/core": "1.15.33",
     "@vitest/coverage-v8": "4.1.5",
     "@zeltjs/eslint-plugin": "workspace:*",

--- a/packages/adapter-bun/tsdown.config.ts
+++ b/packages/adapter-bun/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/adapter-cloudflare-workers/tsdown.config.ts
+++ b/packages/adapter-cloudflare-workers/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/adapter-electron/tsdown.config.ts
+++ b/packages/adapter-electron/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/adapter-lambda/tsdown.config.ts
+++ b/packages/adapter-lambda/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/adapter-node/tsdown.config.ts
+++ b/packages/adapter-node/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/auth-jwt/tsdown.config.ts
+++ b/packages/auth-jwt/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/auth-session/tsdown.config.ts
+++ b/packages/auth-session/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: [
     'src/index.ts',
     'src/workers.ts',

--- a/packages/db/tsdown.config.ts
+++ b/packages/db/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/decorator-metadata/tsdown.config.ts
+++ b/packages/decorator-metadata/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/inspect/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/eslint-plugin/tsdown.config.ts
+++ b/packages/eslint-plugin/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/hono-client/tsdown.config.ts
+++ b/packages/hono-client/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/cli.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/rate-limit/tsdown.config.ts
+++ b/packages/rate-limit/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/redis/tsdown.config.ts
+++ b/packages/redis/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/testing/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/testing/tsdown.config.ts
+++ b/packages/testing/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: [
     'src/index.ts',
     'src/adapters/vitest.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.7.1
         version: 4.7.1(eslint@10.3.0(jiti@2.6.1))
+      '@rollup/plugin-swc':
+        specifier: 0.4.0
+        version: 0.4.0(@swc/core@1.15.33)
       '@swc/core':
         specifier: 1.15.33
         version: 1.15.33
@@ -4450,6 +4453,16 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@rollup/plugin-swc@0.4.0':
+    resolution: {integrity: sha512-oAtqXa8rOl7BOK1Rz3rRxI+LIL53S9SqO2KSq2UUUzWgOgXg6492Jh5mL2mv/f9cpit8zFWdwILuVeozZ0C8mg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@swc/core': ^1.3.0
+      rollup: ^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -10004,6 +10017,10 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
+  smob@1.6.2:
+    resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
+    engines: {node: '>=20.0.0'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
@@ -15018,6 +15035,12 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
+  '@rollup/plugin-swc@0.4.0(@swc/core@1.15.33)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0
+      '@swc/core': 1.15.33
+      smob: 1.6.2
+
   '@rollup/pluginutils@5.3.0':
     dependencies:
       '@types/estree': 1.0.8
@@ -15809,7 +15832,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -16160,7 +16183,7 @@ snapshots:
 
   axios@1.15.2:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -17956,6 +17979,8 @@ snapshots:
   flat@5.0.2: {}
 
   flatted@3.4.2: {}
+
+  follow-redirects@1.16.0: {}
 
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
@@ -21501,6 +21526,8 @@ snapshots:
   slash@3.0.0: {}
 
   slash@4.0.0: {}
+
+  smob@1.6.2: {}
 
   smol-toml@1.6.1: {}
 


### PR DESCRIPTION
## Summary

- tsdown/rolldown does not transform TC39 decorators, causing dist files to contain raw decorator syntax (`@Config class ...`) that Node.js cannot execute directly
- Add `@rollup/plugin-swc` to transform decorators during build
- Use `decoratorVersion: '2022-03'` to match vitest config for consistency

## Changes

- Add `@rollup/plugin-swc` as devDependency
- Configure SWC decorator transform in 15 packages that use decorators

## Test plan

- [x] All packages build successfully
- [x] 98 test files pass (was 4 failures on main)
- [x] `node -e "import('./dist/index.js')"` works for adapter-node

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->