### PR TITLE
fix(adapter): accept readonly string[] in execCommand

### DIFF
--- a/packages/adapter-bun/src/on-bun.ts
+++ b/packages/adapter-bun/src/on-bun.ts
@@ -32,7 +32,7 @@ export type HttpBunApp = ReadyResult &
 
 export type CommandBunApp = ReadyResult &
   BunAppBase & {
-    readonly execCommand: (argv: string[]) => Promise<ExecResult>;
+    readonly execCommand: (argv: readonly string[]) => Promise<ExecResult>;
     readonly shutdown: () => Promise<void>;
   };
 
@@ -89,8 +89,8 @@ const createExecForCommands = (
   getCommands: () => ReadonlyMap<string, CommandClass>,
   get: <T extends object>(cls: new (...args: never[]) => T) => T,
   stderr: Stderr,
-): ((argv: string[]) => Promise<ExecResult>) => {
-  return async (argv: string[]): Promise<ExecResult> => {
+): ((argv: readonly string[]) => Promise<ExecResult>) => {
+  return async (argv: readonly string[]): Promise<ExecResult> => {
     const commandName = argv[0];
     if (!commandName) {
       stderr.write('No command specified\n');

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -42,7 +42,7 @@ export type HttpNodeApp = ReadyResult &
 
 export type CommandNodeApp = ReadyResult &
   NodeAppBase & {
-    readonly execCommand: (argv: string[]) => Promise<ExecResult>;
+    readonly execCommand: (argv: readonly string[]) => Promise<ExecResult>;
     readonly shutdown: () => Promise<void>;
   };
 
@@ -109,8 +109,8 @@ const createExecForCommands = (
   getCommands: () => ReadonlyMap<string, CommandClass>,
   get: <T extends object>(cls: new (...args: never[]) => T) => T,
   stderr: Stderr,
-): ((argv: string[]) => Promise<ExecResult>) => {
-  return async (argv: string[]): Promise<ExecResult> => {
+): ((argv: readonly string[]) => Promise<ExecResult>) => {
+  return async (argv: readonly string[]): Promise<ExecResult> => {
     const commandName = argv[0];
     if (!commandName) {
       stderr.write('No command specified\n');


### PR DESCRIPTION
## Summary

- Change `execCommand` parameter type from `string[]` to `readonly string[]`
- Applies to both `@zeltjs/adapter-node` and `@zeltjs/adapter-bun`

This allows `nodeApp.args` (which returns `readonly string[]`) to be passed directly to `execCommand()` without spreading:

```typescript
// Before (workaround required)
const result = await nodeApp.execCommand([...nodeApp.args]);

// After (direct usage)
const result = await nodeApp.execCommand(nodeApp.args);
```

## Test plan

- [x] Type check passes for both packages
- [x] Existing tests pass (21 tests in adapter-node)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated command execution APIs in Bun and Node adapters to enforce immutable argument lists. The `execCommand` function now accepts arguments as a read-only array instead of a mutable array.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->