### PR TITLE
docs(decorator-metadata): enhance README with detailed API documentation

### DIFF
--- a/packages/decorator-metadata/README.md
+++ b/packages/decorator-metadata/README.md
@@ -103,42 +103,32 @@ import { getClassMetadata } from '@zeltjs/decorator-metadata/inspect';
 const meta = getClassMetadata(UserController);
 ```
 
-**Signature:**
+**Return Structure:**
 
-```typescript
-getClassMetadata(cls: object): ClassMeta | undefined
-```
+| Field | Type | Description |
+|-------|------|-------------|
+| `pos` | `Position` | Where the class decorator was applied |
+| `props` | `object` | Props passed to `createClassDecorator` |
+| `methods` | `MethodMeta[]` | Methods with decorators |
+| `properties` | `PropertyMeta[]` | Properties with decorators |
 
-**Return Type:**
+**MethodMeta / PropertyMeta:**
 
-```typescript
-type ClassMeta = {
-  pos: Position;                // Where the class decorator was applied
-  props: object;                // Props passed to createClassDecorator
-  methods: MethodMeta[];        // Methods with decorators
-  properties: PropertyMeta[];   // Properties with decorators
-};
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Method or property name |
+| `pos` | `Position` | Where the decorator was applied |
+| `props` | `object` | Props passed to the decorator factory |
 
-type MethodMeta = {
-  name: string;                 // Method name
-  pos: Position;                // Where the method decorator was applied
-  props: object;                // Props passed to createMethodDecorator
-};
+**Position:**
 
-type PropertyMeta = {
-  name: string;                 // Property name
-  pos: Position;                // Where the property decorator was applied
-  props: object;                // Props passed to createPropertyDecorator
-};
+| Field | Type | Description |
+|-------|------|-------------|
+| `sourceFile` | `string` | Absolute path to source file |
+| `line` | `number` | Line number (1-based) |
+| `column` | `number` | Column number (1-based) |
 
-type Position = {
-  sourceFile: string;           // Absolute path to source file
-  line: number;                 // Line number (1-based)
-  column: number;               // Column number (1-based)
-};
-```
-
-**Example:**
+**Full Example:**
 
 ```typescript
 // Source
@@ -151,19 +141,19 @@ class UserController {
   cache?: Map<string, User>;
 }
 
