### PR TITLE
refactor(decorator-metadata): defer stack trace parsing to inspect time

### DIFF
--- a/.gwq.toml
+++ b/.gwq.toml
@@ -3,5 +3,5 @@ repository = '.'
 copy_files = ['lefthook-local.yml', '.codepolicy/cache/*']
 setup_commands = [
   'pnpm i',
-  './scripts/gwq-bg-build.sh $PWD',
+  'sh ./scripts/gwq-bg-build.sh',
 ]

--- a/packages/core/src/command/decorator.ts
+++ b/packages/core/src/command/decorator.ts
@@ -1,6 +1,6 @@
 import { registerAsTransient } from '../di/transient';
 import { defineInjectableClassDecorator } from '../internal/decorator-helpers';
-import { getCallerPositionForCore } from '../internal/decorator-position';
+import { captureStackTraceForCore } from '../internal/decorator-position';
 
 type CommandOptions = {
   readonly name: string;
@@ -9,7 +9,7 @@ type CommandOptions = {
 
 export const Command = (options: CommandOptions) =>
   defineInjectableClassDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     options.description
       ? {
           decorator: 'Command' as const,

--- a/packages/core/src/config/decorator.ts
+++ b/packages/core/src/config/decorator.ts
@@ -1,10 +1,9 @@
-import { injectable } from '@needle-di/core';
-
 import { registerAsLeaf } from '../di/leaf';
+import { defineInjectableClassDecorator } from '../internal/decorator-helpers';
 
-type AnyConstructor = new (...args: never[]) => unknown;
-
-export const Config = (target: AnyConstructor): void => {
-  registerAsLeaf(target);
-  injectable()(target);
-};
+export const Config = defineInjectableClassDecorator(
+  undefined,
+  { decorator: 'Config' } as const,
+  { afterApply: registerAsLeaf },
+  { unique: true },
+);

--- a/packages/core/src/http/decorators/authorized.ts
+++ b/packages/core/src/http/decorators/authorized.ts
@@ -1,7 +1,7 @@
 import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../errors';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 import type { RequestContextSchema } from '../primitives/get-context';
 
 type Roles = RequestContextSchema['authRoles'];
@@ -9,7 +9,7 @@ type Roles = RequestContextSchema['authRoles'];
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Authorized = (roles: Roles = []) =>
   defineMethodDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     { decorator: 'Authorized' as const, roles } as const,
     {
       rejectStatic: () =>

--- a/packages/core/src/http/decorators/controller.ts
+++ b/packages/core/src/http/decorators/controller.ts
@@ -1,10 +1,10 @@
 import { defineInjectableClassDecorator } from '../../internal/decorator-helpers';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 
 /** @throws {ZeltLifecycleStateError | ZeltDecoratorUsageError} */
 export const Controller = (basePath: string) =>
   defineInjectableClassDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     { decorator: 'Controller', basePath } as const,
     undefined,
     { unique: true },

--- a/packages/core/src/http/decorators/http-method.ts
+++ b/packages/core/src/http/decorators/http-method.ts
@@ -1,13 +1,13 @@
 import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../errors';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 import type { HttpMethod } from '../internal/metadata';
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 const makeDecorator = (method: HttpMethod) => (path: string) =>
   defineMethodDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     { decorator: 'Route' as const, method, path } as const,
     {
       rejectStatic: () =>

--- a/packages/core/src/http/decorators/middleware.ts
+++ b/packages/core/src/http/decorators/middleware.ts
@@ -1,8 +1,8 @@
-import { injectable } from '@needle-di/core';
+import { defineInjectableClassDecorator } from '../../internal/decorator-helpers';
 
-type AnyClass = new (...args: never[]) => object;
-
-export const Middleware = <T extends AnyClass>(target: T): T => {
-  injectable<T>()(target);
-  return target;
-};
+export const Middleware = defineInjectableClassDecorator(
+  undefined,
+  { decorator: 'Middleware' } as const,
+  undefined,
+  { unique: true },
+);

--- a/packages/core/src/http/decorators/skip-middleware.ts
+++ b/packages/core/src/http/decorators/skip-middleware.ts
@@ -1,13 +1,13 @@
 import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../errors';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 import type { MiddlewareIdentifier } from '../middleware/types';
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const SkipMiddleware = (...skipped: MiddlewareIdentifier[]) =>
   defineMethodDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     { decorator: 'SkipMiddleware' as const, skipped } as const,
     {
       rejectStatic: () =>

--- a/packages/core/src/http/decorators/use-middleware.ts
+++ b/packages/core/src/http/decorators/use-middleware.ts
@@ -2,7 +2,7 @@ import { defineClassDecorator, defineMethodDecorator } from '@zeltjs/decorator-m
 import { match, P } from 'ts-pattern';
 
 import { ZeltDecoratorUsageError } from '../../errors';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 import type { MiddlewareInput } from '../middleware/types';
 
 const tc39ClassPattern = { kind: 'class' as const, metadata: P.nonNullable };
@@ -26,10 +26,10 @@ type UseMiddlewareFn = {
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const UseMiddleware = (...middlewares: MiddlewareInput[]): UseMiddlewareFn => {
-  const pos = getCallerPositionForCore();
+  const trace = captureStackTraceForCore();
   const props = { decorator: 'UseMiddleware' as const, middlewares };
-  const classDecorate = defineClassDecorator(pos, props);
-  const methodDecorate = defineMethodDecorator(pos, props, {
+  const classDecorate = defineClassDecorator(trace, props);
+  const methodDecorate = defineMethodDecorator(trace, props, {
     rejectStatic: () =>
       new ZeltDecoratorUsageError({ decoratorName: 'UseMiddleware', reason: 'static_method' }),
   });

--- a/packages/core/src/http/internal/metadata.ts
+++ b/packages/core/src/http/internal/metadata.ts
@@ -1,6 +1,7 @@
 import { getClassMetadata } from '@zeltjs/decorator-metadata';
 import { match, P } from 'ts-pattern';
 
+import { resolvePositionForCore } from '../../internal/decorator-position';
 import type { MiddlewareIdentifier, MiddlewareInput } from '../middleware/types';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
@@ -92,7 +93,7 @@ export const getControllerMetadata = (cls: object): ControllerMetadata | undefin
         controllerPattern,
         (c): ControllerMetadata => ({
           basePath: c.basePath,
-          sourceFile: meta.pos?.sourceFile,
+          sourceFile: resolvePositionForCore(meta.trace)?.sourceFile,
         }),
       )
       .otherwise(() => undefined);

--- a/packages/core/src/internal/decorator-helpers.ts
+++ b/packages/core/src/internal/decorator-helpers.ts
@@ -1,5 +1,5 @@
 import { injectable } from '@needle-di/core';
-import type { ClassDecoratorFn, Position } from '@zeltjs/decorator-metadata';
+import type { ClassDecoratorFn, StackTrace } from '@zeltjs/decorator-metadata';
 import { defineClassDecorator } from '@zeltjs/decorator-metadata';
 import { match } from 'ts-pattern';
 
@@ -37,13 +37,13 @@ const buildUniqueGuard =
 
 /** @throws {ZeltDecoratorUsageError} */
 export const defineInjectableClassDecorator = <TProps extends { decorator: string }>(
-  pos: Position | undefined,
+  trace: StackTrace | undefined,
   props: TProps,
   hooks?: InjectableClassDecoratorHooks,
   options?: DefineInjectableClassDecoratorOptions,
 ): ClassDecoratorFn => {
   const base = defineClassDecorator<TProps, ZeltDecoratorUsageError>(
-    pos,
+    trace,
     props,
     options?.unique ? { rejectIfApplied: buildUniqueGuard(props.decorator) } : undefined,
   );

--- a/packages/core/src/internal/decorator-position.test.ts
+++ b/packages/core/src/internal/decorator-position.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { getCallerPositionForCore } from './decorator-position';
+import { captureStackTraceForCore, resolvePositionForCore } from './decorator-position';
 
-describe('getCallerPositionForCore', () => {
-  it('skips core internal frames and points to the user file', () => {
-    const pos = getCallerPositionForCore();
+describe('captureStackTraceForCore and resolvePositionForCore', () => {
+  it('captures stack trace and resolves to user file position', () => {
+    const trace = captureStackTraceForCore();
+    expect(trace).toBeDefined();
+
+    const pos = resolvePositionForCore(trace);
     expect(pos).toBeDefined();
     expect(pos?.sourceFile).toContain('decorator-position.test.ts');
     expect(pos?.line).toBeGreaterThan(0);

--- a/packages/core/src/internal/decorator-position.ts
+++ b/packages/core/src/internal/decorator-position.ts
@@ -1,13 +1,12 @@
-import type { Position } from '@zeltjs/decorator-metadata';
-import { getCallerPosition } from '@zeltjs/decorator-metadata';
+import type { Position, StackTrace } from '@zeltjs/decorator-metadata';
+import { captureStackTrace, resolvePosition } from '@zeltjs/decorator-metadata';
 
 const isCoreFrameworkPath = (path: string): boolean =>
   path.includes('/node_modules/') ||
-  // Skip both monorepo source (packages/core/src/*) and built output
-  // (packages/core/dist/*) so that consumers importing from the built dist
-  // still get user-code positions in the stack trace.
   (path.includes('/packages/core/') && !/\.(test|spec)\./.test(path)) ||
   path.includes('/packages/decorator-metadata/');
 
-export const getCallerPositionForCore = (): Position | undefined =>
-  getCallerPosition({ isFrameworkPath: isCoreFrameworkPath });
+export const captureStackTraceForCore = (): StackTrace | undefined => captureStackTrace();
+
+export const resolvePositionForCore = (trace: StackTrace | undefined): Position | undefined =>
+  resolvePosition(trace, { isFrameworkPath: isCoreFrameworkPath });

--- a/packages/core/src/scheduler/decorators/cron.ts
+++ b/packages/core/src/scheduler/decorators/cron.ts
@@ -1,7 +1,7 @@
 import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../errors';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 
 type CronOptions = {
   readonly tz?: string;
@@ -10,7 +10,7 @@ type CronOptions = {
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Cron = (expression: string, options?: CronOptions) =>
   defineMethodDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     {
       decorator: 'Schedule' as const,
       cronExpression: expression,

--- a/packages/core/src/scheduler/decorators/daily.ts
+++ b/packages/core/src/scheduler/decorators/daily.ts
@@ -1,7 +1,7 @@
 import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../errors';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 
 type DailyOptions = {
   readonly hour: number;
@@ -14,7 +14,7 @@ export const Daily = (options: DailyOptions) => {
   const minute = options.minute ?? 0;
   const cronExpression = `${minute} ${options.hour} * * *`;
   return defineMethodDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     {
       decorator: 'Schedule' as const,
       cronExpression,

--- a/packages/core/src/scheduler/decorators/every.ts
+++ b/packages/core/src/scheduler/decorators/every.ts
@@ -1,7 +1,7 @@
 import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../errors';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 
 type EveryOptions =
   | { readonly minutes: number; readonly seconds?: never }
@@ -14,7 +14,7 @@ export const Every = (options: EveryOptions) => {
       ? `*/${options.seconds} * * * * *`
       : `*/${options.minutes} * * * *`;
   return defineMethodDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     { decorator: 'Schedule' as const, cronExpression } as const,
     {
       rejectStatic: () =>

--- a/packages/core/src/scheduler/decorators/hourly.ts
+++ b/packages/core/src/scheduler/decorators/hourly.ts
@@ -1,7 +1,7 @@
 import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../errors';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 
 type HourlyOptions = {
   readonly minute?: number;
@@ -13,7 +13,7 @@ export const Hourly = (options?: HourlyOptions) => {
   const minute = options?.minute ?? 0;
   const cronExpression = `${minute} * * * *`;
   return defineMethodDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     {
       decorator: 'Schedule' as const,
       cronExpression,

--- a/packages/core/src/scheduler/decorators/scheduled.ts
+++ b/packages/core/src/scheduler/decorators/scheduled.ts
@@ -1,10 +1,10 @@
 import { defineInjectableClassDecorator } from '../../internal/decorator-helpers';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 
 /** @throws {ZeltLifecycleStateError | ZeltDecoratorUsageError} */
 export const Scheduled = () =>
   defineInjectableClassDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     { decorator: 'Scheduled' } as const,
     undefined,
     { unique: true },

--- a/packages/core/src/scheduler/decorators/weekly.ts
+++ b/packages/core/src/scheduler/decorators/weekly.ts
@@ -1,7 +1,7 @@
 import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../errors';
-import { getCallerPositionForCore } from '../../internal/decorator-position';
+import { captureStackTraceForCore } from '../../internal/decorator-position';
 
 type DayOfWeek = 'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday';
 
@@ -28,7 +28,7 @@ export const Weekly = (options: WeeklyOptions) => {
   const cronDay = dayToCron[options.day];
   const cronExpression = `${minute} ${options.hour} * * ${cronDay}`;
   return defineMethodDecorator(
-    getCallerPositionForCore(),
+    captureStackTraceForCore(),
     {
       decorator: 'Schedule' as const,
       cronExpression,

--- a/packages/decorator-metadata/src/index.ts
+++ b/packages/decorator-metadata/src/index.ts
@@ -13,7 +13,7 @@ export {
   defineMethodDecorator,
   definePropertyDecorator,
 } from './runtime/decorators';
-export type { GetCallerPositionOptions, Position } from './runtime/position';
-export { getCallerPosition } from './runtime/position';
+export type { Position, ResolvePositionOptions, StackTrace } from './runtime/position';
+export { captureStackTrace, resolvePosition } from './runtime/position';
 export type { ClassMeta, MethodMeta, PropertyMeta } from './runtime/store';
 export { getClassMetadata } from './runtime/store';

--- a/packages/decorator-metadata/src/inspect/get-type-metadata.ts
+++ b/packages/decorator-metadata/src/inspect/get-type-metadata.ts
@@ -3,7 +3,8 @@ import { resolve } from 'node:path';
 import type { ResultAsync } from 'neverthrow';
 import { errAsync, okAsync } from 'neverthrow';
 
-import type { Position } from '../runtime/position';
+import type { Position, StackTrace } from '../runtime/position';
+import { resolvePosition } from '../runtime/position';
 import { getClassMetadata } from '../runtime/store';
 import type { ProgramCacheError } from './program-cache';
 import { getOrCreateProgram } from './program-cache';
@@ -32,12 +33,12 @@ type ExtractTypeFn = (type: import('typescript').Type) => TypeInfo;
 
 type StoredMethodMeta = {
   readonly name: string;
-  readonly pos: Position | undefined;
+  readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
 };
 type StoredPropertyMeta = {
   readonly name: string;
-  readonly pos: Position | undefined;
+  readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
 };
 
@@ -110,7 +111,8 @@ const extractMethodInfo = (
     }
   }
 
-  return { name: m.name, pos: m.pos, props: m.props, params, returnType };
+  const pos = resolvePosition(m.trace);
+  return { name: m.name, pos, props: m.props, params, returnType };
 };
 
 const extractPropertyInfo = (
@@ -133,12 +135,13 @@ const extractPropertyInfo = (
     }
   }
 
-  return { name: p.name, pos: p.pos, props: p.props, type, optional };
+  const pos = resolvePosition(p.trace);
+  return { name: p.name, pos, props: p.props, type, optional };
 };
 
 type ResolvedStoredMeta = {
   readonly storedMeta: NonNullable<ReturnType<typeof getClassMetadata>>;
-  readonly storedPos: import('../runtime/position').Position;
+  readonly storedPos: Position;
 };
 
 const resolveStoredMeta = <T extends object>(
@@ -151,7 +154,7 @@ const resolveStoredMeta = <T extends object>(
       error: { code: 'NO_METADATA', message: `No decorator metadata found for class ${cls.name}` },
     };
   }
-  const storedPos = storedMeta.pos;
+  const storedPos = resolvePosition(storedMeta.trace);
   if (!storedPos) {
     return {
       ok: false,

--- a/packages/decorator-metadata/src/runtime/decorators.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.ts
@@ -1,7 +1,7 @@
 import { match, P } from 'ts-pattern';
 
-import type { Position } from './position';
-import { getCallerPosition } from './position';
+import type { StackTrace } from './position';
+import { captureStackTrace } from './position';
 import {
   getClassMetadata,
   setClassMetadata,
@@ -11,7 +11,7 @@ import {
 
 type PendingEntry = {
   readonly name: string;
-  readonly pos: Position | undefined;
+  readonly trace: StackTrace | undefined;
   readonly props: object;
 };
 
@@ -32,11 +32,11 @@ const appendEntry = (
 };
 
 const flushPendingToClass = (cls: object, sharedKey: object): void => {
-  for (const { name, pos, props } of pendingMethods.get(sharedKey) ?? []) {
-    setMethodMetadata(cls, name, pos, props);
+  for (const { name, trace, props } of pendingMethods.get(sharedKey) ?? []) {
+    setMethodMetadata(cls, name, trace, props);
   }
-  for (const { name, pos, props } of pendingFields.get(sharedKey) ?? []) {
-    setPropertyMetadata(cls, name, pos, props);
+  for (const { name, trace, props } of pendingFields.get(sharedKey) ?? []) {
+    setPropertyMetadata(cls, name, trace, props);
   }
   pendingMethods.delete(sharedKey);
   pendingFields.delete(sharedKey);
@@ -117,7 +117,7 @@ export type PropertyDecoratorFn = {
 };
 
 export const defineClassDecorator = <TProps extends object, E extends Error = Error>(
-  pos: Position | undefined,
+  trace: StackTrace | undefined,
   props: TProps,
   options?: DefineClassDecoratorOptions<E>,
 ): ClassDecoratorFn => {
@@ -139,7 +139,7 @@ export const defineClassDecorator = <TProps extends object, E extends Error = Er
       if (err) throw err;
     }
 
-    setClassMetadata(cls, pos, props);
+    setClassMetadata(cls, trace, props);
 
     return match(args[1])
       .with(tc39ClassContextPattern, (ctx) => {
@@ -158,7 +158,7 @@ export const defineClassDecorator = <TProps extends object, E extends Error = Er
 };
 
 export const defineMethodDecorator = <TProps extends object, E extends Error = Error>(
-  pos: Position | undefined,
+  trace: StackTrace | undefined,
   props: TProps,
   options?: DefineMethodDecoratorOptions<E>,
 ): MethodDecoratorFn => {
@@ -186,7 +186,7 @@ export const defineMethodDecorator = <TProps extends object, E extends Error = E
         }
         if (typeof ctx.name !== 'string') return undefined;
         if (!ctx.metadata) return undefined;
-        appendEntry(pendingMethods, ctx.metadata, { name: ctx.name, pos, props });
+        appendEntry(pendingMethods, ctx.metadata, { name: ctx.name, trace, props });
         return undefined;
       })
       .otherwise(() => {
@@ -201,7 +201,7 @@ export const defineMethodDecorator = <TProps extends object, E extends Error = E
         if (typeof contextOrName !== 'string') return undefined;
         const sharedKey = asObject(target);
         if (!sharedKey) return undefined;
-        appendEntry(pendingMethods, sharedKey, { name: contextOrName, pos, props });
+        appendEntry(pendingMethods, sharedKey, { name: contextOrName, trace, props });
         return undefined;
       });
   }
@@ -209,7 +209,7 @@ export const defineMethodDecorator = <TProps extends object, E extends Error = E
 };
 
 export const definePropertyDecorator = <TProps extends object>(
-  pos: Position | undefined,
+  trace: StackTrace | undefined,
   props: TProps,
 ): PropertyDecoratorFn => {
   function decorate(value: undefined, context: ClassFieldDecoratorContext): void;
@@ -222,14 +222,14 @@ export const definePropertyDecorator = <TProps extends object>(
       .with(tc39FieldContextPattern, (ctx) => {
         if (typeof ctx.name !== 'string') return undefined;
         if (!ctx.metadata) return undefined;
-        appendEntry(pendingFields, ctx.metadata, { name: ctx.name, pos, props });
+        appendEntry(pendingFields, ctx.metadata, { name: ctx.name, trace, props });
         return undefined;
       })
       .otherwise(() => {
         if (typeof contextOrName !== 'string') return undefined;
         const sharedKey = asObject(target);
         if (!sharedKey) return undefined;
-        appendEntry(pendingFields, sharedKey, { name: contextOrName, pos, props });
+        appendEntry(pendingFields, sharedKey, { name: contextOrName, trace, props });
         return undefined;
       });
   }
@@ -241,11 +241,11 @@ export const definePropertyDecorator = <TProps extends object>(
 const emptyProps: object = {};
 
 export const createClassDecorator = <TProps extends object>(props?: TProps): ClassDecoratorFn =>
-  defineClassDecorator(getCallerPosition(), props ?? emptyProps);
+  defineClassDecorator(captureStackTrace(), props ?? emptyProps);
 
 export const createMethodDecorator = <TProps extends object>(props?: TProps): MethodDecoratorFn =>
-  defineMethodDecorator(getCallerPosition(), props ?? emptyProps);
+  defineMethodDecorator(captureStackTrace(), props ?? emptyProps);
 
 export const createPropertyDecorator = <TProps extends object>(
   props?: TProps,
-): PropertyDecoratorFn => definePropertyDecorator(getCallerPosition(), props ?? emptyProps);
+): PropertyDecoratorFn => definePropertyDecorator(captureStackTrace(), props ?? emptyProps);

--- a/packages/decorator-metadata/src/runtime/position.ts
+++ b/packages/decorator-metadata/src/runtime/position.ts
@@ -4,7 +4,12 @@ export type Position = {
   readonly column: number;
 };
 
-export type GetCallerPositionOptions = {
+export type StackTrace = {
+  _brand: 'StackTrace';
+  readonly error: Error;
+};
+
+export type ResolvePositionOptions = {
   readonly isFrameworkPath?: (path: string) => boolean;
 };
 
@@ -47,8 +52,6 @@ const findFirstUserPosition = (
   stack: string,
   isFrameworkPath: (path: string) => boolean,
 ): Position | undefined => {
-  // Start at frame 2 to skip Error itself and the immediate caller (this
-  // function), so the first candidate is the user's stack frame.
   const lines = stack.split('\n').slice(2);
   for (const line of lines) {
     if (!line) continue;
@@ -58,11 +61,17 @@ const findFirstUserPosition = (
   return undefined;
 };
 
-export const getCallerPosition = (options?: GetCallerPositionOptions): Position | undefined => {
-  // Some sandboxed runtimes (and certain instrumentation libraries) override
-  // Error.prototype.stack to block stack inspection.
+export const captureStackTrace = (): StackTrace | undefined => {
   if (Object.getOwnPropertyDescriptor(Error.prototype, 'stack') !== undefined) return undefined;
-  const stack = new Error().stack;
+  return { _brand: 'StackTrace', error: new Error() };
+};
+
+export const resolvePosition = (
+  trace: StackTrace | undefined,
+  options?: ResolvePositionOptions,
+): Position | undefined => {
+  if (!trace) return undefined;
+  const stack = trace.error.stack;
   if (!stack) return undefined;
   return findFirstUserPosition(stack, options?.isFrameworkPath ?? defaultIsFrameworkPath);
 };

--- a/packages/decorator-metadata/src/runtime/store.ts
+++ b/packages/decorator-metadata/src/runtime/store.ts
@@ -1,19 +1,19 @@
-import type { Position } from './position';
+import type { StackTrace } from './position';
 
 export type MethodMeta = {
   readonly name: string;
-  readonly pos: Position | undefined;
+  readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
 };
 
 export type PropertyMeta = {
   readonly name: string;
-  readonly pos: Position | undefined;
+  readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
 };
 
 export type ClassMeta = {
-  readonly pos: Position | undefined;
+  readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
   readonly methods: readonly MethodMeta[];
   readonly properties: readonly PropertyMeta[];
@@ -22,18 +22,20 @@ export type ClassMeta = {
 const classStore = new WeakMap<object, ClassMeta>();
 
 const emptyMeta = (): ClassMeta => ({
-  pos: undefined,
+  trace: undefined,
   props: [],
   methods: [],
   properties: [],
 });
 
-export const setClassMetadata = (cls: object, pos: Position | undefined, props: object): void => {
+export const setClassMetadata = (
+  cls: object,
+  trace: StackTrace | undefined,
+  props: object,
+): void => {
   const existing = classStore.get(cls) ?? emptyMeta();
   classStore.set(cls, {
-    // Earliest position wins so the class decorator (or first applied decorator)
-    // owns the canonical source location.
-    pos: existing.pos ?? pos,
+    trace: existing.trace ?? trace,
     props: [...existing.props, props],
     methods: existing.methods,
     properties: existing.properties,
@@ -45,16 +47,16 @@ export const getClassMetadata = (cls: object): ClassMeta | undefined => classSto
 const upsertMethod = (
   methods: readonly MethodMeta[],
   name: string,
-  pos: Position | undefined,
+  trace: StackTrace | undefined,
   props: object,
 ): readonly MethodMeta[] => {
   const existing = methods.find((m) => m.name === name);
   if (!existing) {
-    return [...methods, { name, pos, props: [props] }];
+    return [...methods, { name, trace, props: [props] }];
   }
   const updated: MethodMeta = {
     name: existing.name,
-    pos: existing.pos ?? pos,
+    trace: existing.trace ?? trace,
     props: [...existing.props, props],
   };
   return methods.map((m) => (m === existing ? updated : m));
@@ -63,16 +65,16 @@ const upsertMethod = (
 const upsertProperty = (
   properties: readonly PropertyMeta[],
   name: string,
-  pos: Position | undefined,
+  trace: StackTrace | undefined,
   props: object,
 ): readonly PropertyMeta[] => {
   const existing = properties.find((p) => p.name === name);
   if (!existing) {
-    return [...properties, { name, pos, props: [props] }];
+    return [...properties, { name, trace, props: [props] }];
   }
   const updated: PropertyMeta = {
     name: existing.name,
-    pos: existing.pos ?? pos,
+    trace: existing.trace ?? trace,
     props: [...existing.props, props],
   };
   return properties.map((p) => (p === existing ? updated : p));
@@ -81,14 +83,14 @@ const upsertProperty = (
 export const setMethodMetadata = (
   cls: object,
   name: string,
-  pos: Position | undefined,
+  trace: StackTrace | undefined,
   props: object,
 ): void => {
   const existing = classStore.get(cls) ?? emptyMeta();
   classStore.set(cls, {
-    pos: existing.pos,
+    trace: existing.trace,
     props: existing.props,
-    methods: upsertMethod(existing.methods, name, pos, props),
+    methods: upsertMethod(existing.methods, name, trace, props),
     properties: existing.properties,
   });
 };
@@ -96,14 +98,14 @@ export const setMethodMetadata = (
 export const setPropertyMetadata = (
   cls: object,
   name: string,
-  pos: Position | undefined,
+  trace: StackTrace | undefined,
   props: object,
 ): void => {
   const existing = classStore.get(cls) ?? emptyMeta();
   classStore.set(cls, {
-    pos: existing.pos,
+    trace: existing.trace,
     props: existing.props,
     methods: existing.methods,
-    properties: upsertProperty(existing.properties, name, pos, props),
+    properties: upsertProperty(existing.properties, name, trace, props),
   });
 };

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { describe, expect, it } from 'vitest';
 import {
   createClassDecorator,
@@ -7,8 +8,8 @@ import {
   defineMethodDecorator,
   definePropertyDecorator,
 } from '../runtime/decorators';
-import type { Position } from '../runtime/position';
-import { getCallerPosition } from '../runtime/position';
+import type { StackTrace } from '../runtime/position';
+import { captureStackTrace, resolvePosition } from '../runtime/position';
 import {
   getClassMetadata,
   setClassMetadata,
@@ -16,9 +17,16 @@ import {
   setPropertyMetadata,
 } from '../runtime/store';
 
-describe('getCallerPosition', () => {
-  it('returns position with sourceFile, line, column', () => {
-    const pos = getCallerPosition();
+describe('captureStackTrace and resolvePosition', () => {
+  it('captureStackTrace returns StackTrace with error', () => {
+    const trace = captureStackTrace();
+    expect(trace).toBeDefined();
+    expect(trace?.error).toBeInstanceOf(Error);
+  });
+
+  it('resolvePosition extracts position from trace', () => {
+    const trace = captureStackTrace();
+    const pos = resolvePosition(trace);
 
     expect(pos).toBeDefined();
     expect(pos?.sourceFile).toContain('runtime.test.ts');
@@ -28,10 +36,7 @@ describe('getCallerPosition', () => {
     expect(pos?.column).toBeGreaterThan(0);
   });
 
-  // Some sandboxed runtimes (and certain instrumentation libraries) override
-  // Error.prototype.stack to block stack inspection. Returning undefined keeps
-  // metadata capture optional rather than crashing.
-  it('returns undefined when Error.prototype.stack is overridden', () => {
+  it('captureStackTrace returns undefined when Error.prototype.stack is overridden', () => {
     const originalDescriptor = Object.getOwnPropertyDescriptor(Error.prototype, 'stack');
     Object.defineProperty(Error.prototype, 'stack', {
       value: undefined,
@@ -39,7 +44,7 @@ describe('getCallerPosition', () => {
       configurable: true,
     });
     try {
-      expect(getCallerPosition()).toBeUndefined();
+      expect(captureStackTrace()).toBeUndefined();
     } finally {
       if (originalDescriptor) {
         Object.defineProperty(Error.prototype, 'stack', originalDescriptor);
@@ -49,14 +54,13 @@ describe('getCallerPosition', () => {
     }
   });
 
-  it('accepts custom isFrameworkPath filter to skip wrapper layers', () => {
-    // All paths treated as framework → nothing to capture
-    const allFramework = getCallerPosition({ isFrameworkPath: () => true });
+  it('resolvePosition accepts custom isFrameworkPath filter', () => {
+    const trace = captureStackTrace();
+
+    const allFramework = resolvePosition(trace, { isFrameworkPath: () => true });
     expect(allFramework).toBeUndefined();
 
-    // Custom filter completely replaces the default: it must include
-    // node_modules itself, otherwise vitest internals will leak through.
-    const skipTestAndNodeModules = getCallerPosition({
+    const skipTestAndNodeModules = resolvePosition(trace, {
       isFrameworkPath: (p) => p.includes('runtime.test.ts') || p.includes('/node_modules/'),
     });
     expect(skipTestAndNodeModules).toBeUndefined();
@@ -64,50 +68,44 @@ describe('getCallerPosition', () => {
 });
 
 describe('metadata store', () => {
-  const mockPos: Position = { sourceFile: '/test.ts', line: 10, column: 1 };
+  const mockTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
 
   it('stores and retrieves class metadata', () => {
     class TestClass {}
 
-    setClassMetadata(TestClass, mockPos, { basePath: '/api' });
+    setClassMetadata(TestClass, mockTrace, { basePath: '/api' });
     const meta = getClassMetadata(TestClass);
 
-    expect(meta).toEqual({
-      pos: mockPos,
-      props: [{ basePath: '/api' }],
-      methods: [],
-      properties: [],
-    });
+    expect(meta?.trace).toBe(mockTrace);
+    expect(meta?.props).toEqual([{ basePath: '/api' }]);
+    expect(meta?.methods).toEqual([]);
+    expect(meta?.properties).toEqual([]);
   });
 
   it('stores and retrieves method metadata', () => {
     class TestClass {}
 
-    setClassMetadata(TestClass, mockPos, {});
-    setMethodMetadata(TestClass, 'getUser', mockPos, { method: 'GET' });
+    setClassMetadata(TestClass, mockTrace, {});
+    setMethodMetadata(TestClass, 'getUser', mockTrace, { method: 'GET' });
 
     const meta = getClassMetadata(TestClass);
     expect(meta?.methods).toHaveLength(1);
-    expect(meta?.methods[0]).toEqual({
-      name: 'getUser',
-      pos: mockPos,
-      props: [{ method: 'GET' }],
-    });
+    expect(meta?.methods[0]?.name).toBe('getUser');
+    expect(meta?.methods[0]?.trace).toBe(mockTrace);
+    expect(meta?.methods[0]?.props).toEqual([{ method: 'GET' }]);
   });
 
   it('stores and retrieves property metadata', () => {
     class TestClass {}
 
-    setClassMetadata(TestClass, mockPos, {});
-    setPropertyMetadata(TestClass, 'name', mockPos, { nullable: false });
+    setClassMetadata(TestClass, mockTrace, {});
+    setPropertyMetadata(TestClass, 'name', mockTrace, { nullable: false });
 
     const meta = getClassMetadata(TestClass);
     expect(meta?.properties).toHaveLength(1);
-    expect(meta?.properties[0]).toEqual({
-      name: 'name',
-      pos: mockPos,
-      props: [{ nullable: false }],
-    });
+    expect(meta?.properties[0]?.name).toBe('name');
+    expect(meta?.properties[0]?.trace).toBe(mockTrace);
+    expect(meta?.properties[0]?.props).toEqual([{ nullable: false }]);
   });
 
   it('returns undefined for class without metadata', () => {
@@ -115,18 +113,18 @@ describe('metadata store', () => {
     expect(getClassMetadata(NoMetaClass)).toBeUndefined();
   });
 
-  it('accepts undefined pos and still stores metadata', () => {
+  it('accepts undefined trace and still stores metadata', () => {
     class TestClass {}
     setClassMetadata(TestClass, undefined, { kind: 'X' });
     const meta = getClassMetadata(TestClass);
-    expect(meta?.pos).toBeUndefined();
+    expect(meta?.trace).toBeUndefined();
     expect(meta?.props).toEqual([{ kind: 'X' }]);
   });
 
   it('appends props when the same class is decorated multiple times', () => {
     class TestClass {}
-    setClassMetadata(TestClass, mockPos, { decorator: 'Controller', basePath: '/api' });
-    setClassMetadata(TestClass, mockPos, { decorator: 'UseMiddleware', middlewares: ['auth'] });
+    setClassMetadata(TestClass, mockTrace, { decorator: 'Controller', basePath: '/api' });
+    setClassMetadata(TestClass, mockTrace, { decorator: 'UseMiddleware', middlewares: ['auth'] });
     const meta = getClassMetadata(TestClass);
     expect(meta?.props).toEqual([
       { decorator: 'Controller', basePath: '/api' },
@@ -136,8 +134,11 @@ describe('metadata store', () => {
 
   it('appends props when the same method receives multiple decorators', () => {
     class TestClass {}
-    setMethodMetadata(TestClass, 'handler', mockPos, { decorator: 'Route', method: 'GET' });
-    setMethodMetadata(TestClass, 'handler', mockPos, { decorator: 'Authorized', roles: ['admin'] });
+    setMethodMetadata(TestClass, 'handler', mockTrace, { decorator: 'Route', method: 'GET' });
+    setMethodMetadata(TestClass, 'handler', mockTrace, {
+      decorator: 'Authorized',
+      roles: ['admin'],
+    });
     const meta = getClassMetadata(TestClass);
     expect(meta?.methods).toHaveLength(1);
     expect(meta?.methods[0]?.props).toEqual([
@@ -157,7 +158,8 @@ describe('decorator factories', () => {
     const meta = getClassMetadata(UserController);
     expect(meta).toBeDefined();
     expect(meta?.props).toEqual([{ basePath: '/users' }]);
-    expect(meta?.pos?.sourceFile).toContain('runtime.test.ts');
+    const pos = resolvePosition(meta?.trace);
+    expect(pos?.sourceFile).toContain('runtime.test.ts');
   });
 
   it('createClassDecorator works alone without method/property decorators', () => {
@@ -210,35 +212,35 @@ describe('decorator factories', () => {
 });
 
 describe('define* primitives', () => {
-  it('defineClassDecorator accepts injected pos and saves metadata', () => {
-    const fakePos: Position = { sourceFile: '/inject.ts', line: 1, column: 1 };
+  it('defineClassDecorator accepts injected trace and saves metadata', () => {
+    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
     const Controller = (basePath: string) =>
-      defineClassDecorator(fakePos, { decorator: 'Controller', basePath });
+      defineClassDecorator(fakeTrace, { decorator: 'Controller', basePath });
 
     @Controller('/api')
     class Foo {}
 
     const meta = getClassMetadata(Foo);
-    expect(meta?.pos).toEqual(fakePos);
+    expect(meta?.trace).toBe(fakeTrace);
     expect(meta?.props).toEqual([{ decorator: 'Controller', basePath: '/api' }]);
   });
 
-  it('defineClassDecorator with undefined pos still saves metadata', () => {
+  it('defineClassDecorator with undefined trace still saves metadata', () => {
     const Controller = () => defineClassDecorator(undefined, { decorator: 'Controller' });
 
     @Controller()
     class Foo {}
 
     const meta = getClassMetadata(Foo);
-    expect(meta?.pos).toBeUndefined();
+    expect(meta?.trace).toBeUndefined();
     expect(meta?.props).toEqual([{ decorator: 'Controller' }]);
   });
 
   it('defineMethodDecorator rejectStatic throws via injected error factory on static methods', () => {
-    const fakePos: Position = { sourceFile: '/inject.ts', line: 1, column: 1 };
+    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
     const Get = () =>
       defineMethodDecorator(
-        fakePos,
+        fakeTrace,
         { decorator: 'Route', method: 'GET' },
         { rejectStatic: () => new Error('static not allowed for GET') },
       );
@@ -255,8 +257,8 @@ describe('define* primitives', () => {
   });
 
   it('defineMethodDecorator without rejectStatic accepts static methods', () => {
-    const fakePos: Position = { sourceFile: '/inject.ts', line: 1, column: 1 };
-    const Tag = () => defineMethodDecorator(fakePos, { decorator: 'Tag' });
+    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
+    const Tag = () => defineMethodDecorator(fakeTrace, { decorator: 'Tag' });
 
     class Foo {
       @Tag()
@@ -271,10 +273,10 @@ describe('define* primitives', () => {
   });
 
   it('defineClassDecorator rejectIfApplied callback can veto a second application', () => {
-    const fakePos: Position = { sourceFile: '/inject.ts', line: 1, column: 1 };
+    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
     const Once = () =>
       defineClassDecorator(
-        fakePos,
+        fakeTrace,
         { decorator: 'Once' },
         {
           rejectIfApplied: (existing) =>
@@ -295,9 +297,13 @@ describe('define* primitives', () => {
   });
 
   it('defineClassDecorator rejectIfApplied returns undefined when no conflict', () => {
-    const fakePos: Position = { sourceFile: '/inject.ts', line: 1, column: 1 };
+    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
     const Marker = () =>
-      defineClassDecorator(fakePos, { decorator: 'Marker' }, { rejectIfApplied: () => undefined });
+      defineClassDecorator(
+        fakeTrace,
+        { decorator: 'Marker' },
+        { rejectIfApplied: () => undefined },
+      );
 
     @Marker()
     class Foo {}
@@ -306,10 +312,10 @@ describe('define* primitives', () => {
   });
 
   it('defineClassDecorator stacks multiple decorators by appending props', () => {
-    const fakePos: Position = { sourceFile: '/inject.ts', line: 1, column: 1 };
+    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
     const Controller = (basePath: string) =>
-      defineClassDecorator(fakePos, { decorator: 'Controller', basePath });
-    const UseAuth = () => defineClassDecorator(fakePos, { decorator: 'UseAuth' });
+      defineClassDecorator(fakeTrace, { decorator: 'Controller', basePath });
+    const UseAuth = () => defineClassDecorator(fakeTrace, { decorator: 'UseAuth' });
 
     @UseAuth()
     @Controller('/users')
@@ -328,11 +334,11 @@ describe('define* primitives', () => {
   // instance methods get `(prototype, name, descriptor)`, static methods get
   // `(class, name, descriptor)`, and fields get `(prototype, name)`.
   describe('legacy decorator support', () => {
-    const fakePos: Position = { sourceFile: '/legacy.ts', line: 1, column: 1 };
+    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
 
     it('legacy class decorator stores metadata and returns the target', () => {
       class Foo {}
-      const apply = defineClassDecorator(fakePos, { decorator: 'Controller', basePath: '/x' });
+      const apply = defineClassDecorator(fakeTrace, { decorator: 'Controller', basePath: '/x' });
       const result = (apply as unknown as (target: unknown) => unknown)(Foo);
       expect(result).toBe(Foo);
       const meta = getClassMetadata(Foo);
@@ -341,13 +347,13 @@ describe('define* primitives', () => {
 
     it('legacy instance method flushes via legacy class decorator', () => {
       class Foo {}
-      const method = defineMethodDecorator(fakePos, { decorator: 'Route', method: 'GET' });
+      const method = defineMethodDecorator(fakeTrace, { decorator: 'Route', method: 'GET' });
       (method as unknown as (target: unknown, name: string, desc: object) => void)(
         Foo.prototype,
         'handler',
         { value: () => {} },
       );
-      const cls = defineClassDecorator(fakePos, { decorator: 'Controller' });
+      const cls = defineClassDecorator(fakeTrace, { decorator: 'Controller' });
       (cls as unknown as (target: unknown) => void)(Foo);
       const meta = getClassMetadata(Foo);
       expect(meta?.methods).toHaveLength(1);
@@ -358,7 +364,7 @@ describe('define* primitives', () => {
     it('legacy static method invokes rejectStatic factory', () => {
       class Foo {}
       const method = defineMethodDecorator(
-        fakePos,
+        fakeTrace,
         { decorator: 'Route' },
         { rejectStatic: () => new Error('static not allowed (legacy)') },
       );
@@ -373,9 +379,9 @@ describe('define* primitives', () => {
 
     it('legacy property decorator flushes via legacy class decorator', () => {
       class Foo {}
-      const field = definePropertyDecorator(fakePos, { decorator: 'Column', nullable: false });
+      const field = definePropertyDecorator(fakeTrace, { decorator: 'Column', nullable: false });
       (field as unknown as (target: unknown, name: string) => void)(Foo.prototype, 'name');
-      const cls = defineClassDecorator(fakePos, { decorator: 'Container' });
+      const cls = defineClassDecorator(fakeTrace, { decorator: 'Container' });
       (cls as unknown as (target: unknown) => void)(Foo);
       const meta = getClassMetadata(Foo);
       expect(meta?.properties).toHaveLength(1);
@@ -384,7 +390,7 @@ describe('define* primitives', () => {
     });
 
     it('TC39 class decorator returns undefined to avoid replacement', () => {
-      const apply = defineClassDecorator(fakePos, { decorator: 'Controller' });
+      const apply = defineClassDecorator(fakeTrace, { decorator: 'Controller' });
       class Foo {}
       const ctx: ClassDecoratorContext = {
         kind: 'class',
@@ -401,10 +407,13 @@ describe('define* primitives', () => {
   });
 
   it('definePropertyDecorator accepts injected pos', () => {
-    const fakePos: Position = { sourceFile: '/inject.ts', line: 1, column: 1 };
-    const Container = () => defineClassDecorator(fakePos, { decorator: 'Container' });
+    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
+    const Container = () => defineClassDecorator(fakeTrace, { decorator: 'Container' });
     const Column = (opts?: { nullable?: boolean }) =>
-      definePropertyDecorator(fakePos, { decorator: 'Column', nullable: opts?.nullable ?? false });
+      definePropertyDecorator(fakeTrace, {
+        decorator: 'Column',
+        nullable: opts?.nullable ?? false,
+      });
 
     @Container()
     class Foo {
@@ -417,3 +426,4 @@ describe('define* primitives', () => {
     expect(meta?.properties[0]?.props).toEqual([{ decorator: 'Column', nullable: false }]);
   });
 });
+/* eslint-enable complexity */

--- a/scripts/gwq-bg-build.sh
+++ b/scripts/gwq-bg-build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -e
-cd "$1"
-pnpm build > "/tmp/zelt-build-$(basename "$1").log" 2>&1 &
+DIR="${1:-$(pwd)}"
+cd "$DIR"
+pnpm build > "/tmp/zelt-build-$(basename "$DIR").log" 2>&1 &


### PR DESCRIPTION
## Summary

- Move stack trace analysis from decorator registration time to `getTypeMetadata` call time for better runtime performance
- Replace `getCallerPosition()` with `captureStackTrace()` + `resolvePosition()` - runtime only captures `new Error()`, parsing happens later
- Store `StackTrace` (raw Error) instead of `Position` in metadata
- Migrate `@Config` and `@Middleware` decorators to use `decorator-metadata` for Declaration Layer registration

## Motivation

Previously, every decorator call parsed `Error.stack` immediately at registration time. This adds unnecessary overhead during module loading. Now we only capture the Error object (cheap), and parse the stack lazily when `getTypeMetadata` is called during inspection.

## Test plan

- [x] `pnpm test` passes
- [x] `pnpm run precommit` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782129242&installation_id=133048706&pr_number=200&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F200&signature=5af57ffa76183364ab89650558943475f03904962a7cb0cd4bc1a3671f404719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->