### PR TITLE
docs: add testing guide for command app recreation pattern

### DIFF
--- a/website/docs/testing/unit.md
+++ b/website/docs/testing/unit.md
@@ -153,3 +153,112 @@ describe('UserService', () => {
 2. **Shutdown**: Call `shutdownAll()` in your test runner's global teardown (handled automatically by adapter imports)
 
 This ensures resources are properly cleaned up even if tests fail.
+
+## Testing Commands
+
+When testing CLI commands, you need to create a fresh app instance for each test. App instances cannot be reused after `ready()` is called.
+
+### The Problem
+
+Reusing a global app instance causes errors:
+
+```typescript
+import { describe, it } from 'vitest';
+import { createApp, Command, cliSchema } from '@zeltjs/core';
+import { onNode } from '@zeltjs/adapter-node';
+
+@Command({ name: 'greet' })
+class GreetCommand {
+  static schema = cliSchema({});
+  run() { console.log('Hello!'); }
+}
+
+const app = createApp({ commands: [GreetCommand] });
+// ---cut---
+describe('GreetCommand', () => {
+  it('test 1', async () => {
+    const nodeApp = await onNode(app);
+    await nodeApp.execCommand(['greet']);
+    // works
+  });
+
+  it('test 2', async () => {
+    const nodeApp = await onNode(app);
+    // ❌ ZeltLifecycleStateError: Cannot addFallbackConfig() after ready()
+  });
+});
+```
+
+Once `onNode()` is called, the app transitions to `ready` state. Calling `onNode()` again on the same instance fails because lifecycle hooks cannot be re-registered.
+
+### The Solution
+
+Create a new app instance for each test:
+
+```typescript
+import { describe, it, afterEach } from 'vitest';
+import { createApp, Command, cliSchema } from '@zeltjs/core';
+import { onNode } from '@zeltjs/adapter-node';
+
+@Command({ name: 'greet' })
+class GreetCommand {
+  static schema = cliSchema({});
+  run() { console.log('Hello!'); }
+}
+// ---cut---
+describe('GreetCommand', () => {
+  let nodeApp: Awaited<ReturnType<typeof onNode>> | undefined;
+
+  afterEach(async () => {
+    await nodeApp?.shutdown();
+  });
+
+  it('test 1', async () => {
+    const app = createApp({ commands: [GreetCommand] });
+    nodeApp = await onNode(app);
+    await nodeApp.execCommand(['greet']);
+    // works
+  });
+
+  it('test 2', async () => {
+    const app = createApp({ commands: [GreetCommand] });
+    nodeApp = await onNode(app);
+    await nodeApp.execCommand(['greet']);
+    // works — fresh app instance
+  });
+});
+```
+
+### Using a Factory Function
+
+For cleaner tests, extract app creation into a factory:
+
+```typescript
+import { describe, it, afterEach } from 'vitest';
+import { createApp, Command, cliSchema } from '@zeltjs/core';
+import { onNode } from '@zeltjs/adapter-node';
+
+@Command({ name: 'greet' })
+class GreetCommand {
+  static schema = cliSchema({});
+  run() { console.log('Hello!'); }
+}
+// ---cut---
+function createTestApp() {
+  return createApp({ commands: [GreetCommand] });
+}
+
+describe('GreetCommand', () => {
+  let nodeApp: Awaited<ReturnType<typeof onNode>> | undefined;
+
+  afterEach(async () => {
+    await nodeApp?.shutdown();
+  });
+
+  it('executes successfully', async () => {
+    nodeApp = await onNode(createTestApp());
+    const result = await nodeApp.execCommand(['greet']);
+    // assert result
+  });
+});
+```


### PR DESCRIPTION
## Summary

- Add "Testing Commands" section to unit testing documentation
- Explain why app instances cannot be reused after `ready()` is called
- Provide patterns for creating fresh app instances per test with proper cleanup

## Related

Closes #9f660c27 (bit issue)

## Test plan

- [x] Website build passes
- [x] All tests pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive testing guidelines for CLI command tests, explaining the requirement to create fresh app instances per test to avoid lifecycle-state errors.
  * Included updated examples demonstrating both incorrect and correct testing patterns, plus a factory function approach for simplifying per-test app creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->