### PR TITLE
fix(core): make body() synchronous for default parameter usage

### DIFF
--- a/packages/core/src/errors/classes.ts
+++ b/packages/core/src/errors/classes.ts
@@ -35,3 +35,6 @@ export type ZeltCommandExecutionError = InstanceType<typeof ZeltCommandExecution
 
 export const ZeltEnvError = createErrorClass('ZeltEnvError');
 export type ZeltEnvError = InstanceType<typeof ZeltEnvError>;
+
+export const ZeltBodyTypeMismatchError = createErrorClass('ZeltBodyTypeMismatchError');
+export type ZeltBodyTypeMismatchError = InstanceType<typeof ZeltBodyTypeMismatchError>;

--- a/packages/core/src/errors/definitions.ts
+++ b/packages/core/src/errors/definitions.ts
@@ -84,6 +84,11 @@ export const coreErrorDefinitions = {
 
   ZeltEnvError: (ctx: { key: string; reason: 'required_not_set' }) =>
     `Required environment variable ${ctx.key} is not set`,
+
+  ZeltBodyTypeMismatchError: (ctx: {
+    expected: string;
+    actual: string;
+  }) => `Expected body type '${ctx.expected}' but received '${ctx.actual}'`,
 } as const;
 
 export type CoreErrorContextMap = {

--- a/packages/core/src/errors/definitions.ts
+++ b/packages/core/src/errors/definitions.ts
@@ -85,10 +85,8 @@ export const coreErrorDefinitions = {
   ZeltEnvError: (ctx: { key: string; reason: 'required_not_set' }) =>
     `Required environment variable ${ctx.key} is not set`,
 
-  ZeltBodyTypeMismatchError: (ctx: {
-    expected: string;
-    actual: string;
-  }) => `Expected body type '${ctx.expected}' but received '${ctx.actual}'`,
+  ZeltBodyTypeMismatchError: (ctx: { expected: string; actual: string }) =>
+    `Expected body type '${ctx.expected}' but received '${ctx.actual}'`,
 } as const;
 
 export type CoreErrorContextMap = {

--- a/packages/core/src/http/app.test.ts
+++ b/packages/core/src/http/app.test.ts
@@ -54,8 +54,8 @@ class EchoController {
 class UploadController {
   @Post('/')
   upload(formData = body('form')) {
-    const description = formData?.['description'] as string;
-    const file = formData?.['file'] as File;
+    const description = formData['description'] as string;
+    const file = formData['file'] as File;
     return { description, filename: file.name, size: file.size };
   }
 }

--- a/packages/core/src/http/app.test.ts
+++ b/packages/core/src/http/app.test.ts
@@ -45,18 +45,17 @@ class HelloController {
 @Controller('/echo')
 class EchoController {
   @Post('/')
-  async create() {
-    return body('json');
+  create(data = body('json')) {
+    return data;
   }
 }
 
 @Controller('/upload')
 class UploadController {
   @Post('/')
-  async upload() {
-    const formData = await body('form');
-    const description = formData.get('description') as string;
-    const file = formData.get('file') as File;
+  upload(formData = body('form')) {
+    const description = formData?.['description'] as string;
+    const file = formData?.['file'] as File;
     return { description, filename: file.name, size: file.size };
   }
 }

--- a/packages/core/src/http/internal/entry-context.test.ts
+++ b/packages/core/src/http/internal/entry-context.test.ts
@@ -7,7 +7,7 @@ import { getEntryContext, runInEntryContext } from './entry-context';
 describe('entry-context', () => {
   it('returns the running context inside runInEntryContext', () => {
     const ctx: EntryContext = {
-      input: { jsonBody: { hello: 'world' }, formBody: undefined, pathParams: {} },
+      input: { body: { type: 'json', val: { hello: 'world' } }, pathParams: {} },
       honoContext: {} as unknown as Context,
     };
     const got = runInEntryContext(ctx, () => getEntryContext());
@@ -20,19 +20,19 @@ describe('entry-context', () => {
 
   it('isolates concurrent contexts', async () => {
     const ctxA: EntryContext = {
-      input: { jsonBody: 'A', formBody: undefined, pathParams: {} },
+      input: { body: { type: 'json', val: 'A' }, pathParams: {} },
       honoContext: {} as unknown as Context,
     };
     const ctxB: EntryContext = {
-      input: { jsonBody: 'B', formBody: undefined, pathParams: {} },
+      input: { body: { type: 'json', val: 'B' }, pathParams: {} },
       honoContext: {} as unknown as Context,
     };
     const [a, b] = await Promise.all([
       runInEntryContext(ctxA, async () => {
         await new Promise((r) => setTimeout(r, 10));
-        return getEntryContext().input.jsonBody;
+        return getEntryContext().input.body.val;
       }),
-      runInEntryContext(ctxB, async () => getEntryContext().input.jsonBody),
+      runInEntryContext(ctxB, async () => getEntryContext().input.body.val),
     ]);
     expect(a).toBe('A');
     expect(b).toBe('B');

--- a/packages/core/src/http/internal/entry-context.ts
+++ b/packages/core/src/http/internal/entry-context.ts
@@ -4,11 +4,18 @@ import type { Context } from 'hono';
 
 import { ZeltContextNotAvailableError } from '../../errors';
 
+export type BodyType = 'json' | 'form' | 'text' | 'none';
+
 type FormBody = Record<string, string | File | (string | File)[]>;
 
+type ParsedBody =
+  | { readonly type: 'json'; readonly val: unknown }
+  | { readonly type: 'form'; readonly val: FormBody }
+  | { readonly type: 'text'; readonly val: string }
+  | { readonly type: 'none'; readonly val: undefined };
+
 type EntryInput = {
-  readonly jsonBody: unknown;
-  readonly formBody: FormBody | undefined;
+  readonly body: ParsedBody;
   readonly pathParams: Readonly<Record<string, string>>;
 };
 

--- a/packages/core/src/http/internal/entry-context.ts
+++ b/packages/core/src/http/internal/entry-context.ts
@@ -4,8 +4,6 @@ import type { Context } from 'hono';
 
 import { ZeltContextNotAvailableError } from '../../errors';
 
-type BodyType = 'json' | 'form' | 'text' | 'none';
-
 type FormBody = Record<string, string | File | (string | File)[]>;
 
 type ParsedBody =

--- a/packages/core/src/http/internal/entry-context.ts
+++ b/packages/core/src/http/internal/entry-context.ts
@@ -9,10 +9,10 @@ export type BodyType = 'json' | 'form' | 'text' | 'none';
 type FormBody = Record<string, string | File | (string | File)[]>;
 
 type ParsedBody =
-  | { readonly type: 'json'; readonly val: unknown }
-  | { readonly type: 'form'; readonly val: FormBody }
-  | { readonly type: 'text'; readonly val: string }
-  | { readonly type: 'none'; readonly val: undefined };
+  | { type: 'json'; val: unknown }
+  | { type: 'form'; val: FormBody }
+  | { type: 'text'; val: string }
+  | { type: 'none'; val: undefined };
 
 type EntryInput = {
   readonly body: ParsedBody;

--- a/packages/core/src/http/internal/entry-context.ts
+++ b/packages/core/src/http/internal/entry-context.ts
@@ -4,7 +4,7 @@ import type { Context } from 'hono';
 
 import { ZeltContextNotAvailableError } from '../../errors';
 
-export type BodyType = 'json' | 'form' | 'text' | 'none';
+type BodyType = 'json' | 'form' | 'text' | 'none';
 
 type FormBody = Record<string, string | File | (string | File)[]>;
 

--- a/packages/core/src/http/internal/route-builder.ts
+++ b/packages/core/src/http/internal/route-builder.ts
@@ -88,31 +88,37 @@ const resolveHandler = (instance: object, methodName: string | symbol): (() => u
 
 type FormBody = Record<string, string | File | (string | File)[]>;
 
-type ParsedBodies = {
-  jsonBody: unknown;
-  formBody: FormBody | undefined;
-};
+type ParsedBody =
+  | { readonly type: 'json'; readonly val: unknown }
+  | { readonly type: 'form'; readonly val: FormBody }
+  | { readonly type: 'text'; readonly val: string }
+  | { readonly type: 'none'; readonly val: undefined };
 
 /** @throws {ZeltContextNotAvailableError} */
-const parseRequestBodies = async (
+const parseRequestBody = async (
   c: Parameters<Parameters<Hono['on']>[2]>[0],
-): Promise<ParsedBodies> => {
+): Promise<ParsedBody> => {
   const contentType = c.req.header('content-type') ?? '';
 
   if (contentType.includes('application/json')) {
-    const jsonBody = await c.req.json<unknown>().catch(() => undefined);
-    return { jsonBody, formBody: undefined };
+    const val = await c.req.json<unknown>().catch(() => undefined);
+    return { type: 'json', val };
   }
 
   if (
     contentType.includes('multipart/form-data') ||
     contentType.includes('application/x-www-form-urlencoded')
   ) {
-    const formBody: FormBody = await c.req.parseBody({ all: true }).catch(() => ({}));
-    return { jsonBody: undefined, formBody };
+    const val: FormBody = await c.req.parseBody({ all: true }).catch(() => ({}));
+    return { type: 'form', val };
   }
 
-  return { jsonBody: undefined, formBody: undefined };
+  if (contentType.startsWith('text/')) {
+    const val = await c.req.text().catch(() => '');
+    return { type: 'text', val };
+  }
+
+  return { type: 'none', val: undefined };
 };
 
 /** @throws {ZeltLifecycleStateError} */
@@ -315,9 +321,9 @@ const registerRoute = (
 
     const composedHandler = composeHandler(middlewares, finalHandler);
 
-    const { jsonBody, formBody } = await parseRequestBodies(c);
+    const body = await parseRequestBody(c);
     const pathParams: Readonly<Record<string, string>> = c.req.param();
-    return runInEntryContext({ input: { jsonBody, formBody, pathParams }, honoContext: c }, () =>
+    return runInEntryContext({ input: { body, pathParams }, honoContext: c }, () =>
       composedHandler(c),
     );
   };

--- a/packages/core/src/http/internal/route-builder.ts
+++ b/packages/core/src/http/internal/route-builder.ts
@@ -89,10 +89,10 @@ const resolveHandler = (instance: object, methodName: string | symbol): (() => u
 type FormBody = Record<string, string | File | (string | File)[]>;
 
 type ParsedBody =
-  | { readonly type: 'json'; readonly val: unknown }
-  | { readonly type: 'form'; readonly val: FormBody }
-  | { readonly type: 'text'; readonly val: string }
-  | { readonly type: 'none'; readonly val: undefined };
+  | { type: 'json'; val: unknown }
+  | { type: 'form'; val: FormBody }
+  | { type: 'text'; val: string }
+  | { type: 'none'; val: undefined };
 
 /** @throws {ZeltContextNotAvailableError} */
 const parseRequestBody = async (

--- a/packages/core/src/http/primitives/auth.test.ts
+++ b/packages/core/src/http/primitives/auth.test.ts
@@ -9,7 +9,7 @@ import { currentRoles, currentUser, setUser } from './auth';
 const createMockEntryContext = (): EntryContext => {
   const store: Record<string, unknown> = {};
   return {
-    input: { jsonBody: {}, formBody: undefined, pathParams: {} },
+    input: { body: { type: 'none', val: undefined }, pathParams: {} },
     honoContext: {
       get: (key: string) => store[key],
       set: (key: string, value: unknown) => {

--- a/packages/core/src/http/primitives/body.test.ts
+++ b/packages/core/src/http/primitives/body.test.ts
@@ -53,7 +53,7 @@ describe('body', () => {
     class TestController {
       @Post('/form')
       form(data = body('form')) {
-        return { receivedName: data?.['name'] };
+        return { receivedName: data['name'] };
       }
     }
 
@@ -71,12 +71,33 @@ describe('body', () => {
     expect(await res.json()).toEqual({ receivedName: 'John' });
   });
 
-  it('returns undefined for json body when content-type is not json', async () => {
+  it('provides text body synchronously as default parameter', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/text')
+      text(data = body('text')) {
+        return { received: data, length: data.length };
+      }
+    }
+
+    const app = createApp({ http: { controllers: [TestController] } });
+    await app.ready();
+    const res = await app.fetch(
+      new Request('http://localhost/text', {
+        method: 'POST',
+        body: 'hello world',
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    );
+    expect(await res.json()).toEqual({ received: 'hello world', length: 11 });
+  });
+
+  it('throws error when body type mismatches content-type', async () => {
     @Controller('/')
     class TestController {
       @Post('/json')
       json(data = body('json')) {
-        return { hasData: data !== undefined };
+        return { data };
       }
     }
 
@@ -89,6 +110,6 @@ describe('body', () => {
         headers: { 'Content-Type': 'text/plain' },
       }),
     );
-    expect(await res.json()).toEqual({ hasData: false });
+    expect(res.status).toBe(500);
   });
 });

--- a/packages/core/src/http/primitives/body.test.ts
+++ b/packages/core/src/http/primitives/body.test.ts
@@ -6,35 +6,12 @@ import { Post } from '../decorators/http-method';
 import { body } from './body';
 
 describe('body', () => {
-  it('parses text body', async () => {
-    @Controller('/')
-    class TestController {
-      @Post('/text')
-      async text() {
-        const text = await body('text');
-        return { text };
-      }
-    }
-
-    const app = createApp({ http: { controllers: [TestController] } });
-    await app.ready();
-    const res = await app.fetch(
-      new Request('http://localhost/text', {
-        method: 'POST',
-        body: 'hello world',
-        headers: { 'Content-Type': 'text/plain' },
-      }),
-    );
-    expect(await res.json()).toEqual({ text: 'hello world' });
-  });
-
-  it('parses json body', async () => {
+  it('provides json body synchronously as default parameter', async () => {
     @Controller('/')
     class TestController {
       @Post('/json')
-      async json() {
-        const data = await body('json');
-        return { data };
+      json(data = body('json') as { name: string }) {
+        return { receivedName: data.name };
       }
     }
 
@@ -47,16 +24,36 @@ describe('body', () => {
         headers: { 'Content-Type': 'application/json' },
       }),
     );
-    expect(await res.json()).toEqual({ data: { name: 'test' } });
+    expect(await res.json()).toEqual({ receivedName: 'test' });
   });
 
-  it('parses form body', async () => {
+  it('defaults to json type when no argument provided', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/json')
+      json(data = body() as { value: number }) {
+        return { doubled: data.value * 2 };
+      }
+    }
+
+    const app = createApp({ http: { controllers: [TestController] } });
+    await app.ready();
+    const res = await app.fetch(
+      new Request('http://localhost/json', {
+        method: 'POST',
+        body: JSON.stringify({ value: 21 }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    expect(await res.json()).toEqual({ doubled: 42 });
+  });
+
+  it('provides form body synchronously as default parameter', async () => {
     @Controller('/')
     class TestController {
       @Post('/form')
-      async form() {
-        const formData = await body('form');
-        return { name: formData.get('name') };
+      form(data = body('form')) {
+        return { receivedName: data?.['name'] };
       }
     }
 
@@ -71,49 +68,25 @@ describe('body', () => {
         body: formData,
       }),
     );
-    expect(await res.json()).toEqual({ name: 'John' });
+    expect(await res.json()).toEqual({ receivedName: 'John' });
   });
 
-  it('parses arrayBuffer body', async () => {
+  it('returns undefined for json body when content-type is not json', async () => {
     @Controller('/')
     class TestController {
-      @Post('/buffer')
-      async buffer() {
-        const buf = await body('arrayBuffer');
-        return { size: buf.byteLength };
+      @Post('/json')
+      json(data = body('json')) {
+        return { hasData: data !== undefined };
       }
     }
 
     const app = createApp({ http: { controllers: [TestController] } });
     await app.ready();
     const res = await app.fetch(
-      new Request('http://localhost/buffer', {
+      new Request('http://localhost/json', {
         method: 'POST',
-        body: new Uint8Array([1, 2, 3, 4, 5]),
       }),
     );
-    expect(await res.json()).toEqual({ size: 5 });
-  });
-
-  it('parses blob body', async () => {
-    @Controller('/')
-    class TestController {
-      @Post('/blob')
-      async blob() {
-        const b = await body('blob');
-        return { size: b.size, type: b.type };
-      }
-    }
-
-    const app = createApp({ http: { controllers: [TestController] } });
-    await app.ready();
-    const res = await app.fetch(
-      new Request('http://localhost/blob', {
-        method: 'POST',
-        body: new Blob(['hello'], { type: 'text/plain' }),
-        headers: { 'Content-Type': 'text/plain' },
-      }),
-    );
-    expect(await res.json()).toEqual({ size: 5, type: 'text/plain' });
+    expect(await res.json()).toEqual({ hasData: false });
   });
 });

--- a/packages/core/src/http/primitives/body.test.ts
+++ b/packages/core/src/http/primitives/body.test.ts
@@ -85,6 +85,8 @@ describe('body', () => {
     const res = await app.fetch(
       new Request('http://localhost/json', {
         method: 'POST',
+        body: 'plain text',
+        headers: { 'Content-Type': 'text/plain' },
       }),
     );
     expect(await res.json()).toEqual({ hasData: false });

--- a/packages/core/src/http/primitives/body.ts
+++ b/packages/core/src/http/primitives/body.ts
@@ -1,37 +1,13 @@
-import { match } from 'ts-pattern';
-
 import { getEntryContext } from '../internal/entry-context';
 
-type BodyTypeMap = {
-  text: string;
-  json: unknown;
-  form: FormData;
-  arrayBuffer: ArrayBuffer;
-  blob: Blob;
-};
-
-type BodyType = keyof BodyTypeMap;
+type FormBody = Record<string, string | File | (string | File)[]>;
 
 /** @throws {ZeltContextNotAvailableError} */
-export function body(type: 'text'): Promise<string>;
+export function body(type?: 'json'): unknown;
 /** @throws {ZeltContextNotAvailableError} */
-export function body(type: 'json'): Promise<unknown>;
+export function body(type: 'form'): FormBody | undefined;
 /** @throws {ZeltContextNotAvailableError} */
-export function body(type: 'form'): Promise<FormData>;
-/** @throws {ZeltContextNotAvailableError} */
-export function body(type: 'arrayBuffer'): Promise<ArrayBuffer>;
-/** @throws {ZeltContextNotAvailableError} */
-export function body(type: 'blob'): Promise<Blob>;
-/**
- * @throws {ZeltContextNotAvailableError}
- */
-export function body(type: BodyType): Promise<BodyTypeMap[BodyType]> {
-  const req = getEntryContext().honoContext.req;
-  return match(type)
-    .with('text', () => req.text())
-    .with('json', () => req.json())
-    .with('form', () => req.formData())
-    .with('arrayBuffer', () => req.arrayBuffer())
-    .with('blob', () => req.blob())
-    .exhaustive();
+export function body(type: 'json' | 'form' = 'json'): unknown {
+  const input = getEntryContext().input;
+  return type === 'json' ? input.jsonBody : input.formBody;
 }

--- a/packages/core/src/http/primitives/body.ts
+++ b/packages/core/src/http/primitives/body.ts
@@ -1,13 +1,24 @@
+import { ZeltBodyTypeMismatchError } from '../../errors';
 import { getEntryContext } from '../internal/entry-context';
 
 type FormBody = Record<string, string | File | (string | File)[]>;
 
-/** @throws {ZeltContextNotAvailableError} */
+/** @throws {ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
 export function body(type?: 'json'): unknown;
-/** @throws {ZeltContextNotAvailableError} */
-export function body(type: 'form'): FormBody | undefined;
-/** @throws {ZeltContextNotAvailableError} */
-export function body(type: 'json' | 'form' = 'json'): unknown {
-  const input = getEntryContext().input;
-  return type === 'json' ? input.jsonBody : input.formBody;
+/** @throws {ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
+export function body(type: 'form'): FormBody;
+/** @throws {ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
+export function body(type: 'text'): string;
+/** @throws {ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
+export function body(type: 'json' | 'form' | 'text' = 'json'): unknown {
+  const { body: parsedBody } = getEntryContext().input;
+
+  if (parsedBody.type !== type) {
+    throw new ZeltBodyTypeMismatchError({
+      expected: type,
+      actual: parsedBody.type,
+    });
+  }
+
+  return parsedBody.val;
 }

--- a/packages/core/src/http/primitives/get-context.test.ts
+++ b/packages/core/src/http/primitives/get-context.test.ts
@@ -13,7 +13,7 @@ declare module '@zeltjs/core' {
 }
 
 const createMockEntryContext = (contextValues: Record<string, unknown> = {}): EntryContext => ({
-  input: { jsonBody: {}, formBody: undefined, pathParams: {} },
+  input: { body: { type: 'none', val: undefined }, pathParams: {} },
   honoContext: {
     get: (key: string) => contextValues[key],
     set: vi.fn(),

--- a/packages/core/src/http/primitives/ip.test.ts
+++ b/packages/core/src/http/primitives/ip.test.ts
@@ -18,7 +18,7 @@ describe('ip primitive', () => {
     });
     runInEntryContext(
       // @ts-expect-error narrow typed test fixture
-      { honoContext, input: { jsonBody: undefined, formBody: undefined, pathParams: {} } },
+      { honoContext, input: { body: { type: 'none', val: undefined }, pathParams: {} } },
       () => {
         expect(ip()).toBe('1.1.1.1');
       },
@@ -32,7 +32,7 @@ describe('ip primitive', () => {
     });
     runInEntryContext(
       // @ts-expect-error narrow typed test fixture
-      { honoContext, input: { jsonBody: undefined, formBody: undefined, pathParams: {} } },
+      { honoContext, input: { body: { type: 'none', val: undefined }, pathParams: {} } },
       () => {
         expect(ip()).toBe('3.3.3.3');
       },
@@ -45,7 +45,7 @@ describe('ip primitive', () => {
     });
     runInEntryContext(
       // @ts-expect-error narrow typed test fixture
-      { honoContext, input: { jsonBody: undefined, formBody: undefined, pathParams: {} } },
+      { honoContext, input: { body: { type: 'none', val: undefined }, pathParams: {} } },
       () => {
         expect(ip()).toBe('4.4.4.4');
       },
@@ -56,7 +56,7 @@ describe('ip primitive', () => {
     const honoContext = makeContext({});
     runInEntryContext(
       // @ts-expect-error narrow typed test fixture
-      { honoContext, input: { jsonBody: undefined, formBody: undefined, pathParams: {} } },
+      { honoContext, input: { body: { type: 'none', val: undefined }, pathParams: {} } },
       () => {
         expect(ip()).toBe('unknown');
       },

--- a/packages/core/src/http/primitives/path-param.test.ts
+++ b/packages/core/src/http/primitives/path-param.test.ts
@@ -9,7 +9,7 @@ describe('pathParam()', () => {
   it('returns the path param value', () => {
     const result = runInEntryContext(
       {
-        input: { jsonBody: undefined, formBody: undefined, pathParams: { id: '42' } },
+        input: { body: { type: 'none', val: undefined }, pathParams: { id: '42' } },
         honoContext: {} as unknown as Context,
       },
       () => pathParam('id'),
@@ -21,7 +21,7 @@ describe('pathParam()', () => {
     expect(() =>
       runInEntryContext(
         {
-          input: { jsonBody: undefined, formBody: undefined, pathParams: {} },
+          input: { body: { type: 'none', val: undefined }, pathParams: {} },
           honoContext: {} as unknown as Context,
         },
         () => pathParam('id'),

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,2 +1,3 @@
 export type { EntryContext } from '../http/internal/entry-context';
 export { getEntryContext, runInEntryContext } from '../http/internal/entry-context';
+export { ZeltBodyTypeMismatchError } from '../errors';

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,3 +1,3 @@
+export { ZeltBodyTypeMismatchError } from '../errors';
 export type { EntryContext } from '../http/internal/entry-context';
 export { getEntryContext, runInEntryContext } from '../http/internal/entry-context';
-export { ZeltBodyTypeMismatchError } from '../errors';

--- a/packages/validator-valibot/src/validated.test.ts
+++ b/packages/validator-valibot/src/validated.test.ts
@@ -12,7 +12,7 @@ describe('validated()', () => {
   it('returns parsed body when schema matches (json)', () => {
     const result = runInEntryContext(
       {
-        input: { jsonBody: { name: 'Ada', age: 36 }, formBody: undefined, pathParams: {} },
+        input: { body: { type: 'json', val: { name: 'Ada', age: 36 } }, pathParams: {} },
         honoContext: {} as unknown as Context,
       },
       () => validated(Schema),
@@ -24,7 +24,7 @@ describe('validated()', () => {
     const FormSchema = v.object({ name: v.string() });
     const result = runInEntryContext(
       {
-        input: { jsonBody: undefined, formBody: { name: 'Ada' }, pathParams: {} },
+        input: { body: { type: 'form', val: { name: 'Ada' } }, pathParams: {} },
         honoContext: {} as unknown as Context,
       },
       () => validated(FormSchema, 'form'),
@@ -36,7 +36,7 @@ describe('validated()', () => {
     expect(() =>
       runInEntryContext(
         {
-          input: { jsonBody: { name: 'Ada' }, formBody: undefined, pathParams: {} },
+          input: { body: { type: 'json', val: { name: 'Ada' } }, pathParams: {} },
           honoContext: {} as unknown as Context,
         },
         () => validated(Schema),
@@ -49,7 +49,7 @@ describe('validated()', () => {
     try {
       runInEntryContext(
         {
-          input: { jsonBody: { name: 'Ada' }, formBody: undefined, pathParams: {} },
+          input: { body: { type: 'json', val: { name: 'Ada' } }, pathParams: {} },
           honoContext: {} as unknown as Context,
         },
         () => validated(Schema),

--- a/packages/validator-valibot/src/validated.ts
+++ b/packages/validator-valibot/src/validated.ts
@@ -1,5 +1,5 @@
 import type { ValidatedMarker, ValidationTarget } from '@zeltjs/core';
-import { ZeltBodyTypeMismatchError, getEntryContext } from '@zeltjs/core/runtime';
+import { getEntryContext, ZeltBodyTypeMismatchError } from '@zeltjs/core/runtime';
 import { HTTPException } from 'hono/http-exception';
 import type { GenericSchema, InferOutput } from 'valibot';
 import { safeParse } from 'valibot';

--- a/packages/validator-valibot/src/validated.ts
+++ b/packages/validator-valibot/src/validated.ts
@@ -1,27 +1,34 @@
 import type { ValidatedMarker, ValidationTarget } from '@zeltjs/core';
-import { getEntryContext } from '@zeltjs/core/runtime';
+import { ZeltBodyTypeMismatchError, getEntryContext } from '@zeltjs/core/runtime';
 import { HTTPException } from 'hono/http-exception';
 import type { GenericSchema, InferOutput } from 'valibot';
 import { safeParse } from 'valibot';
 
-/** @throws {HTTPException | ZeltContextNotAvailableError} */
+/** @throws {HTTPException | ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target?: 'json',
 ): ValidatedMarker<InferOutput<Schema>, 'json'>;
-/** @throws {HTTPException | ZeltContextNotAvailableError} */
+/** @throws {HTTPException | ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target: 'form',
 ): ValidatedMarker<InferOutput<Schema>, 'form'>;
-/** @throws {HTTPException | ZeltContextNotAvailableError} */
+/** @throws {HTTPException | ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target: ValidationTarget = 'json',
 ): InferOutput<Schema> {
-  const ctx = getEntryContext();
-  const body = target === 'json' ? ctx.input.jsonBody : ctx.input.formBody;
-  const result = safeParse(schema, body);
+  const { body } = getEntryContext().input;
+
+  if (body.type !== target) {
+    throw new ZeltBodyTypeMismatchError({
+      expected: target,
+      actual: body.type,
+    });
+  }
+
+  const result = safeParse(schema, body.val);
   if (!result.success) {
     throw new HTTPException(400, {
       res: Response.json({ code: 'VALIDATION_FAILED', issues: result.issues }, { status: 400 }),


### PR DESCRIPTION
## Summary

- `body()` を同期的に変更し、デフォルトパラメータとして使用可能に
- 事前パース済みの `ctx.input.jsonBody` / `ctx.input.formBody` を直接返すように修正
- `body('text')`, `body('arrayBuffer')`, `body('blob')` を削除

## BREAKING CHANGE

`body('text')`, `body('arrayBuffer')`, `body('blob')` は削除されました。
これらが必要な場合は `getContext().req.text()` などを直接使用してください。

## Test plan

- [x] 既存テスト通過
- [x] デフォルトパラメータとしての使用をテストで検証

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782131089&installation_id=133048706&pr_number=201&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F201&signature=0c349ebb85c2ed23a27c1f75c9f5a2da0246a7aadb43c5ce8077b4116fe3430d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Synchronous parameter injection for request bodies (defaults to JSON); form bodies surface as structured records including files.

* **Refactor**
  * Unified request-body representation (json/form/text/none) with simplified, synchronous parsing.
  * Runtime now exposes a dedicated body-type-mismatch error.

* **Bug Fixes**
  * Requests with a non-matching body type now raise the new body-type-mismatch error.

* **Tests**
  * Updated tests to cover synchronous body handling and mismatch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->