### PR TITLE
feat(ci): add dist import verification and fix decorator transpilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Verify dist imports
+        run: pnpm verify-dist
+
       - name: leak check on public d.ts
         run: |
           set -e

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "codepolicy": "time codepolicy --filter=all 2>&1 | tee codepolicy.all.log",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "precommit": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm build && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
+    "precommit": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm build && pnpm verify-dist && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
     "prepare": "npx lefthook install",
     "codepolicy:diff": "time codepolicy --filter=diff 2>&1 | tee codepolicy.diff.log",
-    "throw-trace": "throw-trace check --exclude '**/*.test.ts' packages"
+    "throw-trace": "throw-trace check --exclude '**/*.test.ts' packages",
+    "verify-dist": "node scripts/verify-dist-imports.mjs"
   },
   "devDependencies": {
     "@9wick/eslint-plugin-strict-type-rules": "1.2.0",

--- a/packages/eventbus/tsdown.config.ts
+++ b/packages/eventbus/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/adaptor-memory/index.ts', 'src/adaptor-redis/index.ts'],
   format: ['esm'],
   dts: true,

--- a/packages/kv/tsdown.config.ts
+++ b/packages/kv/tsdown.config.ts
@@ -1,6 +1,15 @@
+import swc from '@rollup/plugin-swc';
 import { defineConfig } from 'tsdown';
 
+const swcDecoratorPlugin = swc({
+  jsc: {
+    parser: { syntax: 'typescript', decorators: true },
+    transform: { decoratorVersion: '2022-03' },
+  },
+});
+
 export default defineConfig({
+  plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/adaptor-memory/index.ts', 'src/adaptor-redis/index.ts'],
   format: ['esm'],
   dts: true,

--- a/scripts/verify-dist-imports.mjs
+++ b/scripts/verify-dist-imports.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { glob } from 'node:fs/promises';
+import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const SKIP_PACKAGES = new Set([
@@ -17,7 +18,7 @@ let failed = false;
 let skipped = 0;
 
 for (const entry of entries) {
-  const pkg = entry.split('/')[1];
+  const pkg = path.normalize(entry).split(path.sep)[1];
   
   if (SKIP_PACKAGES.has(pkg)) {
     console.log(`- ${pkg} (skipped: runtime-specific)`);

--- a/scripts/verify-dist-imports.mjs
+++ b/scripts/verify-dist-imports.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { glob } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const SKIP_PACKAGES = new Set([
+  'adapter-cloudflare-workers',
+]);
+
+const entries = await Array.fromAsync(glob('packages/*/dist/index.js'));
+
+if (entries.length === 0) {
+  console.error('No dist/index.js files found. Run build first.');
+  process.exit(1);
+}
+
+let failed = false;
+let skipped = 0;
+
+for (const entry of entries) {
+  const pkg = entry.split('/')[1];
+  
+  if (SKIP_PACKAGES.has(pkg)) {
+    console.log(`- ${pkg} (skipped: runtime-specific)`);
+    skipped++;
+    continue;
+  }
+  
+  try {
+    await import(pathToFileURL(entry).href);
+    console.log(`✓ ${pkg}`);
+  } catch (err) {
+    console.error(`✗ ${pkg}: ${err.message}`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error('\nSome packages failed to import.');
+  process.exit(1);
+}
+
+console.log(`\nAll ${entries.length - skipped} packages imported successfully (${skipped} skipped).`);


### PR DESCRIPTION
## Summary
- Add `verify-dist` script to smoke test all package dist imports after build
- Add verification step to CI workflow and precommit
- Fix decorator transpilation bug in `kv` and `eventbus` packages (missing `swcDecoratorPlugin`)

## Test plan
- [x] `pnpm build && pnpm verify-dist` passes locally
- [ ] CI passes with new verification step

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI and precommit now run an automated verification step to ensure built distribution files import correctly.
  * Package build configurations updated to enable TypeScript decorator support during bundling.
  * Added a verification script that scans and dynamically validates distribution outputs, failing the process if issues are found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->