-// Result
+// Extracted metadata
 {
   pos: { sourceFile: '/app/src/user.controller.ts', line: 1, column: 1 },
   props: { basePath: '/users' },
   methods: [{
     name: 'getUser',
     pos: { sourceFile: '/app/src/user.controller.ts', line: 3, column: 3 },
-    props: { method: 'GET', path: '/:id' }
+    props: { decorator: 'Get', method: 'GET', path: '/:id' }
   }],
   properties: [{
     name: 'cache',
     pos: { sourceFile: '/app/src/user.controller.ts', line: 6, column: 3 },
-    props: { nullable: true }
+    props: { decorator: 'Column', nullable: true }
   }]
 }
 ```

--- a/packages/decorator-metadata/README.md
+++ b/packages/decorator-metadata/README.md
@@ -4,7 +4,48 @@
 
 Runtime decorator metadata capture and TypeScript type extraction for TC39 decorators.
 
-**[Read the Documentation](https://zeltjs.com)**
+## Why This Matters
+
+Traditional decorator-based frameworks (NestJS, TypeORM, etc.) rely on:
+
+- `reflect-metadata` polyfill
+- `emitDecoratorMetadata` compiler flag
+- `experimentalDecorators` (legacy TypeScript decorators)
+
+These require **instantiating classes** to access metadata, which means:
+
+- No tree-shaking (entire dependency graph loaded)
+- Slow startup (all classes must be constructed)
+- Non-standard (experimental features may break)
+
+### The Static Layer Approach
+
+This library introduces a **static layer** — metadata collection happens at module load time, *before* any instance is created:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Traditional Approach                                       │
+│  import → class definition → instantiation → metadata       │
+│                                              ↑              │
+│                                    (requires running app)   │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  Static Layer Approach                                      │
+│  import → class definition → metadata                       │
+│                              ↑                              │
+│                   (no instantiation needed)                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+This enables:
+
+| Capability | Traditional | Static Layer |
+|------------|-------------|--------------|
+| Tree-shaking | ❌ | ✅ |
+| Static analysis (OpenAPI gen, CLI tools) | ❌ | ✅ |
+| Cold start optimization | ❌ | ✅ |
+| TC39 standard decorators | ❌ | ✅ |
 
 ## Installation
 
@@ -16,6 +57,8 @@ pnpm add @zeltjs/decorator-metadata
 
 ### Runtime API
 
+Create decorators that capture metadata at definition time:
+
 ```typescript
 import {
   createClassDecorator,
@@ -23,14 +66,18 @@ import {
   createPropertyDecorator,
 } from '@zeltjs/decorator-metadata';
 
-// Create custom decorators
 const Controller = (basePath: string) =>
   createClassDecorator({ basePath });
 
 const Get = (path: string) =>
-  createMethodDecorator({ method: 'GET', path });
+  createMethodDecorator({ decorator: 'Get', method: 'GET', path });
 
-// Use decorators
+const Post = (path: string) =>
+  createMethodDecorator({ decorator: 'Post', method: 'POST', path });
+
+const Column = (opts?: { nullable?: boolean }) =>
+  createPropertyDecorator({ decorator: 'Column', nullable: opts?.nullable ?? false });
+
 @Controller('/users')
 class UserController {
   @Get('/:id')
@@ -40,7 +87,92 @@ class UserController {
 }
 ```
 
+**Note:** Decorator names (e.g., `@Get`, `@Column`) are not automatically captured. If you need to distinguish between decorator types, include an identifier in `props` (e.g., `{ decorator: 'Get', ... }`).
+
 ### Inspect API
+
+Retrieve captured metadata without instantiating:
+
+#### getClassMetadata (lightweight, no tsconfig)
+
+Retrieves decorator metadata captured at runtime. No TypeScript compiler needed.
+
+```typescript
+import { getClassMetadata } from '@zeltjs/decorator-metadata/inspect';
+
+const meta = getClassMetadata(UserController);
+```
+
+**Signature:**
+
+```typescript
+getClassMetadata(cls: object): ClassMeta | undefined
+```
+
+**Return Type:**
+
+```typescript
+type ClassMeta = {
+  pos: Position;                // Where the class decorator was applied
+  props: object;                // Props passed to createClassDecorator
+  methods: MethodMeta[];        // Methods with decorators
+  properties: PropertyMeta[];   // Properties with decorators
+};
+
+type MethodMeta = {
+  name: string;                 // Method name
+  pos: Position;                // Where the method decorator was applied
+  props: object;                // Props passed to createMethodDecorator
+};
+
+type PropertyMeta = {
+  name: string;                 // Property name
+  pos: Position;                // Where the property decorator was applied
+  props: object;                // Props passed to createPropertyDecorator
+};
+
+type Position = {
+  sourceFile: string;           // Absolute path to source file
+  line: number;                 // Line number (1-based)
+  column: number;               // Column number (1-based)
+};
+```
+
+**Example:**
+
+```typescript
+// Source
+@Controller('/users')
+class UserController {
+  @Get('/:id')
+  getUser(id: string): User { ... }
+  
+  @Column({ nullable: true })
+  cache?: Map<string, User>;
+}
+
+// Result
+{
+  pos: { sourceFile: '/app/src/user.controller.ts', line: 1, column: 1 },
+  props: { basePath: '/users' },
+  methods: [{
+    name: 'getUser',
+    pos: { sourceFile: '/app/src/user.controller.ts', line: 3, column: 3 },
+    props: { method: 'GET', path: '/:id' }
+  }],
+  properties: [{
+    name: 'cache',
+    pos: { sourceFile: '/app/src/user.controller.ts', line: 6, column: 3 },
+    props: { nullable: true }
+  }]
+}
+```
+
+**Note:** Returns `undefined` if the class has no decorator metadata.
+
+#### getTypeMetadata (full type extraction, requires tsconfig)
+
+Extracts full TypeScript type information using the compiler API.
 
 ```typescript
 import { getTypeMetadata } from '@zeltjs/decorator-metadata/inspect';
@@ -49,17 +181,105 @@ const result = await getTypeMetadata(UserController, {
   tsconfig: './tsconfig.json',
   expandStrategy: 'exported-only',
 });
+```
 
-if (result.isOk()) {
-  console.log(result.value);
-  // {
-  //   name: 'UserController',
-  //   props: { basePath: '/users' },
-  //   methods: [{ name: 'getUser', params: [...], returnType: {...} }],
-  //   properties: []
-  // }
+**Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `tsconfig` | `string` | `'./tsconfig.json'` | Path to tsconfig.json |
+| `expandStrategy` | `ExpandStrategy` | `'exported-only'` | How to handle named types |
+
+**Expand Strategies:**
+
+| Strategy | Behavior |
+|----------|----------|
+| `'exported-only'` | Keep exported types as `{ kind: 'named' }` references, expand internal types inline |
+| `'all-named'` | Keep all named types as references (most compact) |
+| `'always'` | Expand all types inline (most detailed) |
+
+**Extracted Type Kinds:**
+
+| Kind | Example Source | Output |
+|------|----------------|--------|
+| `primitive` | `string`, `number`, `boolean` | `{ kind: 'primitive', type: 'string' }` |
+| `literal` | `'admin'`, `42`, `true` | `{ kind: 'literal', value: 'admin' }` |
+| `array` | `string[]` | `{ kind: 'array', items: {...} }` |
+| `union` | `string \| null` | `{ kind: 'union', types: [...] }` |
+| `object` | `{ id: string }` | `{ kind: 'object', properties: [...] }` |
+| `promise` | `Promise<User>` | `{ kind: 'promise', inner: {...} }` |
+| `named` | `User` (exported type) | `{ kind: 'named', name: 'User', module: '...', isExported: true }` |
+| `ref` | internal type reference | `{ kind: 'ref', name: 'InternalType' }` |
+
+**Full Example:**
+
+```typescript
+// Source
+export type User = { id: string; name: string; email?: string };
+
+@Controller('/users')
+class UserController {
+  @Get('/:id')
+  getUser(id: string): Promise<User | null> { ... }
+}
+
+// Extracted metadata
+{
+  name: 'UserController',
+  props: { basePath: '/users' },
+  methods: [{
+    name: 'getUser',
+    props: { method: 'GET', path: '/:id' },
+    params: [{ name: 'id', type: { kind: 'primitive', type: 'string' } }],
+    returnType: {
+      kind: 'union',
+      types: [
+        { kind: 'named', name: 'User', module: '/path/to/file.ts', isExported: true },
+        { kind: 'primitive', type: 'null' }
+      ]
+    }
+  }],
+  properties: []
 }
 ```
+
+## Use Cases
+
+### OpenAPI Schema Generation
+
+Generate OpenAPI specs without starting the server:
+
+```typescript
+import { getTypeMetadata } from '@zeltjs/decorator-metadata/inspect';
+
+const meta = await getTypeMetadata(UserController);
+// → Convert to OpenAPI paths, no app.listen() required
+```
+
+### Validation Schema Generation
+
+Auto-generate Zod/Valibot schemas from type information:
+
+```typescript
+const meta = await getTypeMetadata(CreateUserDto);
+// → Generate validation schema from params/properties types
+```
+
+### CLI Tooling
+
+Build framework-aware CLI tools that analyze code statically:
+
+```typescript
+// Scan all controllers, extract routes, generate documentation
+// All without instantiating a single class
+```
+
+## Requirements
+
+- TypeScript 5.0+ (TC39 decorators)
+- No `experimentalDecorators`
+- No `emitDecoratorMetadata`
+- No `reflect-metadata`
 
 ## License
 

--- a/packages/decorator-metadata/src/index.ts
+++ b/packages/decorator-metadata/src/index.ts
@@ -4,4 +4,3 @@ export {
   createPropertyDecorator,
 } from './runtime/decorators';
 export type { Position } from './runtime/position';
-export { getClassMetadata } from './runtime/store';

--- a/packages/decorator-metadata/src/inspect/index.ts
+++ b/packages/decorator-metadata/src/inspect/index.ts
@@ -1,3 +1,4 @@
+export { getClassMetadata } from '../runtime/store';
 export { getTypeMetadata } from './get-type-metadata';
 export { clearProgramCache } from './program-cache';
 export type {


### PR DESCRIPTION
## Summary

- Add "Why This Matters" section explaining the static layer approach vs traditional (reflect-metadata, emitDecoratorMetadata)
- Move `getClassMetadata` from runtime to inspect API for better categorization (runtime = setup, inspect = analysis)
- Document `getClassMetadata` with signature, return types, and examples
- Document `getTypeMetadata` with options table, expand strategies, and extracted type kinds
- Add note about decorator names not being auto-captured

## Changes

- `packages/decorator-metadata/README.md`: Comprehensive documentation rewrite
- `packages/decorator-metadata/src/index.ts`: Remove `getClassMetadata` export (moved to inspect)
- `packages/decorator-metadata/src/inspect/index.ts`: Add `getClassMetadata` export

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Tests pass (`pnpm test`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README substantially expanded: "static layer" approach, "Why This Matters" and comparison table, fuller runtime API examples for creating class/method/property decorators (includes Column nullable helper), expanded Inspect API with getClassMetadata, enriched getTypeMetadata examples, Use Cases and explicit Requirements (TypeScript 5.0+, no experimental decorators/emit/reflect).

* **Refactor**
  * Inspection/export surface reorganized; metadata inspection export locations changed—please verify import paths if you consume inspection APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->