### PR TITLE
fix(website): sync llms.txt order with sidebar menu

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,6 +6,23 @@ import type { PluginOptions as SearchPluginOptions } from '@easyops-cn/docusauru
 import rehypeShiki from '@shikijs/rehype';
 import { rendererRich, transformerTwoslash } from '@shikijs/twoslash';
 import { createTwoslasher } from 'twoslash';
+import sidebars from './sidebars.js';
+
+type SidebarItem =
+  | string
+  | { type: 'category'; items: SidebarItem[] }
+  | { type: 'link' }
+  | { type: 'doc'; id: string };
+
+const extractDocPaths = (items: SidebarItem[]): string[] =>
+  items.flatMap((item): string[] => {
+    if (typeof item === 'string') return [`${item}.md`];
+    if (item.type === 'category') return extractDocPaths(item.items);
+    if (item.type === 'doc') return [`${item.id}.md`];
+    return [];
+  });
+
+const llmsIncludeOrder = extractDocPaths(sidebars.docsSidebar as SidebarItem[]);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -198,6 +215,8 @@ const config: Config = {
         docsDir: 'docs',
         title: 'Zelt Documentation',
         description: 'A fast, type-safe application framework for TypeScript',
+        includeOrder: llmsIncludeOrder,
+        includeUnmatchedLast: false,
       },
     ],
     'docusaurus-markdown-source-plugin',


### PR DESCRIPTION
## Summary

- Extract doc paths from sidebars.ts to generate `includeOrder` dynamically
- llms.txt now always matches the sidebar structure automatically
- Set `includeUnmatchedLast: false` to exclude docs not in sidebar

## Test plan

- [x] Build website and verify llms.txt order matches sidebar

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781908670&installation_id=133048706&pr_number=190&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F190&signature=c6cec184c249edc541e8d96aa34371b53fe48d1a27c78b1b6a4b18289c0e5269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation configuration to optimize indexing and ordering behavior for documentation tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->