### PR TITLE
fix(build): bundle dependencies to reduce install size

### DIFF
--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -27,11 +27,11 @@
   },
   "dependencies": {
     "@hono/node-server": "2.0.1",
-    "@zeltjs/core": "workspace:*",
-    "dotenv": "17.4.2"
+    "@zeltjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "22.19.17"
+    "@types/node": "22.19.17",
+    "dotenv": "17.4.2"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/adapter-node/tsdown.config.ts
+++ b/packages/adapter-node/tsdown.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   clean: true,
   fixedExtension: false,
   deps: {
+    alwaysBundle: ['dotenv'],
     neverBundle: [/^@zeltjs\//, 'hono', /^hono\//, /^@hono\//],
   },
 });

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -29,14 +29,12 @@
     "@zeltjs/core": "workspace:*",
     "hono": "^4.0.0"
   },
-  "dependencies": {
-    "jose": "6.0.11"
-  },
   "devDependencies": {
     "@types/node": "22.19.17",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/testing": "workspace:*",
-    "hono": "4.12.16"
+    "hono": "4.12.16",
+    "jose": "6.0.11"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/auth-jwt/tsdown.config.ts
+++ b/packages/auth-jwt/tsdown.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   clean: true,
   fixedExtension: false,
   deps: {
+    alwaysBundle: ['jose'],
     neverBundle: ['hono', /^hono\//, /^@hono\//, '@zeltjs/core', /^@zeltjs\/core\//],
   },
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,17 +36,17 @@
   "dependencies": {
     "@zeltjs/adapter-node": "workspace:*",
     "@zeltjs/core": "workspace:*",
-    "c12": "3.0.4",
-    "chokidar": "5.0.0",
-    "citty": "0.1.6",
-    "consola": "3.4.2",
-    "ts-pattern": "5.7.1"
+    "chokidar": "5.0.0"
   },
   "peerDependencies": {
     "typescript": ">=5.0.0"
   },
   "devDependencies": {
     "@types/node": "22.19.17",
+    "c12": "3.0.4",
+    "citty": "0.1.6",
+    "consola": "3.4.2",
+    "ts-pattern": "5.7.1",
     "tsdown": "0.21.10",
     "typescript": "6.0.2",
     "valibot": "1.3.1"

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   clean: true,
   fixedExtension: false,
   deps: {
-    neverBundle: [/^@zeltjs\//, 'tsdown', 'typescript'],
+    alwaysBundle: ['c12', 'citty', 'consola', 'ts-pattern'],
+    neverBundle: [/^@zeltjs\//, 'tsdown', 'typescript', 'chokidar'],
   },
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,14 +54,14 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
-    "croner": "9.1.0",
-    "hono": "4.12.16",
-    "ts-pattern": "5.6.2"
+    "hono": "4.12.16"
   },
   "devDependencies": {
     "@needle-di/core": "1.1.2",
     "@types/node": "22.19.17",
-    "neverthrow": "8.2.0"
+    "croner": "9.1.0",
+    "neverthrow": "8.2.0",
+    "ts-pattern": "5.6.2"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
   clean: true,
   fixedExtension: false,
   deps: {
+    alwaysBundle: ['croner', 'ts-pattern'],
     neverBundle: ['hono', /^hono\//, /^@hono\//, 'valibot'],
   },
 });

--- a/packages/decorator-metadata/package.json
+++ b/packages/decorator-metadata/package.json
@@ -30,10 +30,6 @@
     "test": "vitest run",
     "typecheck": "tsc -b"
   },
-  "dependencies": {
-    "neverthrow": "8.2.0",
-    "ts-pattern": "5.6.2"
-  },
   "peerDependencies": {
     "typescript": ">=5.0.0"
   },
@@ -47,6 +43,8 @@
   },
   "devDependencies": {
     "@types/node": "22.19.17",
+    "neverthrow": "8.2.0",
+    "ts-pattern": "5.6.2",
     "typescript": "6.0.2"
   },
   "volta": {

--- a/packages/decorator-metadata/tsdown.config.ts
+++ b/packages/decorator-metadata/tsdown.config.ts
@@ -15,4 +15,8 @@ export default defineConfig({
   dts: true,
   clean: true,
   fixedExtension: false,
+  deps: {
+    alwaysBundle: ['neverthrow', 'ts-pattern'],
+    neverBundle: ['typescript', /^typescript-/],
+  },
 });

--- a/packages/validator-valibot/package.json
+++ b/packages/validator-valibot/package.json
@@ -29,14 +29,12 @@
     "test": "vitest run",
     "typecheck": "tsc -b"
   },
-  "dependencies": {
-    "valibot": "1.3.1",
-    "@valibot/to-json-schema": "1.6.0"
-  },
   "peerDependencies": {
     "@zeltjs/core": "workspace:*",
     "@zeltjs/openapi": "workspace:*",
-    "hono": "4.12.16"
+    "hono": "4.12.16",
+    "valibot": "^1.0.0",
+    "@valibot/to-json-schema": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@zeltjs/openapi": {
@@ -45,9 +43,11 @@
   },
   "devDependencies": {
     "@types/node": "22.19.17",
+    "@valibot/to-json-schema": "1.6.0",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/openapi": "workspace:*",
-    "hono": "4.12.16"
+    "hono": "4.12.16",
+    "valibot": "1.3.1"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/validator-valibot/tsdown.config.ts
+++ b/packages/validator-valibot/tsdown.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
       /^@zeltjs\/openapi\//,
       'hono',
       /^hono\//,
+      'valibot',
+      /^valibot\//,
+      '@valibot/to-json-schema',
     ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,19 +225,15 @@ importers:
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
-      dotenv:
-        specifier: 17.4.2
-        version: 17.4.2
     devDependencies:
       '@types/node':
         specifier: 22.19.17
         version: 22.19.17
+      dotenv:
+        specifier: 17.4.2
+        version: 17.4.2
 
   packages/auth-jwt:
-    dependencies:
-      jose:
-        specifier: 6.0.11
-        version: 6.0.11
     devDependencies:
       '@types/node':
         specifier: 22.19.17
@@ -251,6 +247,9 @@ importers:
       hono:
         specifier: 4.12.16
         version: 4.12.16
+      jose:
+        specifier: 6.0.11
+        version: 6.0.11
 
   packages/auth-session:
     devDependencies:
@@ -275,12 +274,16 @@ importers:
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
-      c12:
-        specifier: 3.0.4
-        version: 3.0.4
       chokidar:
         specifier: 5.0.0
         version: 5.0.0
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.17
+        version: 22.19.17
+      c12:
+        specifier: 3.0.4
+        version: 3.0.4
       citty:
         specifier: 0.1.6
         version: 0.1.6
@@ -290,10 +293,6 @@ importers:
       ts-pattern:
         specifier: 5.7.1
         version: 5.7.1
-    devDependencies:
-      '@types/node':
-        specifier: 22.19.17
-        version: 22.19.17
       tsdown:
         specifier: 0.21.10
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2)
@@ -306,15 +305,9 @@ importers:
 
   packages/core:
     dependencies:
-      croner:
-        specifier: 9.1.0
-        version: 9.1.0
       hono:
         specifier: 4.12.16
         version: 4.12.16
-      ts-pattern:
-        specifier: 5.6.2
-        version: 5.6.2
     devDependencies:
       '@needle-di/core':
         specifier: 1.1.2
@@ -322,9 +315,15 @@ importers:
       '@types/node':
         specifier: 22.19.17
         version: 22.19.17
+      croner:
+        specifier: 9.1.0
+        version: 9.1.0
       neverthrow:
         specifier: 8.2.0
         version: 8.2.0
+      ts-pattern:
+        specifier: 5.6.2
+        version: 5.6.2
 
   packages/db:
     devDependencies:
@@ -336,17 +335,16 @@ importers:
         version: link:../core
 
   packages/decorator-metadata:
-    dependencies:
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.17
+        version: 22.19.17
       neverthrow:
         specifier: 8.2.0
         version: 8.2.0
       ts-pattern:
         specifier: 5.6.2
         version: 5.6.2
-    devDependencies:
-      '@types/node':
-        specifier: 22.19.17
-        version: 22.19.17
       typescript:
         specifier: 6.0.2
         version: 6.0.2
@@ -508,17 +506,13 @@ importers:
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/validator-valibot:
-    dependencies:
-      '@valibot/to-json-schema':
-        specifier: 1.6.0
-        version: 1.6.0(valibot@1.3.1(typescript@6.0.2))
-      valibot:
-        specifier: 1.3.1
-        version: 1.3.1(typescript@6.0.2)
     devDependencies:
       '@types/node':
         specifier: 22.19.17
         version: 22.19.17
+      '@valibot/to-json-schema':
+        specifier: 1.6.0
+        version: 1.6.0(valibot@1.3.1(typescript@6.0.2))
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
@@ -528,6 +522,9 @@ importers:
       hono:
         specifier: 4.12.16
         version: 4.12.16
+      valibot:
+        specifier: 1.3.1
+        version: 1.3.1(typescript@6.0.2)
 
   website:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `alwaysBundle` config to tsdown for pure JS dependencies
- Move bundled deps from `dependencies` to `devDependencies`
- Move valibot to `peerDependencies` in validator-valibot

## Changes

| Package | Bundled | Reason |
|---------|---------|--------|
| core | croner, ts-pattern | Pure JS, internal use |
| cli | c12, citty, consola, ts-pattern | Pure JS, internal use |
| auth-jwt | jose | Pure JS, internal use |
| decorator-metadata | neverthrow, ts-pattern | Pure JS, internal use |
| adapter-node | dotenv | Pure JS, internal use |
| validator-valibot | - | valibot moved to peer (user-facing) |

## Impact

- **Publish size**: Increases slightly (bundled code included)
- **Install size**: Decreases significantly (fewer transitive deps)

Example for core:
- Before: 379KB + croner(120KB) + ts-pattern(536KB) + hono = ~2.18MB
- After: 515KB + hono = ~1.2MB (estimated 45% reduction)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] Verified bundled deps are not in external imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package dependencies and build configurations across multiple packages to optimize bundling behavior and dependency management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->