### PR TITLE
fix(core): move command execution logic to core with detailed error reporting

### DIFF
--- a/packages/adapter-bun/src/on-bun.ts
+++ b/packages/adapter-bun/src/on-bun.ts
@@ -1,4 +1,4 @@
-import type { CommandApp, CommandClass, HttpApp, ReadyOptions, ReadyResult } from '@zeltjs/core';
+import type { CommandApp, ExecResult, HttpApp, ReadyOptions, ReadyResult } from '@zeltjs/core';
 
 import { BunEnvConfig } from './bun-env.config';
 
@@ -16,9 +16,7 @@ export type BunAppOptions = {
   readonly warmup?: boolean;
 };
 
-export type ExecResult = {
-  readonly exitCode: 0 | 1;
-};
+export type { ExecResult } from '@zeltjs/core';
 
 type BunAppBase = {
   readonly args: readonly string[];
@@ -41,9 +39,6 @@ export type FullBunApp = HttpBunApp & CommandBunApp;
 export type BunApp = HttpBunApp | CommandBunApp | FullBunApp;
 
 type Stderr = { write: (s: string) => void };
-
-const successResult: ExecResult = { exitCode: 0 };
-const failureResult: ExecResult = { exitCode: 1 };
 
 const createServeForHttp = (
   appFetch: (request: Request) => Promise<Response>,
@@ -71,55 +66,13 @@ const createServeForHttp = (
   };
 };
 
-/** @throws {ZeltLifecycleStateError} */
-const runCommand = (
-  CommandClass: CommandClass,
-  get: <T extends object>(cls: new (...args: never[]) => T) => T,
-): Promise<ExecResult> => {
-  const instance = get(CommandClass);
-  return Promise.resolve()
-    .then(() => instance.run())
-    .then(() => successResult)
-    .catch(() => failureResult);
-};
-
-/** @throws {ZeltLifecycleStateError} */
-const createExecForCommands = (
-  hasCommand: (name: string) => boolean,
-  getCommands: () => ReadonlyMap<string, CommandClass>,
-  get: <T extends object>(cls: new (...args: never[]) => T) => T,
-  stderr: Stderr,
-): ((argv: readonly string[]) => Promise<ExecResult>) => {
-  return async (argv: readonly string[]): Promise<ExecResult> => {
-    const commandName = argv[0];
-    if (!commandName) {
-      stderr.write('No command specified\n');
-      return failureResult;
-    }
-
-    if (!hasCommand(commandName)) {
-      stderr.write(`Command not found: ${commandName}\n`);
-      return failureResult;
-    }
-
-    const commandMap = getCommands();
-    const CommandClass = commandMap.get(commandName);
-    if (!CommandClass) {
-      return failureResult;
-    }
-
-    return runCommand(CommandClass, get);
-  };
-};
-
 const getStderr = (): Stderr => globalThis.process.stderr;
 
 const getArgs = (): readonly string[] => Bun.argv.slice(2);
 
 type AppCapabilities = {
   fetch?: (request: Request) => Promise<Response>;
-  hasCommand?: (name: string) => boolean;
-  getCommands?: () => ReadonlyMap<string, CommandClass>;
+  execCommand?: (argv: readonly string[]) => Promise<ExecResult>;
 };
 
 const extractCapabilities = (app: HttpApp | CommandApp | (HttpApp & CommandApp)): AppCapabilities =>
@@ -140,7 +93,6 @@ const buildHttpBunApp = (
   return { ...resolver, args, serve: createServeForHttp(caps.fetch, shutdown), shutdown };
 };
 
-/** @throws {ZeltLifecycleStateError} */
 const buildCommandBunApp = (
   caps: AppCapabilities,
   resolver: ReadyResult,
@@ -148,17 +100,20 @@ const buildCommandBunApp = (
   stderr: Stderr,
   args: readonly string[],
 ): CommandBunApp | undefined => {
-  if (typeof caps.hasCommand !== 'function' || typeof caps.getCommands !== 'function')
-    return undefined;
-  return {
-    ...resolver,
-    args,
-    execCommand: createExecForCommands(caps.hasCommand, caps.getCommands, resolver.get, stderr),
-    shutdown,
+  if (typeof caps.execCommand !== 'function') return undefined;
+
+  const coreExecCommand = caps.execCommand;
+  const execCommand = async (argv: readonly string[]): Promise<ExecResult> => {
+    const result = await coreExecCommand(argv);
+    if (result.exitCode === 1) {
+      stderr.write(`${result.reason.message}\n`);
+    }
+    return result;
   };
+
+  return { ...resolver, args, execCommand, shutdown };
 };
 
-/** @throws {ZeltLifecycleStateError} */
 const buildBunApps = (
   caps: AppCapabilities,
   resolver: ReadyResult,

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -1,4 +1,5 @@
 import {
+  args,
   CliConfig,
   Command,
   Controller,
@@ -245,6 +246,58 @@ describe('onNode with commands', () => {
     const result = await nodeApp.execCommand(['failing']);
 
     expect(result.exitCode).toBe(1);
+  });
+
+  it('args() returns parsed arguments within command', async () => {
+    let capturedName: string | undefined;
+
+    class GreetCommand {
+      static schema = cliSchema({
+        args: [{ name: 'name', type: 'string' }],
+      });
+
+      run() {
+        const parsed = args(GreetCommand);
+        capturedName = parsed.name;
+      }
+    }
+    Command({ name: 'greet' })(GreetCommand);
+
+    const app = createApp({ commands: [GreetCommand] });
+    nodeApp = await onNode(app);
+    const result = await nodeApp.execCommand(['greet', 'Alice']);
+
+    expect(result.exitCode).toBe(0);
+    expect(capturedName).toBe('Alice');
+  });
+
+  it('args() returns parsed options with defaults', async () => {
+    let capturedVerbose: boolean | undefined;
+    let capturedPort: number | undefined;
+
+    class ServeCommand {
+      static schema = cliSchema({
+        options: [
+          { name: 'verbose', type: 'boolean', alias: 'v' },
+          { name: 'port', type: 'number', default: 3000 },
+        ],
+      });
+
+      run() {
+        const parsed = args(ServeCommand);
+        capturedVerbose = parsed.verbose;
+        capturedPort = parsed.port;
+      }
+    }
+    Command({ name: 'serve' })(ServeCommand);
+
+    const app = createApp({ commands: [ServeCommand] });
+    nodeApp = await onNode(app);
+    const result = await nodeApp.execCommand(['serve', '-v']);
+
+    expect(result.exitCode).toBe(0);
+    expect(capturedVerbose).toBe(true);
+    expect(capturedPort).toBe(3000);
   });
 });
 

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -2,7 +2,7 @@ import type { ServerType } from '@hono/node-server';
 import { serve } from '@hono/node-server';
 import type {
   CommandApp,
-  CommandClass,
+  ExecResult,
   HttpApp,
   ReadyOptions,
   ReadyResult,
@@ -26,9 +26,7 @@ export type NodeAppOptions = {
   readonly warmup?: boolean;
 };
 
-export type ExecResult = {
-  readonly exitCode: 0 | 1;
-};
+export type { ExecResult } from '@zeltjs/core';
 
 type NodeAppBase = {
   readonly args: readonly string[];
@@ -56,9 +54,6 @@ export type FullNodeApp = HttpNodeApp & CommandNodeApp;
 export type NodeApp = HttpNodeApp | CommandNodeApp | FullNodeApp;
 
 type Stderr = { write: (s: string) => void };
-
-const successResult: ExecResult = { exitCode: 0 };
-const failureResult: ExecResult = { exitCode: 1 };
 
 const createListenForHttp = (
   appFetch: (request: Request) => Promise<Response>,
@@ -91,55 +86,13 @@ const createListenForHttp = (
   };
 };
 
-/** @throws {ZeltLifecycleStateError} */
-const runCommand = (
-  CommandClass: CommandClass,
-  get: <T extends object>(cls: new (...args: never[]) => T) => T,
-): Promise<ExecResult> => {
-  const instance = get(CommandClass);
-  return Promise.resolve()
-    .then(() => instance.run())
-    .then(() => successResult)
-    .catch(() => failureResult);
-};
-
-/** @throws {ZeltLifecycleStateError} */
-const createExecForCommands = (
-  hasCommand: (name: string) => boolean,
-  getCommands: () => ReadonlyMap<string, CommandClass>,
-  get: <T extends object>(cls: new (...args: never[]) => T) => T,
-  stderr: Stderr,
-): ((argv: readonly string[]) => Promise<ExecResult>) => {
-  return async (argv: readonly string[]): Promise<ExecResult> => {
-    const commandName = argv[0];
-    if (!commandName) {
-      stderr.write('No command specified\n');
-      return failureResult;
-    }
-
-    if (!hasCommand(commandName)) {
-      stderr.write(`Command not found: ${commandName}\n`);
-      return failureResult;
-    }
-
-    const commandMap = getCommands();
-    const CommandClass = commandMap.get(commandName);
-    if (!CommandClass) {
-      return failureResult;
-    }
-
-    return runCommand(CommandClass, get);
-  };
-};
-
 const getStderr = (): Stderr => globalThis.process.stderr;
 
 const getArgs = (): readonly string[] => globalThis.process.argv.slice(2);
 
 type AppCapabilities = {
   fetch?: (request: Request) => Promise<Response>;
-  hasCommand?: (name: string) => boolean;
-  getCommands?: () => ReadonlyMap<string, CommandClass>;
+  execCommand?: (argv: readonly string[]) => Promise<ExecResult>;
   startScheduler?: () => Promise<void>;
   stopScheduler?: () => Promise<void>;
 };
@@ -164,7 +117,6 @@ const buildHttpNodeApp = (
   return { ...resolver, args, listen: createListenForHttp(caps.fetch, shutdown), shutdown };
 };
 
-/** @throws {ZeltLifecycleStateError} */
 const buildCommandNodeApp = (
   caps: AppCapabilities,
   resolver: ReadyResult,
@@ -172,14 +124,18 @@ const buildCommandNodeApp = (
   stderr: Stderr,
   args: readonly string[],
 ): CommandNodeApp | undefined => {
-  if (typeof caps.hasCommand !== 'function' || typeof caps.getCommands !== 'function')
-    return undefined;
-  return {
-    ...resolver,
-    args,
-    execCommand: createExecForCommands(caps.hasCommand, caps.getCommands, resolver.get, stderr),
-    shutdown,
+  if (typeof caps.execCommand !== 'function') return undefined;
+
+  const coreExecCommand = caps.execCommand;
+  const execCommand = async (argv: readonly string[]): Promise<ExecResult> => {
+    const result = await coreExecCommand(argv);
+    if (result.exitCode === 1) {
+      stderr.write(`${result.reason.message}\n`);
+    }
+    return result;
   };
+
+  return { ...resolver, args, execCommand, shutdown };
 };
 
 const buildSchedulerPart = (caps: AppCapabilities): SchedulerNodeAppPart | undefined => {
@@ -191,7 +147,6 @@ const buildSchedulerPart = (caps: AppCapabilities): SchedulerNodeAppPart | undef
   };
 };
 
-/** @throws {ZeltLifecycleStateError} */
 const buildNodeApps = (
   caps: AppCapabilities,
   resolver: ReadyResult,

--- a/packages/core/src/app/create-app.ts
+++ b/packages/core/src/app/create-app.ts
@@ -1,5 +1,6 @@
 import { Container } from '@needle-di/core';
 
+import type { ExecResult } from '../command/exec-result';
 import type { CommandClass } from '../command/types';
 import type { ConfigClass } from '../config';
 import { ZeltAppConfigurationError } from '../errors';
@@ -39,6 +40,7 @@ type HttpCapabilities = {
 type CommandCapabilities = {
   readonly hasCommand: (name: string) => boolean;
   readonly getCommands: () => ReadonlyMap<string, CommandClass>;
+  readonly execCommand: (argv: readonly string[]) => Promise<ExecResult>;
 };
 
 type SchedulerCapabilities = {
@@ -130,6 +132,7 @@ const buildCommandMethods = (
     ? {
         hasCommand: (name: string) => commandModule.hasCommand(name),
         getCommands: () => commandModule.getCommands(),
+        execCommand: (argv: readonly string[]) => commandModule.exec(argv),
       }
     : {};
 

--- a/packages/core/src/app/modules/command-module.ts
+++ b/packages/core/src/app/modules/command-module.ts
@@ -1,9 +1,18 @@
-import { injectable } from '@needle-di/core';
+import { Container, injectable } from '@needle-di/core';
 
+import { runInCommandContext } from '../../command/command-context';
+import type { ExecResult } from '../../command/exec-result';
 import { getCommandMetadata } from '../../command/metadata';
+import { parseArgv } from '../../command/parse-argv';
+import type { SchemaDefinition } from '../../command/schema';
 import type { CommandClass } from '../../command/types';
 import { inject } from '../../di/inject';
-import { ZeltAppConfigurationError, ZeltDecoratorUsageError } from '../../errors';
+import { resolve } from '../../di/resolve';
+import {
+  ZeltAppConfigurationError,
+  ZeltCommandExecutionError,
+  ZeltDecoratorUsageError,
+} from '../../errors';
 import type { Lifecycle } from '../../lifecycle';
 import { LifecycleManager } from '../../lifecycle';
 import { COMMAND_OPTIONS } from '../tokens';
@@ -16,6 +25,7 @@ export class CommandModule implements Lifecycle {
   constructor(
     private readonly commands: readonly CommandClass[] = inject(COMMAND_OPTIONS),
     private readonly lifecycleManager: LifecycleManager = inject(LifecycleManager),
+    private readonly container: Container = inject(Container),
   ) {
     this.lifecycleManager.register(this);
     this.validateAndRegisterCommands();
@@ -50,5 +60,62 @@ export class CommandModule implements Lifecycle {
 
   getCommands(): ReadonlyMap<string, CommandClass> {
     return this.commandMap;
+  }
+
+  private async runCommand(
+    CommandClass: CommandClass,
+    commandName: string,
+    argv: readonly string[],
+  ): Promise<ExecResult> {
+    // Runtime safety: schema may be undefined despite type definition
+    const commandWithOptionalSchema: { schema?: SchemaDefinition } = CommandClass;
+    const schema = commandWithOptionalSchema.schema ?? { args: [], options: [] };
+    const parseResult = parseArgv(argv, schema);
+    if (!parseResult.ok) {
+      return {
+        exitCode: 1 as const,
+        reason: new ZeltCommandExecutionError({
+          reason: 'argv_parse_error',
+          commandName,
+          details: parseResult.error,
+        }),
+      };
+    }
+
+    const instance = resolve(this.container, CommandClass);
+
+    try {
+      const result = runInCommandContext({ parsedArgs: parseResult.parsed }, () => instance.run());
+      await Promise.resolve(result);
+      return { exitCode: 0 as const };
+    } catch (e: unknown) {
+      const details = e instanceof Error ? e.message : String(e);
+      const cause = e instanceof Error ? e : undefined;
+      return {
+        exitCode: 1 as const,
+        reason: new ZeltCommandExecutionError({ reason: 'run_error', commandName, details }, cause),
+      };
+    }
+  }
+
+  async exec(argv: readonly string[]): Promise<ExecResult> {
+    const commandName = argv[0];
+
+    if (!commandName) {
+      return {
+        exitCode: 1,
+        reason: new ZeltCommandExecutionError({ reason: 'no_command_specified' }),
+      };
+    }
+
+    const CommandClass = this.commandMap.get(commandName);
+    if (!CommandClass) {
+      return {
+        exitCode: 1,
+        reason: new ZeltCommandExecutionError({ reason: 'command_not_found', commandName }),
+      };
+    }
+
+    return this.runCommand(CommandClass, commandName, argv.slice(1));
   }
 }

--- a/packages/core/src/app/modules/command-module.ts
+++ b/packages/core/src/app/modules/command-module.ts
@@ -83,9 +83,8 @@ export class CommandModule implements Lifecycle {
       };
     }
 
-    const instance = resolve(this.container, CommandClass);
-
     try {
+      const instance = resolve(this.container, CommandClass);
       const result = runInCommandContext({ parsedArgs: parseResult.parsed }, () => instance.run());
       await Promise.resolve(result);
       return { exitCode: 0 as const };

--- a/packages/core/src/command/exec-result.ts
+++ b/packages/core/src/command/exec-result.ts
@@ -1,0 +1,5 @@
+import type { ZeltCommandExecutionError } from '../errors';
+
+export type ExecResult =
+  | { exitCode: 0 }
+  | { exitCode: 1; readonly reason: ZeltCommandExecutionError };

--- a/packages/core/src/command/parse-argv.test.ts
+++ b/packages/core/src/command/parse-argv.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseArgv } from './parse-argv';
+import { cliSchema } from './schema';
+
+describe('parseArgv', () => {
+  describe('empty schema', () => {
+    it('returns empty object for empty schema', () => {
+      const result = parseArgv([], cliSchema({}));
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed).toEqual({});
+    });
+  });
+
+  describe('positional args', () => {
+    it('extracts positional string args in order', () => {
+      const schema = cliSchema({ args: [{ name: 'target', type: 'string' }] });
+      const result = parseArgv(['hello'], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['target']).toBe('hello');
+    });
+
+    it('extracts multiple positional args', () => {
+      const schema = cliSchema({
+        args: [
+          { name: 'source', type: 'string' },
+          { name: 'dest', type: 'string' },
+        ],
+      });
+      const result = parseArgv(['a.txt', 'b.txt'], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.parsed['source']).toBe('a.txt');
+        expect(result.parsed['dest']).toBe('b.txt');
+      }
+    });
+
+    it('converts number args', () => {
+      const schema = cliSchema({ args: [{ name: 'count', type: 'number' }] });
+      const result = parseArgv(['42'], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['count']).toBe(42);
+    });
+
+    it('returns error for invalid number', () => {
+      const schema = cliSchema({ args: [{ name: 'count', type: 'number' }] });
+      const result = parseArgv(['not-a-number'], schema);
+      expect(result.ok).toBe(false);
+    });
+
+    it('handles optional args as undefined when missing', () => {
+      const schema = cliSchema({
+        args: [{ name: 'target', type: 'string', optional: true }],
+      });
+      const result = parseArgv([], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['target']).toBeUndefined();
+    });
+  });
+
+  describe('options', () => {
+    it('parses boolean options', () => {
+      const schema = cliSchema({ options: [{ name: 'verbose', type: 'boolean' }] });
+      const result = parseArgv(['--verbose'], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['verbose']).toBe(true);
+    });
+
+    it('defaults boolean to false when not specified', () => {
+      const schema = cliSchema({ options: [{ name: 'verbose', type: 'boolean' }] });
+      const result = parseArgv([], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['verbose']).toBe(false);
+    });
+
+    it('parses string options', () => {
+      const schema = cliSchema({ options: [{ name: 'name', type: 'string' }] });
+      const result = parseArgv(['--name', 'alice'], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['name']).toBe('alice');
+    });
+
+    it('parses number options', () => {
+      const schema = cliSchema({ options: [{ name: 'port', type: 'number' }] });
+      const result = parseArgv(['--port', '3000'], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['port']).toBe(3000);
+    });
+
+    it('applies default values for string options', () => {
+      const schema = cliSchema({
+        options: [{ name: 'env', type: 'string', default: 'development' }],
+      });
+      const result = parseArgv([], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['env']).toBe('development');
+    });
+
+    it('applies default values for number options', () => {
+      const schema = cliSchema({ options: [{ name: 'port', type: 'number', default: 3000 }] });
+      const result = parseArgv([], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['port']).toBe(3000);
+    });
+
+    it('applies default values for boolean options', () => {
+      const schema = cliSchema({ options: [{ name: 'debug', type: 'boolean', default: true }] });
+      const result = parseArgv([], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['debug']).toBe(true);
+    });
+
+    it('parses alias options', () => {
+      const schema = cliSchema({ options: [{ name: 'verbose', type: 'boolean', alias: 'v' }] });
+      const result = parseArgv(['-v'], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['verbose']).toBe(true);
+    });
+
+    it('returns undefined for unspecified string options without default', () => {
+      const schema = cliSchema({ options: [{ name: 'name', type: 'string' }] });
+      const result = parseArgv([], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.parsed['name']).toBeUndefined();
+    });
+  });
+
+  describe('mixed args and options', () => {
+    it('parses both positional args and options', () => {
+      const schema = cliSchema({
+        args: [{ name: 'target', type: 'string' }],
+        options: [
+          { name: 'verbose', type: 'boolean', alias: 'v' },
+          { name: 'port', type: 'number', default: 8080 },
+        ],
+      });
+      const result = parseArgv(['hello', '-v', '--port', '3000'], schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.parsed['target']).toBe('hello');
+        expect(result.parsed['verbose']).toBe(true);
+        expect(result.parsed['port']).toBe(3000);
+      }
+    });
+  });
+});

--- a/packages/core/src/command/parse-argv.test.ts
+++ b/packages/core/src/command/parse-argv.test.ts
@@ -56,6 +56,15 @@ describe('parseArgv', () => {
       expect(result.ok).toBe(true);
       if (result.ok) expect(result.parsed['target']).toBeUndefined();
     });
+
+    it('returns error for missing required arg', () => {
+      const schema = cliSchema({
+        args: [{ name: 'target', type: 'string' }],
+      });
+      const result = parseArgv([], schema);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('Missing required argument: target');
+    });
   });
 
   describe('options', () => {

--- a/packages/core/src/command/parse-argv.ts
+++ b/packages/core/src/command/parse-argv.ts
@@ -1,0 +1,119 @@
+import type { ParseArgsConfig } from 'node:util';
+import { parseArgs } from 'node:util';
+
+import type { ArgDef, OptionDef, SchemaDefinition } from './schema';
+
+export type ParsedArgs = Record<string, unknown>;
+
+export type ParseResult = { ok: true; parsed: ParsedArgs } | { ok: false; error: string };
+
+const buildOptionsConfig = (
+  options: readonly OptionDef[],
+): NonNullable<ParseArgsConfig['options']> => {
+  const config: NonNullable<ParseArgsConfig['options']> = {};
+  for (const opt of options) {
+    const entry: { type: 'boolean' | 'string'; short?: string } = {
+      type: opt.type === 'boolean' ? 'boolean' : 'string',
+    };
+    if (opt.alias) {
+      entry.short = opt.alias;
+    }
+    config[opt.name] = entry;
+  }
+  return config;
+};
+
+const applyDefaults = (
+  values: Record<string, unknown>,
+  options: readonly OptionDef[],
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = { ...values };
+  for (const opt of options) {
+    if (result[opt.name] === undefined) {
+      if (opt.type === 'boolean') {
+        result[opt.name] = opt.default ?? false;
+      } else if (opt.default !== undefined) {
+        result[opt.name] = opt.default;
+      }
+    }
+  }
+  return result;
+};
+
+const convertNumberOptions = (
+  values: Record<string, unknown>,
+  options: readonly OptionDef[],
+): { ok: true; result: Record<string, unknown> } | { ok: false; error: string } => {
+  const result: Record<string, unknown> = { ...values };
+  for (const opt of options) {
+    if (opt.type === 'number' && typeof result[opt.name] === 'string') {
+      const num = Number(result[opt.name]);
+      if (!Number.isFinite(num)) {
+        return { ok: false, error: `Invalid number for option --${opt.name}: ${result[opt.name]}` };
+      }
+      result[opt.name] = num;
+    }
+  }
+  return { ok: true, result };
+};
+
+const parsePositionalArgs = (
+  positionals: string[],
+  argDefs: readonly ArgDef[],
+): { ok: true; result: Record<string, unknown> } | { ok: false; error: string } => {
+  const result: Record<string, unknown> = {};
+  for (const [i, def] of argDefs.entries()) {
+    const value = positionals[i];
+
+    if (value === undefined) {
+      result[def.name] = undefined;
+      continue;
+    }
+
+    if (def.type === 'number') {
+      const num = Number(value);
+      if (!Number.isFinite(num)) {
+        return { ok: false, error: `Invalid number for argument ${def.name}: ${value}` };
+      }
+      result[def.name] = num;
+    } else {
+      result[def.name] = value;
+    }
+  }
+  return { ok: true, result };
+};
+
+export const parseArgv = (argv: readonly string[], schema: SchemaDefinition): ParseResult => {
+  try {
+    const optionsDef = schema.options ?? [];
+    const argsDef = schema.args ?? [];
+
+    const config: ParseArgsConfig = {
+      args: [...argv],
+      options: buildOptionsConfig(optionsDef),
+      allowPositionals: true,
+      strict: false,
+    };
+
+    const { values, positionals } = parseArgs(config);
+
+    const valuesWithDefaults = applyDefaults(values, optionsDef);
+
+    const numberConversion = convertNumberOptions(valuesWithDefaults, optionsDef);
+    if (!numberConversion.ok) {
+      return { ok: false, error: numberConversion.error };
+    }
+
+    const positionalResult = parsePositionalArgs(positionals, argsDef);
+    if (!positionalResult.ok) {
+      return { ok: false, error: positionalResult.error };
+    }
+
+    return {
+      ok: true,
+      parsed: { ...positionalResult.result, ...numberConversion.result },
+    };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+};

--- a/packages/core/src/command/parse-argv.ts
+++ b/packages/core/src/command/parse-argv.ts
@@ -66,6 +66,9 @@ const parsePositionalArgs = (
     const value = positionals[i];
 
     if (value === undefined) {
+      if (!def.optional) {
+        return { ok: false, error: `Missing required argument: ${def.name} (position ${i + 1})` };
+      }
       result[def.name] = undefined;
       continue;
     }

--- a/packages/core/src/errors/classes.ts
+++ b/packages/core/src/errors/classes.ts
@@ -23,3 +23,6 @@ export type ZeltNotImplementedError = InstanceType<typeof ZeltNotImplementedErro
 
 export const ZeltSchemaValidationError = createErrorClass('ZeltSchemaValidationError');
 export type ZeltSchemaValidationError = InstanceType<typeof ZeltSchemaValidationError>;
+
+export const ZeltCommandExecutionError = createErrorClass('ZeltCommandExecutionError');
+export type ZeltCommandExecutionError = InstanceType<typeof ZeltCommandExecutionError>;

--- a/packages/core/src/errors/definitions.ts
+++ b/packages/core/src/errors/definitions.ts
@@ -1,3 +1,5 @@
+import { match } from 'ts-pattern';
+
 export const coreErrorDefinitions = {
   ZeltDecoratorUsageError: (ctx: {
     decoratorName: string;
@@ -50,6 +52,18 @@ export const coreErrorDefinitions = {
 
   ZeltSchemaValidationError: (ctx: { schemaType: string; reason: string }) =>
     `Invalid ${ctx.schemaType} schema: ${ctx.reason}`,
+
+  ZeltCommandExecutionError: (ctx: {
+    reason: 'command_not_found' | 'no_command_specified' | 'argv_parse_error' | 'run_error';
+    commandName?: string;
+    details?: string;
+  }): string =>
+    match(ctx.reason)
+      .with('command_not_found', () => `Command not found: ${ctx.commandName}`)
+      .with('no_command_specified', () => 'No command specified')
+      .with('argv_parse_error', () => `Failed to parse arguments: ${ctx.details}`)
+      .with('run_error', () => `Command execution failed: ${ctx.details}`)
+      .exhaustive(),
 } as const;
 
 export type CoreErrorContextMap = {

--- a/packages/core/src/errors/definitions.ts
+++ b/packages/core/src/errors/definitions.ts
@@ -73,10 +73,10 @@ export const coreErrorDefinitions = {
     details?: string;
   }): string =>
     match(ctx.reason)
-      .with('command_not_found', () => `Command not found: ${ctx.commandName}`)
+      .with('command_not_found', () => `Command not found: ${ctx.commandName ?? '<unknown>'}`)
       .with('no_command_specified', () => 'No command specified')
-      .with('argv_parse_error', () => `Failed to parse arguments: ${ctx.details}`)
-      .with('run_error', () => `Command execution failed: ${ctx.details}`)
+      .with('argv_parse_error', () => `Failed to parse arguments: ${ctx.details ?? ''}`)
+      .with('run_error', () => `Command execution failed: ${ctx.details ?? ''}`)
       .exhaustive(),
 } as const;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export type { ControllerClass, HttpMetadata } from './app/modules/http-module';
 export type { CommandContextStore } from './command/command-context';
 export { runInCommandContext } from './command/command-context';
 export { Command } from './command/decorator';
+export type { ExecResult } from './command/exec-result';
 export type { CommandMetadata } from './command/metadata';
 export { getCommandMetadata, setCommandMetadata } from './command/metadata';
 export { args } from './command/primitives/args';
@@ -40,6 +41,7 @@ export type { CoreErrorContextMap } from './errors';
 export {
   defineHttpException,
   ZeltAppConfigurationError,
+  ZeltCommandExecutionError,
   ZeltContextNotAvailableError,
   ZeltDecoratorUsageError,
   ZeltLifecycleStateError,


### PR DESCRIPTION
## Summary

- Add `CommandModule.exec()` method with proper argv parsing and command context setup
- Add `ExecResult` type with `ZeltCommandExecutionError` for failure reasons (command_not_found, no_command_specified, argv_parse_error, run_error)
- Add `parseArgv` function using Node.js `util.parseArgs` for CLI argument parsing
- Simplify adapter-node/bun to delegate to core `execCommand` instead of implementing their own logic
- Adapters now output error messages to stderr on failure

This fixes the issue where `run()` method was not being called because the adapter was bypassing core's command execution logic and missing the `runInCommandContext` setup required for `args()` primitive to work.

## Test plan

- [x] parseArgv unit tests pass (positional args, options, aliases, defaults, number conversion)
- [x] CommandModule.exec() tests pass (success, command_not_found, no_command_specified, run_error)
- [x] E2E tests for args() working inside command
- [x] All existing tests pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CLI parsing: positional args, typed options, aliases, defaults, and programmatic command entrypoint for apps.
  * Clear unified command execution result and error reporting surfaced to callers.

* **Bug Fixes**
  * Improved parsing error handling and clearer failure messages emitted to stderr.

* **Refactor**
  * Standardized command execution flow across core and adapters; added tests covering parsing and command argument handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->