### PR TITLE
chore: integrate throw-trace for static @throws analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "codepolicy": "time codepolicy --filter=all 2>&1 | tee codepolicy.all.log",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "precommit": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm build && pnpm check:no-neverthrow-leak && pnpm test && npx precommit-verify save",
+    "precommit": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm build && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
     "prepare": "npx lefthook install",
-    "codepolicy:diff": "time codepolicy --filter=diff 2>&1 | tee codepolicy.diff.log"
+    "codepolicy:diff": "time codepolicy --filter=diff 2>&1 | tee codepolicy.diff.log",
+    "throw-trace": "throw-trace check --exclude '**/*.test.ts' packages"
   },
   "devDependencies": {
     "@9wick/eslint-plugin-strict-type-rules": "1.2.0",
@@ -45,6 +46,7 @@
     "tsdown": "0.21.10",
     "typescript": "6.0.2",
     "typescript-eslint": "8.59.1",
+    "throw-trace": "0.1.5",
     "unplugin-swc": "1.5.9",
     "vitest": "4.1.5"
   },

--- a/packages/auth-jwt/src/jwt.middleware.ts
+++ b/packages/auth-jwt/src/jwt.middleware.ts
@@ -16,6 +16,7 @@ export class JwtMiddleware {
   /**
    * @throws {UnauthorizedException} When token is missing (401)
    * @throws {UnauthorizedException} When token is invalid or expired (401)
+   * @throws {ZeltContextNotAvailableError}
    */
   async use(c: RequestContext, next: Next): Promise<Response | undefined> {
     const token = this.extractToken(c);

--- a/packages/core/src/app/app-runtime.ts
+++ b/packages/core/src/app/app-runtime.ts
@@ -45,6 +45,7 @@ export class AppRuntime {
     return this.readyPromise;
   }
 
+  /** @throws {ZeltLifecycleStateError} */
   private async doReady(options?: ReadyOptions): Promise<ReadyResult> {
     this.bindConfigs();
     if (options?.warmup) {

--- a/packages/core/src/app/modules/command-module.ts
+++ b/packages/core/src/app/modules/command-module.ts
@@ -27,6 +27,7 @@ export class CommandModule implements Lifecycle {
     this.commandMap.clear();
   }
 
+  /** @throws {ZeltDecoratorUsageError | ZeltAppConfigurationError} */
   private validateAndRegisterCommands(): void {
     for (const cls of this.commands) {
       const meta = getCommandMetadata(cls);

--- a/packages/core/src/app/modules/http-module.ts
+++ b/packages/core/src/app/modules/http-module.ts
@@ -66,6 +66,7 @@ const resolveErrorHandlers = (
 export class HttpModule implements Lifecycle {
   private hono: Hono | undefined;
 
+  /** @throws {ZeltNotImplementedError} */
   constructor(
     private readonly options: HttpOptions = inject(HTTP_OPTIONS),
     private readonly container: Container = inject(Container),
@@ -95,6 +96,7 @@ export class HttpModule implements Lifecycle {
     this.hono = undefined;
   }
 
+  /** @throws {ZeltNotImplementedError | ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
   private async initializeHono(): Promise<Hono> {
     try {
       const hono = new Hono({ strict: false });

--- a/packages/core/src/app/modules/scheduler-module.ts
+++ b/packages/core/src/app/modules/scheduler-module.ts
@@ -23,6 +23,7 @@ export class SchedulerModule implements Lifecycle {
     this.lifecycleManager.register(this);
   }
 
+  /** @throws {ZeltNotImplementedError} */
   async startup(): Promise<void> {
     if (this.schedulers.length === 0) return;
     const resolver = {

--- a/packages/core/src/errors/classes.ts
+++ b/packages/core/src/errors/classes.ts
@@ -23,3 +23,9 @@ export type ZeltNotImplementedError = InstanceType<typeof ZeltNotImplementedErro
 
 export const ZeltSchemaValidationError = createErrorClass('ZeltSchemaValidationError');
 export type ZeltSchemaValidationError = InstanceType<typeof ZeltSchemaValidationError>;
+
+export const ZeltPluginConfigurationError = createErrorClass('ZeltPluginConfigurationError');
+export type ZeltPluginConfigurationError = InstanceType<typeof ZeltPluginConfigurationError>;
+
+export const ZeltCommandArgumentError = createErrorClass('ZeltCommandArgumentError');
+export type ZeltCommandArgumentError = InstanceType<typeof ZeltCommandArgumentError>;

--- a/packages/core/src/errors/definitions.ts
+++ b/packages/core/src/errors/definitions.ts
@@ -50,6 +50,20 @@ export const coreErrorDefinitions = {
 
   ZeltSchemaValidationError: (ctx: { schemaType: string; reason: string }) =>
     `Invalid ${ctx.schemaType} schema: ${ctx.reason}`,
+
+  ZeltPluginConfigurationError: (
+    ctx:
+      | { pluginName: string; reason: 'missing_entry' }
+      | { pluginName: string; reason: 'app_not_found' | 'invalid_app'; details: string },
+  ) => {
+    if (ctx.reason === 'missing_entry') return `[${ctx.pluginName}] entry is required`;
+    if (ctx.reason === 'app_not_found')
+      return `[${ctx.pluginName}] Could not find app with getMetadata() in ${ctx.details}`;
+    return `[${ctx.pluginName}] Invalid app configuration: ${ctx.details}`;
+  },
+
+  ZeltCommandArgumentError: (ctx: { commandName: string; argument: string; reason: string }) =>
+    `[${ctx.commandName}] ${ctx.argument}: ${ctx.reason}`,
 } as const;
 
 export type CoreErrorContextMap = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,11 +40,13 @@ export type { CoreErrorContextMap } from './errors';
 export {
   defineHttpException,
   ZeltAppConfigurationError,
+  ZeltCommandArgumentError,
   ZeltContextNotAvailableError,
   ZeltDecoratorUsageError,
   ZeltLifecycleStateError,
   ZeltMiddlewareExecutionError,
   ZeltNotImplementedError,
+  ZeltPluginConfigurationError,
   ZeltRouteConfigurationError,
   ZeltSchemaValidationError,
 } from './errors';

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -5,6 +5,7 @@ export interface Disposable {
 }
 
 export interface Lifecycle extends Disposable {
+  /** @throws {ZeltNotImplementedError} */
   startup(): Promise<void>;
 }
 

--- a/packages/core/src/modules/cli/cli.config.ts
+++ b/packages/core/src/modules/cli/cli.config.ts
@@ -6,26 +6,32 @@ export type SignalHandler = () => void;
 
 @Config
 export class CliConfig {
+  /** @throws {ZeltNotImplementedError} */
   cwd(): string {
     throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'cwd' });
   }
 
+  /** @throws {ZeltNotImplementedError} */
   argv(): readonly string[] {
     throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'argv' });
   }
 
+  /** @throws {ZeltNotImplementedError} */
   exit(_code: number): never {
     throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'exit' });
   }
 
+  /** @throws {ZeltNotImplementedError} */
   setExitCode(_code: number): void {
     throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'setExitCode' });
   }
 
+  /** @throws {ZeltNotImplementedError} */
   onSignal(_signal: Signal, _handler: SignalHandler): void {
     throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'onSignal' });
   }
 
+  /** @throws {ZeltNotImplementedError} */
   offSignal(_signal: Signal, _handler: SignalHandler): void {
     throw new ZeltNotImplementedError({ className: 'CliConfig', methodName: 'offSignal' });
   }

--- a/packages/decorator-metadata/src/inspect/get-type-metadata.ts
+++ b/packages/decorator-metadata/src/inspect/get-type-metadata.ts
@@ -128,6 +128,7 @@ const extractPropertyInfo = (
   return { name: p.name, pos: p.pos, props: p.props, type, optional };
 };
 
+/** @throws {UnsupportedTypeScriptVersionError} */
 export const getTypeMetadata = <T extends object>(
   cls: new (...args: unknown[]) => T,
   options?: InspectOptions,

--- a/packages/decorator-metadata/src/inspect/program-cache.ts
+++ b/packages/decorator-metadata/src/inspect/program-cache.ts
@@ -44,6 +44,7 @@ const createProgramResult = (
   return okAsync({ program, checker, ts });
 };
 
+/** @throws {UnsupportedTypeScriptVersionError} */
 export const getOrCreateProgram = (
   tsconfigPath: string,
 ): ResultAsync<CachedProgram, ProgramCacheError> => {

--- a/packages/decorator-metadata/src/inspect/resolve-typescript.ts
+++ b/packages/decorator-metadata/src/inspect/resolve-typescript.ts
@@ -1,7 +1,22 @@
 type TypeScriptModule = typeof import('typescript');
 
+export class UnsupportedTypeScriptVersionError extends Error {
+  override readonly name = 'UnsupportedTypeScriptVersionError';
+  constructor(
+    public readonly context: {
+      currentVersion: string;
+      supportedVersions: string;
+    },
+  ) {
+    super(
+      `TypeScript ${context.currentVersion} is not supported. Supported versions: ${context.supportedVersions}`,
+    );
+  }
+}
+
 let cachedTs: TypeScriptModule | undefined;
 
+/** @throws {UnsupportedTypeScriptVersionError} */
 export const resolveTypeScript = async (): Promise<TypeScriptModule> => {
   if (cachedTs) return cachedTs;
 
@@ -9,11 +24,10 @@ export const resolveTypeScript = async (): Promise<TypeScriptModule> => {
   const major = parseInt(userTs.version.split('.')[0] ?? '0', 10);
 
   if (major >= 7) {
-    throw new Error(
-      `TypeScript ${userTs.version} is not yet supported. ` +
-        `TypeScript 7 requires Corsa API which is not available. ` +
-        `Please use TypeScript 5.x or 6.x.`,
-    );
+    throw new UnsupportedTypeScriptVersionError({
+      currentVersion: userTs.version,
+      supportedVersions: '5.x or 6.x',
+    });
   }
 
   cachedTs = userTs;

--- a/packages/hono-client/src/commands/generate.command.test.ts
+++ b/packages/hono-client/src/commands/generate.command.test.ts
@@ -94,7 +94,7 @@ describe('GenerateCommand', () => {
 
     const parsedArgs = { app: undefined, dist: tempDir, output: 'types.ts' };
     await expect(runInCommandContext({ parsedArgs }, () => command.run())).rejects.toThrow(
-      '--app option is required',
+      '[generate] --app: required',
     );
   });
 });

--- a/packages/hono-client/src/commands/generate.command.ts
+++ b/packages/hono-client/src/commands/generate.command.ts
@@ -2,7 +2,16 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { args, CliConfig, Command, cliSchema, inject, Logger } from '@zeltjs/core';
+import {
+  args,
+  CliConfig,
+  Command,
+  cliSchema,
+  inject,
+  Logger,
+  ZeltCommandArgumentError,
+  ZeltPluginConfigurationError,
+} from '@zeltjs/core';
 
 import type { HttpAppLike } from '../generator';
 import { GeneratorService } from '../generator';
@@ -29,11 +38,16 @@ export class GenerateCommand {
     private readonly logger = inject(Logger),
   ) {}
 
+  /** @throws {ZeltCommandArgumentError | ZeltPluginConfigurationError | ZeltContextNotAvailableError} */
   async run(parsedArgs = args(GenerateCommand)): Promise<void> {
     const { app: appPath, dist, output } = parsedArgs;
 
     if (!appPath) {
-      throw new Error('--app option is required');
+      throw new ZeltCommandArgumentError({
+        commandName: 'generate',
+        argument: '--app',
+        reason: 'required',
+      });
     }
 
     const absolutePath = resolve(this.cli.cwd(), appPath);
@@ -42,7 +56,11 @@ export class GenerateCommand {
     const httpApp = mod.app ?? mod.default;
 
     if (!httpApp || typeof httpApp.getMetadata !== 'function') {
-      throw new Error(`Could not find app with getMetadata() in ${appPath}`);
+      throw new ZeltPluginConfigurationError({
+        pluginName: 'hono-client',
+        reason: 'app_not_found',
+        details: appPath,
+      });
     }
 
     const content = this.generator.generateFromApp(httpApp, { distDir: dist });

--- a/packages/hono-client/src/generator/emit.lib.test.ts
+++ b/packages/hono-client/src/generator/emit.lib.test.ts
@@ -55,7 +55,7 @@ describe('emitAppType', () => {
       ],
     };
     expect(() => emitAppType(noSourceMeta, '/app/generated')).toThrow(
-      'Controller "AnonymousController" has no sourceFile',
+      'AnonymousController is missing @Controller decorator',
     );
   });
 });

--- a/packages/hono-client/src/generator/emit.lib.ts
+++ b/packages/hono-client/src/generator/emit.lib.ts
@@ -1,5 +1,7 @@
 import { relative } from 'node:path';
 
+import { ZeltDecoratorUsageError } from '@zeltjs/core';
+
 import type { ControllerRouteInfo, HttpMetadata, RouteInfo } from './types';
 
 const stripTsExtension = (p: string): string => p.replace(/\.tsx?$/, '');
@@ -9,11 +11,14 @@ const toRelativeImport = (distDir: string, modulePath: string): string => {
   return rel.startsWith('.') ? rel : `./${rel}`;
 };
 
+/** @throws {ZeltDecoratorUsageError} */
 const renderImport = (distDir: string, c: ControllerRouteInfo): string => {
   if (!c.sourceFile) {
-    throw new Error(
-      `Controller "${c.name}" has no sourceFile. Ensure @Controller decorator is applied.`,
-    );
+    throw new ZeltDecoratorUsageError({
+      decoratorName: 'Controller',
+      reason: 'missing_decorator',
+      targetName: c.name,
+    });
   }
   return `import type { ${c.name} } from '${toRelativeImport(distDir, c.sourceFile)}';`;
 };
@@ -21,6 +26,7 @@ const renderImport = (distDir: string, c: ControllerRouteInfo): string => {
 const renderRouteLine = (c: ControllerRouteInfo, r: RouteInfo): string =>
   `  Route<'${r.method}', '${r.fullPath}', typeof ${c.name}.prototype.${r.methodName}>,`;
 
+/** @throws {ZeltDecoratorUsageError} */
 export const emitAppType = (metadata: HttpMetadata, distDir: string): string => {
   const imports = metadata.controllers.map((c) => renderImport(distDir, c)).join('\n');
 

--- a/packages/hono-client/src/generator/generator.service.ts
+++ b/packages/hono-client/src/generator/generator.service.ts
@@ -5,10 +5,12 @@ import type { GenerateOptions, HttpAppLike, HttpMetadata } from './types';
 
 @Injectable()
 export class GeneratorService {
+  /** @throws {ZeltDecoratorUsageError} */
   generate(metadata: HttpMetadata, options: GenerateOptions): string {
     return emitAppType(metadata, options.distDir);
   }
 
+  /** @throws {ZeltDecoratorUsageError} */
   generateFromApp(app: HttpAppLike, options: GenerateOptions): string {
     return emitAppType(app.getMetadata(), options.distDir);
   }

--- a/packages/hono-client/src/legacy.ts
+++ b/packages/hono-client/src/legacy.ts
@@ -8,6 +8,7 @@ export const generateHonoAppType = emitAppType;
 
 /**
  * @deprecated Use GeneratorService instead
+ * @throws {ZeltDecoratorUsageError}
  */
 export const generateHonoAppTypeFromApp = (app: HttpAppLike, options: GenerateOptions): string =>
   emitAppType(app.getMetadata(), options.distDir);

--- a/packages/hono-client/src/plugin.ts
+++ b/packages/hono-client/src/plugin.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import type { ZeltPlugin } from '@zeltjs/cli';
+import { ZeltPluginConfigurationError } from '@zeltjs/core';
 
 import type { HttpAppLike } from './generator';
 import { emitAppType } from './generator';
@@ -18,23 +19,32 @@ export type HonoClientPluginOptions = {
   readonly output?: string;
 };
 
+/** @throws {ZeltPluginConfigurationError} */
 const loadApp = async (cwd: string, entry: string): Promise<HttpAppLike> => {
   const absPath = resolve(cwd, entry);
   const fileUrl = pathToFileURL(absPath).href;
   const mod: AppModule = await import(fileUrl);
   const app = mod.app ?? mod.default;
   if (app === undefined || typeof app.getMetadata !== 'function') {
-    throw new Error(`[hono-client] Could not find app with getMetadata() in ${entry}`);
+    throw new ZeltPluginConfigurationError({
+      pluginName: 'hono-client',
+      reason: 'app_not_found',
+      details: entry,
+    });
   }
   return app;
 };
 
+/** @throws {ZeltPluginConfigurationError | ZeltDecoratorUsageError} */
 export const honoClientPlugin = (options: HonoClientPluginOptions = {}): ZeltPlugin => ({
   name: 'hono-client',
   async preBuild(ctx) {
     const entry = options.entry ?? ctx.config.entry;
     if (entry === undefined) {
-      throw new Error('[hono-client] entry is required. Set it in plugin options or config.entry');
+      throw new ZeltPluginConfigurationError({
+        pluginName: 'hono-client',
+        reason: 'missing_entry',
+      });
     }
 
     const app = await loadApp(ctx.cwd, entry);

--- a/packages/kv/src/adaptor-memory/memory-kv.adaptor.ts
+++ b/packages/kv/src/adaptor-memory/memory-kv.adaptor.ts
@@ -77,6 +77,7 @@ class MemoryKVStore implements AtomicKVStore {
     return entry ? deserialize<T>(entry.raw) : undefined;
   }
 
+  /** @throws {ZeltKVInvalidTtlError} */
   async set<T extends Defined>(key: string, value: T, opts?: SetOptions): Promise<void> {
     validateTtl(opts?.ttlSec);
     const raw = serialize(value);
@@ -91,6 +92,7 @@ class MemoryKVStore implements AtomicKVStore {
     return this.current(key) !== undefined;
   }
 
+  /** @throws {ZeltKVInvalidTtlError} */
   async expire(key: string, ttlSec: number): Promise<boolean> {
     validateTtl(ttlSec);
     const entry = this.current(key);
@@ -103,6 +105,7 @@ class MemoryKVStore implements AtomicKVStore {
     return new MemoryKVStore(this.data, joinPrefix(this.prefix, sub));
   }
 
+  /** @throws {ZeltKVInvalidTtlError} */
   async incr(key: string, by = 1, opts?: { ttlSec?: number }): Promise<number> {
     validateTtl(opts?.ttlSec);
     const k = this.k(key);
@@ -117,6 +120,7 @@ class MemoryKVStore implements AtomicKVStore {
     return next;
   }
 
+  /** @throws {ZeltKVInvalidTtlError} */
   async setnx<T extends Defined>(key: string, value: T, opts?: SetOptions): Promise<boolean> {
     validateTtl(opts?.ttlSec);
     if (this.current(key)) return false;

--- a/packages/kv/src/adaptor-redis/redis-kv-store.ts
+++ b/packages/kv/src/adaptor-redis/redis-kv-store.ts
@@ -36,6 +36,7 @@ export class RedisKVStore implements AtomicKVStore {
     return raw === null ? undefined : deserialize<T>(raw);
   }
 
+  /** @throws {ZeltKVInvalidTtlError} */
   async set<T extends Defined>(key: string, value: T, opts?: SetOptions): Promise<void> {
     validateTtl(opts?.ttlSec);
     const json = serialize(value);
@@ -55,6 +56,7 @@ export class RedisKVStore implements AtomicKVStore {
     return n === 1;
   }
 
+  /** @throws {ZeltKVInvalidTtlError} */
   async expire(key: string, ttlSec: number): Promise<boolean> {
     validateTtl(ttlSec);
     const n = await this.client.expire(this.k(key), ttlSec);
@@ -65,11 +67,13 @@ export class RedisKVStore implements AtomicKVStore {
     return new RedisKVStore(this.client, joinPrefix(this.prefix, sub));
   }
 
+  /** @throws {ZeltKVInvalidTtlError} */
   async incr(key: string, by = 1, opts?: { ttlSec?: number }): Promise<number> {
     validateTtl(opts?.ttlSec);
     return incrWithTtl(this.client, this.k(key), by, opts?.ttlSec);
   }
 
+  /** @throws {ZeltKVInvalidTtlError} */
   async setnx<T extends Defined>(key: string, value: T, opts?: SetOptions): Promise<boolean> {
     validateTtl(opts?.ttlSec);
     const json = serialize(value);

--- a/packages/kv/src/types.ts
+++ b/packages/kv/src/types.ts
@@ -18,10 +18,16 @@ export interface AtomicKVAdaptor extends KVAdaptor {
 /** namespaced view。実際の data ops はここ */
 export interface KVStore {
   get<T>(key: string): Promise<T | undefined>;
+  /**
+   * @throws {ZeltKVInvalidTtlError}
+   */
   set<T extends Defined>(key: string, value: T, opts?: SetOptions): Promise<void>;
   del(key: string): Promise<void>;
   has(key: string): Promise<boolean>;
-  /** TTL 延長 (session touch / lock extend 用)。key 不在時は false。 */
+  /**
+   * TTL 延長 (session touch / lock extend 用)。key 不在時は false。
+   * @throws {ZeltKVInvalidTtlError}
+   */
   expire(key: string, ttlSec: number): Promise<boolean>;
   /** 子 namespace。チェーン可能。 */
   namespace<const S extends string>(prefix: NonEmptyString<S>): KVStore;
@@ -29,9 +35,15 @@ export interface KVStore {
 
 /** atomic 操作対応 view */
 export interface AtomicKVStore extends KVStore {
-  /** atomic incr。最初の incr 時のみ TTL をセット。 */
+  /**
+   * atomic incr。最初の incr 時のみ TTL をセット。
+   * @throws {ZeltKVInvalidTtlError}
+   */
   incr(key: string, by?: number, opts?: { ttlSec?: number }): Promise<number>;
-  /** atomic set if not exists。set されたら true、既存なら false。 */
+  /**
+   * atomic set if not exists。set されたら true、既存なら false。
+   * @throws {ZeltKVInvalidTtlError}
+   */
   setnx<T extends Defined>(key: string, value: T, opts?: SetOptions): Promise<boolean>;
   namespace<const S extends string>(prefix: NonEmptyString<S>): AtomicKVStore;
 }

--- a/packages/openapi/src/plugin.ts
+++ b/packages/openapi/src/plugin.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import type { ZeltPlugin } from '@zeltjs/cli';
+import { ZeltPluginConfigurationError } from '@zeltjs/core';
 
 import type { GenerateOpenApiOptions, HttpMetadata } from './generate-openapi';
 import { generateOpenApi } from './generate-openapi';
@@ -23,13 +24,18 @@ export type OpenApiPluginOptions = {
   readonly version?: string;
 };
 
+/** @throws {ZeltPluginConfigurationError} */
 const loadApp = async (cwd: string, entry: string): Promise<HttpAppLike> => {
   const absPath = resolve(cwd, entry);
   const fileUrl = pathToFileURL(absPath).href;
   const mod: AppModule = await import(fileUrl);
   const app = mod.app ?? mod.default;
   if (app === undefined || typeof app.getMetadata !== 'function') {
-    throw new Error(`[openapi] Could not find app with getMetadata() in ${entry}`);
+    throw new ZeltPluginConfigurationError({
+      pluginName: 'openapi',
+      reason: 'app_not_found',
+      details: entry,
+    });
   }
   return app;
 };
@@ -41,12 +47,13 @@ const buildGenerateOptions = (options: OpenApiPluginOptions): GenerateOpenApiOpt
   ...(options.version !== undefined && { version: options.version }),
 });
 
+/** @throws {ZeltPluginConfigurationError} */
 export const openapiPlugin = (options: OpenApiPluginOptions = {}): ZeltPlugin => ({
   name: 'openapi',
   async preBuild(ctx) {
     const entry = options.entry ?? ctx.config.entry;
     if (entry === undefined) {
-      throw new Error('[openapi] entry is required. Set it in plugin options or config.entry');
+      throw new ZeltPluginConfigurationError({ pluginName: 'openapi', reason: 'missing_entry' });
     }
     const app = await loadApp(ctx.cwd, entry);
     await generateOpenApi(app, buildGenerateOptions(options));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       precommit-verify:
         specifier: 0.1.8
         version: 0.1.8
+      throw-trace:
+        specifier: 0.1.5
+        version: 0.1.5
       tsdown:
         specifier: 0.21.10
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2)
@@ -10418,6 +10421,13 @@ packages:
     peerDependencies:
       tslib: ^2
 
+  throw-trace@0.1.5:
+    resolution: {integrity: sha512-teRFlHBIaeZXsYEbCTIzALFHMLGSknfeqfUMLEtALEl32eY+IGa0AgeRBk3qUuhnKe/rGBaioj54qqpjeOyXVA==}
+    engines: {node: '>=18'}
+    cpu: [x64, arm64]
+    os: [linux, darwin, win32]
+    hasBin: true
+
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
 
@@ -16027,7 +16037,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -22118,6 +22128,8 @@ snapshots:
   thingies@2.6.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
+
+  throw-trace@0.1.5: {}
 
   thunky@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- Add throw-trace to precommit workflow for static analysis of @throws declarations
- Add @throws annotations across all packages to document exception behavior
- Add `ZeltPluginConfigurationError` and `ZeltCommandArgumentError` error types
- Replace generic `Error` with typed Zelt errors for better error handling
- Fix LSP violations by declaring throws in parent interfaces

## Test plan

- [x] `pnpm precommit` passes
- [x] `pnpm throw-trace` passes with no issues
- [x] All tests pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a static check to the precommit pipeline.

* **Bug Fixes**
  * Replaced many generic errors with specific, typed error classes for clearer failure messages.
  * Introduced and re-exported new error types for more structured error handling.

* **Documentation**
  * Expanded JSDoc `@throws` annotations across modules to clarify which operations may throw.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->