### PR TITLE
docs(website): enable twoslash type-checking for all code blocks

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -68,7 +68,9 @@ const shikiBaseConfig = {
 
 const shikiWithTwoslash = {
   ...shikiBaseConfig,
-  transformers: [transformerTwoslash({ twoslasher, renderer: rendererRich() })],
+  transformers: [
+    transformerTwoslash({ twoslasher, renderer: rendererRich(), explicitTrigger: false }),
+  ],
 };
 
 const shikiOnly = {


### PR DESCRIPTION
## Summary

- Set `explicitTrigger: false` in twoslash config so all TypeScript code blocks are type-checked at build time
- Catches outdated code examples that would otherwise slip through (e.g., deprecated API usage)

## Test plan

- [x] `pnpm run build` passes with all 21 projects
- [x] Website builds successfully with en/ja locales

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code highlighting configuration in documentation to require explicit markers for advanced code annotations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->