### PR TITLE
fix(validator-valibot): make @valibot/to-json-schema optional peer

### DIFF
--- a/packages/validator-valibot/package.json
+++ b/packages/validator-valibot/package.json
@@ -39,6 +39,9 @@
   "peerDependenciesMeta": {
     "@zeltjs/openapi": {
       "optional": true
+    },
+    "@valibot/to-json-schema": {
+      "optional": true
     }
   },
   "devDependencies": {

--- a/website/docs/openapi.md
+++ b/website/docs/openapi.md
@@ -14,7 +14,7 @@ The `@zeltjs/openapi` package analyzes your controller method signatures at buil
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs>
+<Tabs groupId="pkg-manager">
   <TabItem value="npm" label="npm" default>
     ```bash
     npm install @zeltjs/openapi
@@ -36,7 +36,7 @@ import TabItem from '@theme/TabItem';
 
 If you're using `@zeltjs/validator-valibot`, you also need `@valibot/to-json-schema`:
 
-<Tabs>
+<Tabs groupId="pkg-manager">
   <TabItem value="npm" label="npm" default>
     ```bash
     npm install @zeltjs/openapi @valibot/to-json-schema

--- a/website/docs/openapi.md
+++ b/website/docs/openapi.md
@@ -11,9 +11,52 @@ The `@zeltjs/openapi` package analyzes your controller method signatures at buil
 
 ## Installation
 
-```bash
-pnpm add @zeltjs/openapi
-```
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm install @zeltjs/openapi
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm add @zeltjs/openapi
+    ```
+  </TabItem>
+  <TabItem value="bun" label="bun">
+    ```bash
+    bun add @zeltjs/openapi
+    ```
+  </TabItem>
+</Tabs>
+
+### With @zeltjs/validator-valibot
+
+If you're using `@zeltjs/validator-valibot`, you also need `@valibot/to-json-schema`:
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm install @zeltjs/openapi @valibot/to-json-schema
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm add @zeltjs/openapi @valibot/to-json-schema
+    ```
+  </TabItem>
+  <TabItem value="bun" label="bun">
+    ```bash
+    bun add @zeltjs/openapi @valibot/to-json-schema
+    ```
+  </TabItem>
+</Tabs>
+
+:::tip Version Compatibility
+`@valibot/to-json-schema` must match your `valibot` version. See [Validation - Installation](./validation.md#installation) for details.
+:::
 
 ## Configuration
 

--- a/website/docs/validation.md
+++ b/website/docs/validation.md
@@ -7,9 +7,56 @@ Zelt uses [Valibot](https://valibot.dev/) for request validation, providing a ty
 
 ## Installation
 
-```bash
-pnpm add @zeltjs/validator-valibot valibot
-```
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm install @zeltjs/validator-valibot valibot
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm add @zeltjs/validator-valibot valibot
+    ```
+  </TabItem>
+  <TabItem value="bun" label="bun">
+    ```bash
+    bun add @zeltjs/validator-valibot valibot
+    ```
+  </TabItem>
+</Tabs>
+
+### With OpenAPI Generation
+
+If you're using `@zeltjs/openapi` to generate OpenAPI specs, you also need `@valibot/to-json-schema`:
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm install @zeltjs/validator-valibot valibot @valibot/to-json-schema
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm add @zeltjs/validator-valibot valibot @valibot/to-json-schema
+    ```
+  </TabItem>
+  <TabItem value="bun" label="bun">
+    ```bash
+    bun add @zeltjs/validator-valibot valibot @valibot/to-json-schema
+    ```
+  </TabItem>
+</Tabs>
+
+:::tip Version Compatibility
+`@valibot/to-json-schema` must match your `valibot` version. For example:
+- `valibot@1.4.x` → `@valibot/to-json-schema@1.7.x`
+- `valibot@1.3.x` → `@valibot/to-json-schema@1.6.x`
+
+Check the [@valibot/to-json-schema releases](https://github.com/fabian-hiller/valibot/releases) for compatibility.
+:::
 
 ## Basic Usage
 

--- a/website/docs/validation.md
+++ b/website/docs/validation.md
@@ -10,7 +10,7 @@ Zelt uses [Valibot](https://valibot.dev/) for request validation, providing a ty
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs>
+<Tabs groupId="pkg-manager">
   <TabItem value="npm" label="npm" default>
     ```bash
     npm install @zeltjs/validator-valibot valibot
@@ -32,7 +32,7 @@ import TabItem from '@theme/TabItem';
 
 If you're using `@zeltjs/openapi` to generate OpenAPI specs, you also need `@valibot/to-json-schema`:
 
-<Tabs>
+<Tabs groupId="pkg-manager">
   <TabItem value="npm" label="npm" default>
     ```bash
     npm install @zeltjs/validator-valibot valibot @valibot/to-json-schema

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/openapi.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/openapi.md
@@ -14,7 +14,7 @@ The `@zeltjs/openapi` package analyzes your controller method signatures at buil
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs>
+<Tabs groupId="pkg-manager">
   <TabItem value="npm" label="npm" default>
     ```bash
     npm install @zeltjs/openapi
@@ -36,7 +36,7 @@ import TabItem from '@theme/TabItem';
 
 `@zeltjs/validator-valibot` を使っている場合、`@valibot/to-json-schema` も必要です：
 
-<Tabs>
+<Tabs groupId="pkg-manager">
   <TabItem value="npm" label="npm" default>
     ```bash
     npm install @zeltjs/openapi @valibot/to-json-schema

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/openapi.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/openapi.md
@@ -11,9 +11,52 @@ The `@zeltjs/openapi` package analyzes your controller method signatures at buil
 
 ## Installation
 
-```bash
-pnpm add @zeltjs/openapi
-```
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm install @zeltjs/openapi
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm add @zeltjs/openapi
+    ```
+  </TabItem>
+  <TabItem value="bun" label="bun">
+    ```bash
+    bun add @zeltjs/openapi
+    ```
+  </TabItem>
+</Tabs>
+
+### @zeltjs/validator-valibot と併用する場合
+
+`@zeltjs/validator-valibot` を使っている場合、`@valibot/to-json-schema` も必要です：
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm install @zeltjs/openapi @valibot/to-json-schema
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm add @zeltjs/openapi @valibot/to-json-schema
+    ```
+  </TabItem>
+  <TabItem value="bun" label="bun">
+    ```bash
+    bun add @zeltjs/openapi @valibot/to-json-schema
+    ```
+  </TabItem>
+</Tabs>
+
+:::tip バージョン互換性
+`@valibot/to-json-schema` は `valibot` のバージョンと合わせる必要があります。詳細は [Validation - Installation](./validation.md#installation) を参照してください。
+:::
 
 ## Configuration
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/validation.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/validation.md
@@ -10,7 +10,7 @@ Zelt uses [Valibot](https://valibot.dev/) for request validation, providing a ty
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs>
+<Tabs groupId="pkg-manager">
   <TabItem value="npm" label="npm" default>
     ```bash
     npm install @zeltjs/validator-valibot valibot
@@ -32,7 +32,7 @@ import TabItem from '@theme/TabItem';
 
 `@zeltjs/openapi` で OpenAPI スペックを生成する場合は、`@valibot/to-json-schema` も必要です：
 
-<Tabs>
+<Tabs groupId="pkg-manager">
   <TabItem value="npm" label="npm" default>
     ```bash
     npm install @zeltjs/validator-valibot valibot @valibot/to-json-schema

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/validation.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/validation.md
@@ -7,9 +7,56 @@ Zelt uses [Valibot](https://valibot.dev/) for request validation, providing a ty
 
 ## Installation
 
-```bash
-pnpm add @zeltjs/validator-valibot valibot
-```
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm install @zeltjs/validator-valibot valibot
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm add @zeltjs/validator-valibot valibot
+    ```
+  </TabItem>
+  <TabItem value="bun" label="bun">
+    ```bash
+    bun add @zeltjs/validator-valibot valibot
+    ```
+  </TabItem>
+</Tabs>
+
+### OpenAPI 生成を使う場合
+
+`@zeltjs/openapi` で OpenAPI スペックを生成する場合は、`@valibot/to-json-schema` も必要です：
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm install @zeltjs/validator-valibot valibot @valibot/to-json-schema
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm add @zeltjs/validator-valibot valibot @valibot/to-json-schema
+    ```
+  </TabItem>
+  <TabItem value="bun" label="bun">
+    ```bash
+    bun add @zeltjs/validator-valibot valibot @valibot/to-json-schema
+    ```
+  </TabItem>
+</Tabs>
+
+:::tip バージョン互換性
+`@valibot/to-json-schema` は `valibot` のバージョンと合わせる必要があります。例：
+- `valibot@1.4.x` → `@valibot/to-json-schema@1.7.x`
+- `valibot@1.3.x` → `@valibot/to-json-schema@1.6.x`
+
+互換性については [@valibot/to-json-schema releases](https://github.com/fabian-hiller/valibot/releases) を参照してください。
+:::
 
 ## Basic Usage
 


### PR DESCRIPTION
## Summary

- Make `@valibot/to-json-schema` an optional peer dependency in `@zeltjs/validator-valibot`
- Users can now choose their valibot version freely without ERESOLVE conflicts
- `@valibot/to-json-schema` is only required when using `@zeltjs/openapi` together with `@zeltjs/validator-valibot`
- Update installation docs (EN/JA) with npm/pnpm/bun tabs and version compatibility notes

## Test plan

- [x] `pnpm --filter @zeltjs/validator-valibot test` passes
- [x] Website build succeeds

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782103848&installation_id=133048706&pr_number=196&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F196&signature=20bb56a7b14edd067e2ea94351cec0e8ae0e816d69a6ab58ba2b677b05e6491e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded installation guides with tabbed code examples for npm, pnpm, and bun in English and Japanese
  * Added explicit installation instructions for OpenAPI generation and validator integration
  * Added version-compatibility guidance for pairing validator and schema-generation packages

* **Chores**
  * Marked the schema-generation peer dependency as optional in package metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->