### PR TITLE
chore(gwq): add background build on worktree setup

### DIFF
--- a/.gwq.toml
+++ b/.gwq.toml
@@ -1,4 +1,7 @@
 [[repository_settings]]
 repository = '.'
 copy_files = ['lefthook-local.yml', '.codepolicy/cache/*']
-setup_commands = ['pnpm i']
+setup_commands = [
+  'pnpm i',
+  './scripts/gwq-bg-build.sh $PWD',
+]

--- a/scripts/gwq-bg-build.sh
+++ b/scripts/gwq-bg-build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+cd "$1"
+pnpm build > "/tmp/zelt-build-$(basename "$1").log" 2>&1 &


### PR DESCRIPTION
## Summary
- Add `scripts/gwq-bg-build.sh` to run `pnpm build` in background
- Update `.gwq.toml` to call the script after `pnpm install`
- Reduces worktree creation time from ~2min to ~7s by not waiting for build

## Test plan
- [x] Verified worktree creation completes in ~7 seconds
- [x] Verified background build runs and completes successfully
- [x] Verified dist directories are created after build finishes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Setup now runs dependency installation followed by an automatic background build during initialization.
  * A background build helper was added to run the project build and capture output to a temporary log, improving startup automation and making build progress/errors easier to inspect.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->