### PR TITLE
fix(website): align doc slug with filename for llms.txt links

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -79,7 +79,8 @@ const config: KnipConfig = {
     },
     website: {
       // prism-theme-kanagawa.ts is imported by docusaurus.config.ts but knip --production misses it
-      entry: ['docusaurus.config.ts', 'src/prism-theme-kanagawa.ts'],
+      // scripts/check-doc-slugs.ts is run via npm script lint:slugs
+      entry: ['docusaurus.config.ts', 'src/prism-theme-kanagawa.ts', 'scripts/check-doc-slugs.ts'],
       // prism-react-renderer is used internally by Docusaurus for code block syntax highlighting
       // wrangler is used by Cloudflare Workers build system for deployment
       // @docusaurus/theme-common is used by swizzled theme components

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,7 +1,3 @@
----
-slug: /
----
-
 # Introduction
 
 ZeltJS is a portable TypeScript application framework with built-in DI. Swap adapters to run on Node.js, Bun, Cloudflare Workers, or AWS Lambda.

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/index.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/index.md
@@ -1,7 +1,3 @@
----
-slug: /
----
-
 # Introduction
 
 ZeltJSは、DIを組み込んだポータブルなTypeScriptアプリケーションフレームワークです。アダプターを切り替えることで、Node.js、Bun、Cloudflare Workers、AWS Lambdaで動作します。

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "lint:slugs": "bun scripts/check-doc-slugs.ts"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.1",

--- a/website/scripts/check-doc-slugs.ts
+++ b/website/scripts/check-doc-slugs.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env npx tsx
+/**
+ * Validates that markdown doc files have consistent slugs with their filenames.
+ * This ensures LLM-generated links (llms.txt) work correctly.
+ *
+ * Rules:
+ * - Files without slug frontmatter are OK (filename becomes the URL)
+ * - Files with slug must have matching filename (e.g., slug: /foo → foo.md, slug: / → index.md)
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const DOCS_DIR = join(import.meta.dirname, '../docs');
+
+interface Violation {
+  file: string;
+  slug: string;
+  expectedFilename: string;
+}
+
+const extractSlug = (content: string): string | null => {
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatterMatch) return null;
+
+  const slugMatch = frontmatterMatch[1].match(/^slug:\s*(.+)$/m);
+  if (!slugMatch) return null;
+
+  return slugMatch[1].trim();
+};
+
+const getExpectedFilename = (slug: string): string => {
+  const normalized = slug.replace(/^\//, '').replace(/\/$/, '');
+  if (normalized === '') return 'index.md';
+  return `${normalized.split('/').pop()}.md`;
+};
+
+const scanDirectory = async (dir: string): Promise<Violation[]> => {
+  const violations: Violation[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      violations.push(...(await scanDirectory(fullPath)));
+      continue;
+    }
+
+    if (!entry.name.endsWith('.md')) continue;
+
+    const content = await readFile(fullPath, 'utf-8');
+    const slug = extractSlug(content);
+
+    if (!slug) continue;
+
+    const expectedFilename = getExpectedFilename(slug);
+    if (entry.name !== expectedFilename) {
+      violations.push({
+        file: relative(DOCS_DIR, fullPath),
+        slug,
+        expectedFilename,
+      });
+    }
+  }
+
+  return violations;
+};
+
+const main = async () => {
+  const violations = await scanDirectory(DOCS_DIR);
+
+  if (violations.length === 0) {
+    console.log('✓ All doc slugs are consistent with filenames');
+    process.exit(0);
+  }
+
+  console.error('Doc slug/filename mismatches found:\n');
+  for (const v of violations) {
+    console.error(`  ${v.file}`);
+    console.error(`    slug: ${v.slug}`);
+    console.error(`    expected filename: ${v.expectedFilename}`);
+    console.error('');
+  }
+
+  console.error('Fix: Either rename the file to match the slug, or remove the slug frontmatter.');
+  process.exit(1);
+};
+
+main();

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -2,7 +2,7 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
 
 const sidebars: SidebarsConfig = {
   docsSidebar: [
-    'introduction',
+    'index',
     {
       type: 'category',
       label: 'Getting Started',


### PR DESCRIPTION
## Summary

- `docusaurus-plugin-llms` generates llms.txt links based on source filename
- `introduction.md` had `slug: /`, causing `/docs/introduction.md` to 404
- Renamed `introduction.md` → `index.md` (EN/JA) and removed slug frontmatter
- Added `lint:slugs` script to detect slug/filename mismatches in CI

## Test plan

- [ ] Run `pnpm lint:slugs` in website dir - should pass
- [ ] Build website and verify `/docs/index.md` exists in llms.txt
- [ ] Verify https://zeltjs.com/docs/index.md returns 200 after deploy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Japanese documentation for the site root with introduction, philosophy, examples, benchmark, and status note
  * Updated documentation index slug and sidebar to reference the new root doc

* **Chores**
  * Added a slug-validation script and an npm script to run it
  * Updated repository tooling configuration to include the new validation check

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->