### PR TITLE
docs(website): embed sidebar navigation JSON for AI discovery

### DIFF
--- a/website/src/theme/DocItem/Layout/index.tsx
+++ b/website/src/theme/DocItem/Layout/index.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import {useWindowSize} from '@docusaurus/theme-common';
 import {useDocsSidebar} from '@docusaurus/plugin-content-docs/client';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import DocItemPaginator from '@theme/DocItem/Paginator';
 import DocVersionBanner from '@theme/DocVersionBanner';
 import DocVersionBadge from '@theme/DocVersionBadge';
@@ -13,8 +14,30 @@ import DocItemContent from '@theme/DocItem/Content';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import ContentVisibility from '@theme/ContentVisibility';
 import type {Props} from '@theme/DocItem/Layout';
+import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
 
 import styles from './styles.module.css';
+
+const normalizeHref = (href: string, siteUrl: string): string => {
+  if (href.startsWith('pathname:///')) {
+    return `${siteUrl}${href.replace('pathname://', '')}`;
+  }
+  return href;
+};
+
+const normalizeSidebarItems = (
+  items: PropSidebarItem[],
+  siteUrl: string,
+): PropSidebarItem[] =>
+  items.map((item) => {
+    if (item.type === 'link' && item.href) {
+      return {...item, href: normalizeHref(item.href, siteUrl)};
+    }
+    if (item.type === 'category' && item.items) {
+      return {...item, items: normalizeSidebarItems(item.items, siteUrl)};
+    }
+    return item;
+  });
 
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
@@ -44,13 +67,18 @@ export default function DocItemLayout({children}: Props): ReactNode {
   const docTOC = useDocTOC();
   const {metadata} = useDoc();
   const sidebar = useDocsSidebar();
+  const {siteConfig} = useDocusaurusContext();
+  const siteUrl = siteConfig.url;
+  const normalizedItems = sidebar?.items
+    ? normalizeSidebarItems(sidebar.items, siteUrl)
+    : [];
   return (
     <div className="row">
       <script
         id="zelt-docs-nav"
         type="application/json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(sidebar?.items),
+          __html: JSON.stringify(normalizedItems),
         }}
       />
       <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>

--- a/website/src/theme/DocItem/Layout/index.tsx
+++ b/website/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,73 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {useWindowSize} from '@docusaurus/theme-common';
+import {useDocsSidebar} from '@docusaurus/plugin-content-docs/client';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import DocItemPaginator from '@theme/DocItem/Paginator';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocItemFooter from '@theme/DocItem/Footer';
+import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
+import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
+import DocItemContent from '@theme/DocItem/Content';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import ContentVisibility from '@theme/ContentVisibility';
+import type {Props} from '@theme/DocItem/Layout';
+
+import styles from './styles.module.css';
+
+/**
+ * Decide if the toc should be rendered, on mobile or desktop viewports
+ */
+function useDocTOC() {
+  const {frontMatter, toc} = useDoc();
+  const windowSize = useWindowSize();
+
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+
+  const desktop =
+    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+
+  return {
+    hidden,
+    mobile,
+    desktop,
+  };
+}
+
+export default function DocItemLayout({children}: Props): ReactNode {
+  const docTOC = useDocTOC();
+  const {metadata} = useDoc();
+  const sidebar = useDocsSidebar();
+  return (
+    <div className="row">
+      <script
+        id="zelt-docs-nav"
+        type="application/json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(sidebar?.items),
+        }}
+      />
+      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+        <ContentVisibility metadata={metadata} />
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            {docTOC.mobile}
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/website/src/theme/DocItem/Layout/styles.module.css
+++ b/website/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Swizzle `DocItem/Layout` to inject sidebar items as JSON in a `<script id="zelt-docs-nav">` tag
- Enables AI agents (WebFetch) to discover `llms.txt` via structured navigation data
- Addresses issue where WebFetch summaries drop `<head>` metadata and sidebar HTML structure

## Background

WebFetch summarizes HTML and loses:
- `<head>` metadata (including `<link rel="alternate">` to llms.txt)
- Sidebar HTML structure

VitePress embeds navigation as `window.__VP_SITE_DATA__` which survives summarization. This change brings equivalent capability to Docusaurus.

## Test plan

- [x] Build succeeds (`pnpm run build`)
- [x] JSON embedded in `<main>` content of built HTML
- [x] `llms.txt` reference included in navigation JSON

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782106362&installation_id=133048706&pr_number=197&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F197&signature=aeadc7dd36c77fb4f88014907a75754951ab8789d152899430ca068ef4e0c3da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs layout now shows breadcrumbs, version banner/badge, paginator, and conditional table of contents that adapts to mobile/desktop and hides when empty.
  * Progressive content loading/gating for faster-perceived page rendering and improved sidebar navigation data for consistent doc links.

* **Style**
  * Tweaked spacing and column width to improve documentation readability across viewports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->