### PR TITLE
refactor(env): simplify Env API by consolidating EnvConfig/EnvService into Env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,12 @@ jobs:
           #   TypedResponse — structural part of ResponseBuilder return types
           #   ContentfulStatusCode — structural part of ResponseBuilder status parameter types
           #   Context, Env, Input, MiddlewareHandler — middleware types for KoyaContext/FunctionMiddleware
+          #   Env as Env$1 — renamed to avoid collision with @zeltjs/core Env class
           UNEXPECTED=$(echo "$HONO_REFS" \
             | grep -v "^import { HTTPException } from ['\"]hono/http-exception['\"];$" \
             | grep -v "^import { TypedResponse } from ['\"]hono['\"];$" \
             | grep -v "^import { Context, Env, Input, MiddlewareHandler, TypedResponse } from ['\"]hono['\"];$" \
+            | grep -v "^import { Context, Env as Env\\\$1, Input, MiddlewareHandler, TypedResponse } from ['\"]hono['\"];$" \
             | grep -v "^import { ContentfulStatusCode } from ['\"]hono/utils/http-status['\"];$" \
             || true)
           if [ -n "$UNEXPECTED" ]; then

--- a/docs/superpowers/plans/2026-05-22-env-simplification.md
+++ b/docs/superpowers/plans/2026-05-22-env-simplification.md
@@ -1,0 +1,597 @@
+# Env API Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate EnvConfig/EnvService into a single Env class, make EnvSource internal, remove DotEnvConfig.
+
+**Architecture:** Env (user-facing) → EnvSource (internal abstraction) → ProcessEnvSource (adapter-node). Old classes marked @deprecated.
+
+**Tech Stack:** TypeScript, Vitest, @zeltjs/core, @zeltjs/adapter-node
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `packages/core/src/modules/env/env-source.ts` | Create | Internal abstraction for env value retrieval |
+| `packages/core/src/modules/env/env.ts` | Create | User-facing Env class with getString/getNumber/getBoolean/getRequired |
+| `packages/core/src/modules/env/env.test.ts` | Create | Tests for new Env class |
+| `packages/core/src/modules/env/env.config.ts` | Modify | Add @deprecated |
+| `packages/core/src/modules/env/env.service.ts` | Modify | Add @deprecated |
+| `packages/core/src/modules/env/index.ts` | Modify | Export Env, EnvSource |
+| `packages/core/src/index.ts` | Modify | Export Env |
+| `packages/adapter-node/src/process-env-source.ts` | Create | ProcessEnvSource implementation |
+| `packages/adapter-node/src/on-node.ts` | Modify | Use ProcessEnvSource instead of ProcessEnvConfig |
+| `packages/adapter-node/src/process-env.config.ts` | Modify | Add @deprecated |
+| `packages/adapter-node/src/dotenv.config.ts` | Modify | Add @deprecated |
+| `packages/adapter-node/src/index.ts` | Modify | Export ProcessEnvSource |
+| `website/docs/configuration.md` | Modify | Update to use inject(Env) |
+
+---
+
+### Task 1: Create EnvSource internal abstraction
+
+**Files:**
+- Create: `packages/core/src/modules/env/env-source.ts`
+
+- [ ] **Step 1: Create EnvSource class**
+
+```typescript
+// packages/core/src/modules/env/env-source.ts
+import { Config } from '../../config';
+
+@Config
+export class EnvSource {
+  get(_key: string): string | undefined {
+    return undefined;
+  }
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/modules/env/env-source.ts
+git commit -m "feat(core): add EnvSource internal abstraction"
+```
+
+---
+
+### Task 2: Create Env class with user-facing API
+
+**Files:**
+- Create: `packages/core/src/modules/env/env.ts`
+- Create: `packages/core/src/modules/env/env.test.ts`
+
+- [ ] **Step 1: Write failing tests for Env class**
+
+```typescript
+// packages/core/src/modules/env/env.test.ts
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Config } from '../../config';
+import { createTestTargetBase } from '../../di/container';
+
+import { Env } from './env';
+import { EnvSource } from './env-source';
+
+@Config
+class TestEnvSource extends EnvSource {
+  override get(key: string): string | undefined {
+    return process.env[key];
+  }
+}
+
+let env: Env;
+
+const setupEnv = async () => {
+  const result = await createTestTargetBase(Env, {
+    configs: [TestEnvSource],
+  });
+  env = result.target;
+  return result;
+};
+
+describe('Env', () => {
+  beforeAll(async () => {
+    await setupEnv();
+  });
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('getString', () => {
+    it('returns env value when exists', () => {
+      vi.stubEnv('TEST_KEY', 'test_value');
+      expect(env.getString('TEST_KEY', 'default')).toBe('test_value');
+    });
+
+    it('returns default when env not exists', () => {
+      expect(env.getString('NOT_EXISTS', 'default')).toBe('default');
+    });
+
+    it('returns empty string when no default and env not exists', () => {
+      expect(env.getString('NOT_EXISTS')).toBe('');
+    });
+  });
+
+  describe('getNumber', () => {
+    it('returns parsed number when env exists', () => {
+      vi.stubEnv('PORT', '3000');
+      expect(env.getNumber('PORT', 8080)).toBe(3000);
+    });
+
+    it('returns default when env not exists', () => {
+      expect(env.getNumber('NOT_EXISTS', 8080)).toBe(8080);
+    });
+
+    it('returns default when env is not a valid number', () => {
+      vi.stubEnv('INVALID', 'not_a_number');
+      expect(env.getNumber('INVALID', 8080)).toBe(8080);
+    });
+
+    it('returns 0 when no default and env not exists', () => {
+      expect(env.getNumber('NOT_EXISTS')).toBe(0);
+    });
+  });
+
+  describe('getBoolean', () => {
+    it('returns true when env is "true"', () => {
+      vi.stubEnv('ENABLED', 'true');
+      expect(env.getBoolean('ENABLED', false)).toBe(true);
+    });
+
+    it('returns true when env is "1"', () => {
+      vi.stubEnv('ENABLED', '1');
+      expect(env.getBoolean('ENABLED', false)).toBe(true);
+    });
+
+    it('returns false when env is other value', () => {
+      vi.stubEnv('ENABLED', 'false');
+      expect(env.getBoolean('ENABLED', true)).toBe(false);
+    });
+
+    it('returns default when env not exists', () => {
+      expect(env.getBoolean('NOT_EXISTS', true)).toBe(true);
+    });
+
+    it('returns false when no default and env not exists', () => {
+      expect(env.getBoolean('NOT_EXISTS')).toBe(false);
+    });
+  });
+
+  describe('getRequired', () => {
+    it('returns env value when exists', () => {
+      vi.stubEnv('API_KEY', 'secret123');
+      expect(env.getRequired('API_KEY')).toBe('secret123');
+    });
+
+    it('throws when env not exists', () => {
+      expect(() => env.getRequired('NOT_EXISTS')).toThrow(
+        'Required environment variable NOT_EXISTS is not set',
+      );
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run packages/core/src/modules/env/env.test.ts`
+Expected: FAIL with "Cannot find module './env'"
+
+- [ ] **Step 3: Implement Env class**
+
+```typescript
+// packages/core/src/modules/env/env.ts
+import { inject } from '../../di/inject';
+import { Injectable } from '../../di/injectable';
+
+import { EnvSource } from './env-source';
+
+@Injectable()
+export class Env {
+  constructor(private source = inject(EnvSource)) {}
+
+  getString(key: string, defaultValue: string = ''): string {
+    return this.source.get(key) ?? defaultValue;
+  }
+
+  getNumber(key: string, defaultValue: number = 0): number {
+    const val = this.source.get(key);
+    if (val === undefined) return defaultValue;
+    const parsed = Number(val);
+    if (Number.isNaN(parsed)) return defaultValue;
+    return parsed;
+  }
+
+  getBoolean(key: string, defaultValue: boolean = false): boolean {
+    const val = this.source.get(key);
+    if (val === undefined) return defaultValue;
+    return val === 'true' || val === '1';
+  }
+
+  getRequired(key: string): string {
+    const val = this.source.get(key);
+    if (val === undefined) {
+      throw new Error(`Required environment variable ${key} is not set`);
+    }
+    return val;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run packages/core/src/modules/env/env.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/modules/env/env.ts packages/core/src/modules/env/env.test.ts
+git commit -m "feat(core): add Env class with getString/getNumber/getBoolean/getRequired"
+```
+
+---
+
+### Task 3: Export Env and EnvSource from core
+
+**Files:**
+- Modify: `packages/core/src/modules/env/index.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Update env module exports**
+
+```typescript
+// packages/core/src/modules/env/index.ts
+export { Env } from './env';
+export { EnvConfig } from './env.config';
+export { EnvService } from './env.service';
+export { EnvSource } from './env-source';
+```
+
+- [ ] **Step 2: Update core package exports**
+
+In `packages/core/src/index.ts`, find line 114:
+```typescript
+export { EnvConfig, EnvService } from './modules/env';
+```
+
+Replace with:
+```typescript
+export { Env, EnvConfig, EnvService, EnvSource } from './modules/env';
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/modules/env/index.ts packages/core/src/index.ts
+git commit -m "feat(core): export Env and EnvSource"
+```
+
+---
+
+### Task 4: Create ProcessEnvSource in adapter-node
+
+**Files:**
+- Create: `packages/adapter-node/src/process-env-source.ts`
+
+- [ ] **Step 1: Create ProcessEnvSource class**
+
+```typescript
+// packages/adapter-node/src/process-env-source.ts
+import { Config, EnvSource } from '@zeltjs/core';
+
+@Config
+export class ProcessEnvSource extends EnvSource {
+  override get(key: string): string | undefined {
+    return process.env[key];
+  }
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapter-node/src/process-env-source.ts
+git commit -m "feat(adapter-node): add ProcessEnvSource"
+```
+
+---
+
+### Task 5: Update onNode to use ProcessEnvSource
+
+**Files:**
+- Modify: `packages/adapter-node/src/on-node.ts`
+
+- [ ] **Step 1: Update imports in on-node.ts**
+
+In `packages/adapter-node/src/on-node.ts`, find line 13:
+```typescript
+import { ProcessEnvConfig } from './process-env.config';
+```
+
+Replace with:
+```typescript
+import { ProcessEnvSource } from './process-env-source';
+```
+
+- [ ] **Step 2: Update addFallbackConfig call**
+
+In `packages/adapter-node/src/on-node.ts`, find line 208:
+```typescript
+  app.addFallbackConfig(ProcessEnvConfig);
+```
+
+Replace with:
+```typescript
+  app.addFallbackConfig(ProcessEnvSource);
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pnpm vitest run packages/adapter-node/src/on-node.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/adapter-node/src/on-node.ts
+git commit -m "refactor(adapter-node): use ProcessEnvSource in onNode"
+```
+
+---
+
+### Task 6: Export ProcessEnvSource from adapter-node
+
+**Files:**
+- Modify: `packages/adapter-node/src/index.ts`
+
+- [ ] **Step 1: Add ProcessEnvSource export**
+
+In `packages/adapter-node/src/index.ts`, add after line 6:
+```typescript
+export { ProcessEnvSource } from './process-env-source';
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapter-node/src/index.ts
+git commit -m "feat(adapter-node): export ProcessEnvSource"
+```
+
+---
+
+### Task 7: Deprecate old classes
+
+**Files:**
+- Modify: `packages/core/src/modules/env/env.config.ts`
+- Modify: `packages/core/src/modules/env/env.service.ts`
+- Modify: `packages/adapter-node/src/process-env.config.ts`
+- Modify: `packages/adapter-node/src/dotenv.config.ts`
+
+- [ ] **Step 1: Deprecate EnvConfig**
+
+```typescript
+// packages/core/src/modules/env/env.config.ts
+import { Config } from '../../config';
+
+/**
+ * @deprecated Use `inject(Env)` instead. Will be removed in next major version.
+ * @see Env
+ */
+@Config
+export class EnvConfig {
+  get(_key: string): string | undefined {
+    return undefined;
+  }
+}
+```
+
+- [ ] **Step 2: Deprecate EnvService**
+
+```typescript
+// packages/core/src/modules/env/env.service.ts
+import { inject } from '../../di/inject';
+import { Injectable } from '../../di/injectable';
+
+import { EnvConfig } from './env.config';
+
+/**
+ * @deprecated Use `inject(Env)` instead. Will be removed in next major version.
+ * @see Env
+ */
+@Injectable()
+export class EnvService {
+  constructor(private config = inject(EnvConfig)) {}
+
+  getString<D extends string | null | undefined>(key: string, defaultValue: D): string | D {
+    return this.config.get(key) ?? defaultValue;
+  }
+
+  getInteger<D extends number | null | undefined>(key: string, defaultValue: D): number | D {
+    const val = this.config.get(key);
+    if (val === undefined) return defaultValue;
+    const parsed = parseInt(val, 10);
+    if (Number.isNaN(parsed)) return defaultValue;
+    return parsed;
+  }
+
+  getBoolean<D extends boolean | null | undefined>(key: string, defaultValue: D): boolean | D {
+    const val = this.config.get(key);
+    if (val === undefined) return defaultValue;
+    return val === 'true' || val === '1';
+  }
+
+  isDevelopment(): boolean {
+    return this.getString('NODE_ENV', 'production') === 'development';
+  }
+
+  isProduction(): boolean {
+    return this.getString('NODE_ENV', 'production') === 'production';
+  }
+}
+```
+
+- [ ] **Step 3: Deprecate ProcessEnvConfig**
+
+```typescript
+// packages/adapter-node/src/process-env.config.ts
+import { Config, EnvConfig } from '@zeltjs/core';
+
+/**
+ * @deprecated Use `inject(Env)` instead. ProcessEnvSource is registered automatically by onNode().
+ * Will be removed in next major version.
+ * @see Env
+ */
+@Config
+export class ProcessEnvConfig extends EnvConfig {
+  override get(key: string): string | undefined {
+    return process.env[key];
+  }
+}
+```
+
+- [ ] **Step 4: Deprecate DotEnvConfig**
+
+```typescript
+// packages/adapter-node/src/dotenv.config.ts
+import { Config, EnvConfig } from '@zeltjs/core';
+import { config } from 'dotenv';
+
+/**
+ * @deprecated Use `import 'dotenv/config'` at your entry point instead.
+ * Will be removed in next major version.
+ *
+ * @example
+ * ```typescript
+ * // main.ts
+ * import 'dotenv/config';
+ * import { createApp } from '@zeltjs/core';
+ * ```
+ */
+@Config
+export class DotEnvConfig extends EnvConfig {
+  protected readonly paths: string[] = ['.env'];
+
+  constructor() {
+    super();
+    for (const path of this.paths) {
+      config({ path, override: true });
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/modules/env/env.config.ts packages/core/src/modules/env/env.service.ts packages/adapter-node/src/process-env.config.ts packages/adapter-node/src/dotenv.config.ts
+git commit -m "deprecate: mark EnvConfig, EnvService, ProcessEnvConfig, DotEnvConfig as deprecated"
+```
+
+---
+
+### Task 8: Run full test suite
+
+**Files:** None (validation only)
+
+- [ ] **Step 1: Run all tests**
+
+Run: `pnpm test`
+Expected: PASS
+
+- [ ] **Step 2: Run build**
+
+Run: `pnpm build`
+Expected: PASS
+
+- [ ] **Step 3: Run precommit**
+
+Run: `pnpm precommit`
+Expected: PASS
+
+---
+
+### Task 9: Update documentation
+
+**Files:**
+- Modify: `website/docs/configuration.md`
+
+- [ ] **Step 1: Update configuration documentation**
+
+In `website/docs/configuration.md`, update the examples to use `inject(Env)` instead of `inject(EnvConfig)`.
+
+Find all occurrences of:
+```typescript
+constructor(private env = inject(EnvConfig)) {}
+```
+
+Replace with:
+```typescript
+constructor(private env = inject(Env)) {}
+```
+
+Also update method calls:
+- `this.env.get('KEY')` → `this.env.getString('KEY')`
+- `this.env.get('KEY') ?? 'default'` → `this.env.getString('KEY', 'default')`
+
+Add a migration note at the top of the file after the frontmatter:
+
+```markdown
+:::info Migration Note
+As of version X.X, use `inject(Env)` instead of `inject(EnvConfig)` or `inject(EnvService)`.
+The old classes are deprecated and will be removed in the next major version.
+:::
+```
+
+- [ ] **Step 2: Verify docs build**
+
+Run: `cd website && pnpm build`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/docs/configuration.md
+git commit -m "docs: update configuration to use inject(Env)"
+```
+
+---
+
+## Summary
+
+After completing all tasks:
+1. Users can use `inject(Env)` with `getString`, `getNumber`, `getBoolean`, `getRequired`
+2. Old classes (`EnvConfig`, `EnvService`, `ProcessEnvConfig`, `DotEnvConfig`) are deprecated
+3. `.env` loading is user responsibility via `import 'dotenv/config'`
+4. `EnvSource` is internal, `ProcessEnvSource` is registered by `onNode()` automatically

--- a/docs/superpowers/specs/2026-05-22-env-simplification-design.md
+++ b/docs/superpowers/specs/2026-05-22-env-simplification-design.md
@@ -1,0 +1,152 @@
+# Env API Simplification Design
+
+## Summary
+
+Simplify the environment variable API by consolidating `EnvConfig` and `EnvService` into a single `Env` class, removing `DotEnvConfig`, and making `.env` file loading the user's responsibility.
+
+## Problem
+
+Current state has 4 classes with unclear roles:
+
+| Class | Package | Role |
+|-------|---------|------|
+| EnvConfig | core | Abstract base, `get()` only |
+| EnvService | core | Wrapper with `getString/getNumber/getBoolean` |
+| ProcessEnvConfig | adapter-node | Reads from `process.env` |
+| DotEnvConfig | adapter-node | Reads `.env` then `process.env` |
+
+User confusion:
+- Which to inject? `EnvConfig`? `EnvService`? `DotEnvConfig`?
+- What to register in `configs`?
+- How to specify custom `.env` paths?
+
+## Design
+
+### User-Facing API
+
+Single `Env` class with utility methods:
+
+```typescript
+import { Config, Env, inject } from '@zeltjs/core';
+
+@Config
+class AppConfig {
+  constructor(private env = inject(Env)) {}
+  
+  get port() { return this.env.getNumber('PORT', 3000); }
+  get apiKey() { return this.env.getRequired('API_KEY'); }
+  get debug() { return this.env.getBoolean('DEBUG', false); }
+}
+
+@Config
+class DatabaseConfig {
+  constructor(private env = inject(Env)) {}
+  
+  get host() { return this.env.getString('DB_HOST', 'localhost'); }
+  get port() { return this.env.getNumber('DB_PORT', 5432); }
+}
+```
+
+### Env Class Methods
+
+```typescript
+class Env {
+  getString(key: string, defaultValue?: string): string;
+  getNumber(key: string, defaultValue?: number): number;
+  getBoolean(key: string, defaultValue?: boolean): boolean;
+  getRequired(key: string): string;  // throws if missing
+}
+```
+
+### Internal Implementation
+
+```
+Env (core)
+  └── uses EnvSource (internal, not exposed)
+        ↑ ProcessEnvSource (adapter-node) - reads process.env
+        ↑ CloudflareEnvSource (adapter-cloudflare) - reads c.env
+```
+
+- `EnvSource` is an internal abstraction, not exposed to users
+- `onNode()` registers `ProcessEnvSource` automatically
+- `onCloudflareWorkers()` registers `CloudflareEnvSource` automatically
+
+### .env File Loading
+
+User responsibility, not framework's:
+
+```typescript
+// main.ts (Node.js entry point)
+import 'dotenv/config';  // standard dotenv usage
+
+const app = createApp({
+  http: { controllers: [AppController] },
+  configs: [AppConfig, DatabaseConfig],
+});
+
+await onNode(app);
+```
+
+For custom paths:
+```typescript
+import { config } from 'dotenv';
+config({ path: ['.env', '.env.local', '.env.staging'] });
+```
+
+### Platform Separation
+
+```
+Entry points (platform-dependent):
+├── main.ts (Node.js)
+│   import 'dotenv/config'
+│   await onNode(app)
+│
+└── worker.ts (Cloudflare Workers)
+    export default onCloudflareWorkers(app)
+
+Business logic (platform-independent):
+├── app.config.ts     → inject(Env)
+├── database.config.ts → inject(Env)
+└── ...
+```
+
+## Migration
+
+### Breaking Changes
+
+| Before | After | Action |
+|--------|-------|--------|
+| `inject(EnvConfig)` | `inject(Env)` | Rename |
+| `inject(EnvService)` | `inject(Env)` | Rename |
+| `inject(ProcessEnvConfig)` | `inject(Env)` | Rename |
+| `inject(DotEnvConfig)` | `inject(Env)` + `import 'dotenv/config'` | Change pattern |
+| `configs: [DotEnvConfig]` | Remove, add `import 'dotenv/config'` to entry | Change pattern |
+| `extends DotEnvConfig` with custom paths | Use `dotenv.config({ path: [...] })` | Change pattern |
+
+### Deprecation Strategy
+
+1. Add `Env` class with new API
+2. Mark `EnvConfig`, `EnvService`, `ProcessEnvConfig`, `DotEnvConfig` as `@deprecated`
+3. Remove deprecated classes in next major version
+
+## Removed Concepts
+
+| Removed | Reason |
+|---------|--------|
+| `EnvConfig` | Merged into `Env` |
+| `EnvService` | Merged into `Env` |
+| `ProcessEnvConfig` | Internal implementation (`ProcessEnvSource`) |
+| `DotEnvConfig` | User uses `dotenv` directly |
+
+## Benefits
+
+1. **Single injection target**: `inject(Env)` only
+2. **No framework coupling for .env**: Standard `dotenv` usage
+3. **Fewer concepts**: 4 classes → 1 class
+4. **Clear separation**: Entry point (platform-dependent) vs business logic (platform-independent)
+5. **Custom .env paths**: Use `dotenv` API directly, no framework workaround needed
+
+## Related
+
+- Issue: #e086d2a0
+- User feedback: 2026-05-21

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -247,7 +247,11 @@ export default tseslint.config(
   },
   {
     // Env module needs process.env access
-    files: ['packages/core/src/modules/env/env.service.ts'],
+    files: [
+      'packages/core/src/modules/env/env.service.ts',
+      // ProcessEnvSource reads process.env as Node.js environment adapter
+      'packages/adapter-node/src/process-env-source.ts',
+    ],
     rules: {
       '@9wick/strict-type-rules/no-process-access': 'off',
     },

--- a/packages/adapter-node/src/dotenv.config.ts
+++ b/packages/adapter-node/src/dotenv.config.ts
@@ -1,6 +1,17 @@
 import { Config, EnvConfig } from '@zeltjs/core';
 import { config } from 'dotenv';
 
+/**
+ * @deprecated Use `import 'dotenv/config'` at your entry point instead.
+ * Will be removed in next major version.
+ *
+ * @example
+ * ```typescript
+ * // main.ts
+ * import 'dotenv/config';
+ * import { createApp } from '@zeltjs/core';
+ * ```
+ */
 @Config
 export class DotEnvConfig extends EnvConfig {
   protected readonly paths: string[] = ['.env'];

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -4,5 +4,6 @@ export { DotEnvConfig } from './dotenv.config';
 export type { ServerHandle } from './on-node';
 export { onNode } from './on-node';
 export { ProcessEnvConfig } from './process-env.config';
+export { ProcessEnvSource } from './process-env-source';
 export type { AddressInfo, ServeOptions } from './serve';
 export { serveApp as serve } from './serve';

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -15,7 +15,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NodeCliConfig } from './cli.config';
 import type { CommandNodeApp, HttpNodeApp, SchedulerNodeAppPart, ServerHandle } from './on-node';
 import { onNode } from './on-node';
-import { ProcessEnvConfig } from './process-env.config';
+import { ProcessEnvSource } from './process-env-source';
 
 describe('onNode with HTTP', () => {
   let nodeApp: HttpNodeApp | undefined;
@@ -88,7 +88,7 @@ describe('onNode with HTTP', () => {
     expect(body.status).toBe('ok');
   });
 
-  it('auto-injects ProcessEnvConfig when EnvConfig token is in configs', async () => {
+  it('auto-injects ProcessEnvSource when EnvConfig token is in configs', async () => {
     const app = createApp({
       http: { controllers: [] },
       configs: [EnvConfig],
@@ -97,7 +97,7 @@ describe('onNode with HTTP', () => {
 
     nodeApp = await onNode(app);
 
-    expect(addFallbackConfigSpy).toHaveBeenCalledWith(ProcessEnvConfig);
+    expect(addFallbackConfigSpy).toHaveBeenCalledWith(ProcessEnvSource);
   });
 
   it('auto-injects NodeCliConfig when CliConfig token is in configs', async () => {

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -10,7 +10,7 @@ import type {
 } from '@zeltjs/core';
 
 import { NodeCliConfig } from './cli.config';
-import { ProcessEnvConfig } from './process-env.config';
+import { ProcessEnvSource } from './process-env-source';
 
 type ListenOptions = {
   readonly port?: number;
@@ -205,7 +205,7 @@ export function onNode(app: CommandApp, options?: NodeAppOptions): Promise<Comma
 /** @throws {ZeltLifecycleStateError} */
 export async function onNode(app: AnyApp, options: NodeAppOptions = {}): Promise<NodeApp> {
   app.addFallbackConfig(NodeCliConfig);
-  app.addFallbackConfig(ProcessEnvConfig);
+  app.addFallbackConfig(ProcessEnvSource);
 
   const readyOptions: ReadyOptions = { warmup: options.warmup ?? true };
   const resolver = await app.ready(readyOptions);

--- a/packages/adapter-node/src/process-env-source.ts
+++ b/packages/adapter-node/src/process-env-source.ts
@@ -1,0 +1,8 @@
+import { Config, EnvSource } from '@zeltjs/core';
+
+@Config
+export class ProcessEnvSource extends EnvSource {
+  override get(key: string): string | undefined {
+    return process.env[key];
+  }
+}

--- a/packages/adapter-node/src/process-env.config.ts
+++ b/packages/adapter-node/src/process-env.config.ts
@@ -1,5 +1,10 @@
 import { Config, EnvConfig } from '@zeltjs/core';
 
+/**
+ * @deprecated Use `inject(Env)` instead. ProcessEnvSource is registered automatically by onNode().
+ * Will be removed in next major version.
+ * @see Env
+ */
 @Config
 export class ProcessEnvConfig extends EnvConfig {
   override get(key: string): string | undefined {

--- a/packages/core/src/errors/classes.ts
+++ b/packages/core/src/errors/classes.ts
@@ -32,3 +32,6 @@ export type ZeltCommandArgumentError = InstanceType<typeof ZeltCommandArgumentEr
 
 export const ZeltCommandExecutionError = createErrorClass('ZeltCommandExecutionError');
 export type ZeltCommandExecutionError = InstanceType<typeof ZeltCommandExecutionError>;
+
+export const ZeltEnvError = createErrorClass('ZeltEnvError');
+export type ZeltEnvError = InstanceType<typeof ZeltEnvError>;

--- a/packages/core/src/errors/definitions.ts
+++ b/packages/core/src/errors/definitions.ts
@@ -78,6 +78,9 @@ export const coreErrorDefinitions = {
       .with('argv_parse_error', () => `Failed to parse arguments: ${ctx.details ?? ''}`)
       .with('run_error', () => `Command execution failed: ${ctx.details ?? ''}`)
       .exhaustive(),
+
+  ZeltEnvError: (ctx: { key: string; reason: 'required_not_set' }) =>
+    `Required environment variable ${ctx.key} is not set`,
 } as const;
 
 export type CoreErrorContextMap = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,7 +111,7 @@ export type { Disposable, Lifecycle } from './lifecycle';
 export { LifecycleManager } from './lifecycle';
 export type { Signal, SignalHandler } from './modules/cli';
 export { CliConfig } from './modules/cli';
-export { EnvConfig, EnvService } from './modules/env';
+export { Env, EnvConfig, EnvService, EnvSource } from './modules/env';
 export type {
   LogContext,
   LogEntry,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,7 @@ export {
   ZeltCommandExecutionError,
   ZeltContextNotAvailableError,
   ZeltDecoratorUsageError,
+  ZeltEnvError,
   ZeltLifecycleStateError,
   ZeltMiddlewareExecutionError,
   ZeltNotImplementedError,

--- a/packages/core/src/modules/env/env-source.ts
+++ b/packages/core/src/modules/env/env-source.ts
@@ -1,0 +1,8 @@
+import { Config } from '../../config';
+
+@Config
+export class EnvSource {
+  get(_key: string): string | undefined {
+    return undefined;
+  }
+}

--- a/packages/core/src/modules/env/env-source.ts
+++ b/packages/core/src/modules/env/env-source.ts
@@ -1,5 +1,8 @@
 import { Config } from '../../config';
 
+/**
+ * @internal Platform adapters extend this class; end users should use inject(Env) instead.
+ */
 @Config
 export class EnvSource {
   get(_key: string): string | undefined {

--- a/packages/core/src/modules/env/env.config.ts
+++ b/packages/core/src/modules/env/env.config.ts
@@ -1,5 +1,9 @@
 import { Config } from '../../config';
 
+/**
+ * @deprecated Use `inject(Env)` instead. Will be removed in next major version.
+ * @see Env
+ */
 @Config
 export class EnvConfig {
   get(_key: string): string | undefined {

--- a/packages/core/src/modules/env/env.service.ts
+++ b/packages/core/src/modules/env/env.service.ts
@@ -3,6 +3,10 @@ import { Injectable } from '../../di/injectable';
 
 import { EnvConfig } from './env.config';
 
+/**
+ * @deprecated Use `inject(Env)` instead. Will be removed in next major version.
+ * @see Env
+ */
 @Injectable()
 export class EnvService {
   constructor(private config = inject(EnvConfig)) {}

--- a/packages/core/src/modules/env/env.test.ts
+++ b/packages/core/src/modules/env/env.test.ts
@@ -1,0 +1,107 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Config } from '../../config';
+import { createTestTargetBase } from '../../di/container';
+
+import { Env } from './env';
+import { EnvSource } from './env-source';
+
+@Config
+class TestEnvSource extends EnvSource {
+  override get(key: string): string | undefined {
+    return process.env[key];
+  }
+}
+
+let env: Env;
+
+const setupEnv = async () => {
+  const result = await createTestTargetBase(Env, {
+    configs: [TestEnvSource],
+  });
+  env = result.target;
+  return result;
+};
+
+describe('Env', () => {
+  beforeAll(async () => {
+    await setupEnv();
+  });
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('getString', () => {
+    it('returns env value when exists', () => {
+      vi.stubEnv('TEST_KEY', 'test_value');
+      expect(env.getString('TEST_KEY', 'default')).toBe('test_value');
+    });
+
+    it('returns default when env not exists', () => {
+      expect(env.getString('NOT_EXISTS', 'default')).toBe('default');
+    });
+
+    it('returns empty string when no default and env not exists', () => {
+      expect(env.getString('NOT_EXISTS')).toBe('');
+    });
+  });
+
+  describe('getNumber', () => {
+    it('returns parsed number when env exists', () => {
+      vi.stubEnv('PORT', '3000');
+      expect(env.getNumber('PORT', 8080)).toBe(3000);
+    });
+
+    it('returns default when env not exists', () => {
+      expect(env.getNumber('NOT_EXISTS', 8080)).toBe(8080);
+    });
+
+    it('returns default when env is not a valid number', () => {
+      vi.stubEnv('INVALID', 'not_a_number');
+      expect(env.getNumber('INVALID', 8080)).toBe(8080);
+    });
+
+    it('returns 0 when no default and env not exists', () => {
+      expect(env.getNumber('NOT_EXISTS')).toBe(0);
+    });
+  });
+
+  describe('getBoolean', () => {
+    it('returns true when env is "true"', () => {
+      vi.stubEnv('ENABLED', 'true');
+      expect(env.getBoolean('ENABLED', false)).toBe(true);
+    });
+
+    it('returns true when env is "1"', () => {
+      vi.stubEnv('ENABLED', '1');
+      expect(env.getBoolean('ENABLED', false)).toBe(true);
+    });
+
+    it('returns false when env is other value', () => {
+      vi.stubEnv('ENABLED', 'false');
+      expect(env.getBoolean('ENABLED', true)).toBe(false);
+    });
+
+    it('returns default when env not exists', () => {
+      expect(env.getBoolean('NOT_EXISTS', true)).toBe(true);
+    });
+
+    it('returns false when no default and env not exists', () => {
+      expect(env.getBoolean('NOT_EXISTS')).toBe(false);
+    });
+  });
+
+  describe('getRequired', () => {
+    it('returns env value when exists', () => {
+      vi.stubEnv('API_KEY', 'secret123');
+      expect(env.getRequired('API_KEY')).toBe('secret123');
+    });
+
+    it('throws when env not exists', () => {
+      expect(() => env.getRequired('NOT_EXISTS')).toThrow(
+        'Required environment variable NOT_EXISTS is not set',
+      );
+    });
+  });
+});

--- a/packages/core/src/modules/env/env.ts
+++ b/packages/core/src/modules/env/env.ts
@@ -1,0 +1,37 @@
+import { inject } from '../../di/inject';
+import { Injectable } from '../../di/injectable';
+import { ZeltEnvError } from '../../errors';
+
+import { EnvSource } from './env-source';
+
+@Injectable()
+export class Env {
+  constructor(private source = inject(EnvSource)) {}
+
+  getString(key: string, defaultValue: string = ''): string {
+    return this.source.get(key) ?? defaultValue;
+  }
+
+  getNumber(key: string, defaultValue: number = 0): number {
+    const val = this.source.get(key);
+    if (val === undefined) return defaultValue;
+    const parsed = Number(val);
+    if (Number.isNaN(parsed)) return defaultValue;
+    return parsed;
+  }
+
+  getBoolean(key: string, defaultValue: boolean = false): boolean {
+    const val = this.source.get(key);
+    if (val === undefined) return defaultValue;
+    return val === 'true' || val === '1';
+  }
+
+  /** @throws {ZeltEnvError} */
+  getRequired(key: string): string {
+    const val = this.source.get(key);
+    if (val === undefined) {
+      throw new ZeltEnvError({ key, reason: 'required_not_set' });
+    }
+    return val;
+  }
+}

--- a/packages/core/src/modules/env/index.ts
+++ b/packages/core/src/modules/env/index.ts
@@ -1,2 +1,4 @@
+export { Env } from './env';
 export { EnvConfig } from './env.config';
 export { EnvService } from './env.service';
+export { EnvSource } from './env-source';

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -5,25 +5,30 @@
 
 Zelt provides a type-safe configuration system using the `@Config` decorator and `inject()` helper.
 
+:::info Migration Note
+As of version X.X, use `inject(Env)` instead of `inject(EnvConfig)` or `inject(EnvService)`.
+The old classes are deprecated and will be removed in the next major version.
+:::
+
 ## Defining Configuration
 
 Use the `@Config` decorator to define a configuration class. Each config class must have a static `Token` property:
 
 ```typescript
-import { Config, EnvConfig, inject } from '@zeltjs/core';
+import { Config, Env, inject } from '@zeltjs/core';
 
 @Config
 export class DatabaseConfig {
   static readonly Token = DatabaseConfig;
 
-  constructor(private env = inject(EnvConfig)) {}
+  constructor(private env = inject(Env)) {}
 
   get host() {
-    return this.env.get('DATABASE_HOST') ?? 'localhost';
+    return this.env.getString('DATABASE_HOST', 'localhost');
   }
 
   get port() {
-    return Number(this.env.get('DATABASE_PORT') ?? 5432);
+    return this.env.getNumber('DATABASE_PORT', 5432);
   }
 
   get connectionString() {
@@ -37,14 +42,14 @@ export class DatabaseConfig {
 Inject configuration into services or controllers using `inject()`:
 
 ```typescript
-import { Injectable, inject, Config, EnvConfig } from '@zeltjs/core';
+import { Injectable, inject, Config, Env } from '@zeltjs/core';
 
 @Config
 class DatabaseConfig {
   static readonly Token = DatabaseConfig;
-  constructor(private env = inject(EnvConfig)) {}
-  get host() { return this.env.get('DATABASE_HOST') ?? 'localhost'; }
-  get port() { return Number(this.env.get('DATABASE_PORT') ?? 5432); }
+  constructor(private env = inject(Env)) {}
+  get host() { return this.env.getString('DATABASE_HOST', 'localhost'); }
+  get port() { return this.env.getNumber('DATABASE_PORT', 5432); }
   get connectionString() { return `postgres://${this.host}:${this.port}/mydb`; }
 }
 // ---cut---
@@ -63,14 +68,14 @@ export class DatabaseService {
 Register config classes when creating the app:
 
 ```typescript
-import { createApp, Config, EnvConfig, inject, Controller, Get } from '@zeltjs/core';
+import { createApp, Config, Env, inject, Controller, Get } from '@zeltjs/core';
 
 @Config
 class DatabaseConfig {
   static readonly Token = DatabaseConfig;
-  constructor(private env = inject(EnvConfig)) {}
-  get host() { return this.env.get('DATABASE_HOST') ?? 'localhost'; }
-  get port() { return Number(this.env.get('DATABASE_PORT') ?? 5432); }
+  constructor(private env = inject(Env)) {}
+  get host() { return this.env.getString('DATABASE_HOST', 'localhost'); }
+  get port() { return this.env.getNumber('DATABASE_PORT', 5432); }
   get connectionString() { return `postgres://${this.host}:${this.port}/mydb`; }
 }
 @Controller('/') class AppController { @Get('/') index() { return { ok: true }; } }
@@ -88,14 +93,14 @@ const app = createApp({
 Override configuration values for testing by extending the config class:
 
 ```typescript
-import { Config, createApp, EnvConfig, inject } from '@zeltjs/core';
+import { Config, createApp, Env, inject } from '@zeltjs/core';
 declare class AppController {}
 @Config
 class DatabaseConfig {
   static readonly Token = DatabaseConfig;
-  constructor(private env = inject(EnvConfig)) {}
-  get host() { return this.env.get('DATABASE_HOST') ?? 'localhost'; }
-  get port() { return Number(this.env.get('DATABASE_PORT') ?? 5432); }
+  constructor(private env = inject(Env)) {}
+  get host() { return this.env.getString('DATABASE_HOST', 'localhost'); }
+  get port() { return this.env.getNumber('DATABASE_PORT', 5432); }
   get connectionString() { return `postgres://${this.host}:${this.port}/mydb`; }
 }
 // ---cut---
@@ -123,19 +128,14 @@ The `Token` property is inherited from the parent class, so `inject(DatabaseConf
 
 ## Environment-Based Configuration
 
-Zelt provides environment configuration through platform-specific adapters.
+`inject(Env)` reads environment variables from the platform-specific source registered by the adapter. No additional setup is needed for the common case.
 
 ### Node.js Environment
 
-For Node.js applications, use the configs from `@zeltjs/adapter-node`:
-
-#### ProcessEnvConfig
-
-Reads from `process.env` directly:
+When using `onNode()`, `ProcessEnvSource` is registered automatically, so `inject(Env)` reads from `process.env` without any extra config:
 
 ```typescript
-import { Config, inject, createApp, Controller, Get } from '@zeltjs/core';
-import { ProcessEnvConfig } from '@zeltjs/adapter-node';
+import { Config, Env, inject, createApp, Controller, Get } from '@zeltjs/core';
 
 @Controller('/') class AppController { @Get('/') index() { return { ok: true }; } }
 // ---cut---
@@ -143,14 +143,14 @@ import { ProcessEnvConfig } from '@zeltjs/adapter-node';
 export class DatabaseConfig {
   static readonly Token = DatabaseConfig;
 
-  constructor(private env = inject(ProcessEnvConfig)) {}
+  constructor(private env = inject(Env)) {}
 
   get host() {
-    return this.env.get('DATABASE_HOST') ?? 'localhost';
+    return this.env.getString('DATABASE_HOST', 'localhost');
   }
 
   get port() {
-    return Number(this.env.get('DATABASE_PORT') ?? 5432);
+    return this.env.getNumber('DATABASE_PORT', 5432);
   }
 
   get connectionString() {
@@ -158,58 +158,26 @@ export class DatabaseConfig {
   }
 }
 
-// Register both configs
 const app = createApp({
   http: {
     controllers: [AppController],
   },
-  configs: [ProcessEnvConfig, DatabaseConfig],
+  configs: [DatabaseConfig],
 });
 ```
 
-#### DotEnvConfig
+### Loading `.env` Files
 
-Loads `.env` files using [dotenv](https://github.com/motdotla/dotenv), then reads from `process.env`:
-
-```typescript
-import { Config, inject, createApp, Controller, Get } from '@zeltjs/core';
-import { DotEnvConfig } from '@zeltjs/adapter-node';
-
-@Controller('/') class AppController { @Get('/') index() { return { ok: true }; } }
-// ---cut---
-@Config
-export class DatabaseConfig {
-  static readonly Token = DatabaseConfig;
-
-  constructor(private env = inject(DotEnvConfig)) {}
-
-  get host() {
-    return this.env.get('DATABASE_HOST') ?? 'localhost';
-  }
-}
-
-// DotEnvConfig loads .env on construction
-const app = createApp({
-  http: {
-    controllers: [AppController],
-  },
-  configs: [DotEnvConfig, DatabaseConfig],
-});
-```
-
-#### Custom Env Paths
-
-Extend `DotEnvConfig` to load from custom paths:
+To load a `.env` file, import `dotenv/config` at the entry point of your application before anything else:
 
 ```typescript
-import { Config } from '@zeltjs/core';
-import { DotEnvConfig } from '@zeltjs/adapter-node';
-// ---cut---
-@Config
-export class MyEnvConfig extends DotEnvConfig {
-  protected override readonly paths = ['.env', '.env.local'];
-}
+// @errors: 2882
+import 'dotenv/config';
+import { onNode } from '@zeltjs/adapter-node';
+// ...rest of app setup
 ```
+
+`inject(Env)` will then read the variables populated by dotenv from `process.env`.
 
 ### Cloudflare Workers Environment
 
@@ -254,4 +222,3 @@ Zelt automatically detects the decorator mode based on the runtime context:
 - **Legacy mode**: Decorator receives `target`, `propertyKey`, and `descriptor` arguments
 
 Both modes work identically from an API perspective—you don't need to change your code when switching between them.
-


### PR DESCRIPTION
## Summary

- Consolidated 4 confusing classes (`EnvConfig`, `EnvService`, `ProcessEnvConfig`, `DotEnvConfig`) into single `inject(Env)` entry point
- Added typed accessor methods: `getString`, `getNumber`, `getBoolean`, `getRequired`
- Made `.env` file loading user responsibility via standard `import 'dotenv/config'`
- Deprecated old classes with migration guidance

## Motivation

User feedback indicated confusion about which class to inject and how to configure environment variables. The new API is simpler:

```typescript
@Config
class AppConfig {
  constructor(private env = inject(Env)) {}
  
  get port() { return this.env.getNumber('PORT', 3000); }
  get apiKey() { return this.env.getRequired('API_KEY'); }
}
```

## Changes

| Before | After |
|--------|-------|
| `inject(EnvConfig)` | `inject(Env)` |
| `inject(EnvService)` | `inject(Env)` |
| `inject(ProcessEnvConfig)` | `inject(Env)` (auto-registered by onNode) |
| `configs: [DotEnvConfig]` | `import 'dotenv/config'` at entry point |

## Test plan

- [x] All 552 tests pass
- [x] Typecheck passes
- [x] Build passes
- [x] Documentation updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782039412&installation_id=133048706&pr_number=194&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F194&signature=92689f649a0a0bd54d434c92c8fe9c5caa795f5cf0447882d4d12999dc54c8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified Env API for typed access to environment variables: getString, getNumber, getBoolean, and getRequired (throws when missing).

* **Deprecations**
  * Legacy environment configuration classes marked deprecated and slated for removal; migration guidance provided (use the new Env and load .env at app entry).

* **Documentation**
  * Updated configuration docs with migration examples and simplified .env loading.

* **Tests**
  * Added test coverage validating Env behaviors and defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->