### PR TITLE
feat(decorator-metadata): add decorator composition

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -161,6 +161,14 @@ export default tseslint.config(
     },
   },
   {
+    // compose* functions forward overloaded decorator types through unknown[],
+    // which requires casting through unknown at this type-system boundary.
+    files: ['packages/decorator-metadata/src/runtime/decorators.ts'],
+    rules: {
+      '@9wick/strict-type-rules/no-as-assertion': 'off',
+    },
+  },
+  {
     files: [...TEST_FILES, ...EXAMPLE_FILES, ...FIXTURE_FILES],
     rules: {
       'no-console': 'off',

--- a/packages/decorator-metadata/src/index.ts
+++ b/packages/decorator-metadata/src/index.ts
@@ -6,6 +6,7 @@ export type {
   PropertyDecoratorFn,
 } from './runtime/decorators';
 export {
+  composeClassDecorators,
   createClassDecorator,
   createMethodDecorator,
   createPropertyDecorator,

--- a/packages/decorator-metadata/src/index.ts
+++ b/packages/decorator-metadata/src/index.ts
@@ -7,6 +7,8 @@ export type {
 } from './runtime/decorators';
 export {
   composeClassDecorators,
+  composeMethodDecorators,
+  composePropertyDecorators,
   createClassDecorator,
   createMethodDecorator,
   createPropertyDecorator,

--- a/packages/decorator-metadata/src/runtime/decorators.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.ts
@@ -269,6 +269,41 @@ export const composeClassDecorators = (...decorators: ClassDecoratorFn[]): Class
   return decorate;
 };
 
+export const composeMethodDecorators = (...decorators: MethodDecoratorFn[]): MethodDecoratorFn => {
+  function decorate(
+    value: (...args: never[]) => unknown,
+    context: ClassMethodDecoratorContext,
+  ): void;
+  function decorate(
+    target: object,
+    propertyKey: string | symbol,
+    descriptor?: PropertyDescriptor,
+  ): void;
+  function decorate(...args: unknown[]): unknown {
+    for (const dec of decorators) {
+      const fn = dec as unknown as (...a: unknown[]) => unknown;
+      fn(...args);
+    }
+    return undefined;
+  }
+  return decorate;
+};
+
+export const composePropertyDecorators = (
+  ...decorators: PropertyDecoratorFn[]
+): PropertyDecoratorFn => {
+  function decorate(value: undefined, context: ClassFieldDecoratorContext): void;
+  function decorate(target: object, propertyKey: string | symbol): void;
+  function decorate(...args: unknown[]): unknown {
+    for (const dec of decorators) {
+      const fn = dec as unknown as (...a: unknown[]) => unknown;
+      fn(...args);
+    }
+    return undefined;
+  }
+  return decorate;
+};
+
 // `props ?? {}` widens to `TProps | {}`; constraining `TProps` to `object`
 // (which `{}` satisfies) lets us pass it directly without an assertion.
 const emptyProps: object = {};

--- a/packages/decorator-metadata/src/runtime/decorators.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.ts
@@ -3,6 +3,7 @@ import { match, P } from 'ts-pattern';
 import type { StackTrace } from './position';
 import { captureStackTrace } from './position';
 import {
+  ensureClassMeta,
   getClassMetadata,
   setClassMetadata,
   setMethodMetadata,
@@ -165,6 +166,7 @@ export const defineMethodDecorator = <TProps extends object, E extends Error = E
   props: TProps,
   options?: DefineMethodDecoratorOptions<E>,
 ): MethodDecoratorFn => {
+  const getTrace = trace !== undefined ? () => trace : captureStackTrace;
   /** @throws {E} */
   function decorate(
     value: (...args: never[]) => unknown,
@@ -189,7 +191,7 @@ export const defineMethodDecorator = <TProps extends object, E extends Error = E
         }
         if (typeof ctx.name !== 'string') return undefined;
         if (!ctx.metadata) return undefined;
-        appendEntry(pendingMethods, ctx.metadata, { name: ctx.name, trace, props });
+        appendEntry(pendingMethods, ctx.metadata, { name: ctx.name, trace: getTrace(), props });
         return undefined;
       })
       .otherwise(() => {
@@ -204,7 +206,7 @@ export const defineMethodDecorator = <TProps extends object, E extends Error = E
         if (typeof contextOrName !== 'string') return undefined;
         const sharedKey = asObject(target);
         if (!sharedKey) return undefined;
-        appendEntry(pendingMethods, sharedKey, { name: contextOrName, trace, props });
+        appendEntry(pendingMethods, sharedKey, { name: contextOrName, trace: getTrace(), props });
         return undefined;
       });
   }
@@ -215,6 +217,7 @@ export const definePropertyDecorator = <TProps extends object>(
   trace: StackTrace | undefined,
   props: TProps,
 ): PropertyDecoratorFn => {
+  const getTrace = trace !== undefined ? () => trace : captureStackTrace;
   function decorate(value: undefined, context: ClassFieldDecoratorContext): void;
   function decorate(target: object, propertyKey: string | symbol): void;
   function decorate(...args: unknown[]): unknown {
@@ -225,16 +228,43 @@ export const definePropertyDecorator = <TProps extends object>(
       .with(tc39FieldContextPattern, (ctx) => {
         if (typeof ctx.name !== 'string') return undefined;
         if (!ctx.metadata) return undefined;
-        appendEntry(pendingFields, ctx.metadata, { name: ctx.name, trace, props });
+        appendEntry(pendingFields, ctx.metadata, { name: ctx.name, trace: getTrace(), props });
         return undefined;
       })
       .otherwise(() => {
         if (typeof contextOrName !== 'string') return undefined;
         const sharedKey = asObject(target);
         if (!sharedKey) return undefined;
-        appendEntry(pendingFields, sharedKey, { name: contextOrName, trace, props });
+        appendEntry(pendingFields, sharedKey, { name: contextOrName, trace: getTrace(), props });
         return undefined;
       });
+  }
+  return decorate;
+};
+
+export const composeClassDecorators = (...decorators: ClassDecoratorFn[]): ClassDecoratorFn => {
+  // Capture trace at compose-call time (when the user factory returns the decorator),
+  // not inside decorate() which runs inside a transpiler helper and loses the user frame.
+  const trace = captureStackTrace();
+  function decorate<T extends abstract new (...args: never[]) => unknown>(
+    value: T,
+    context: ClassDecoratorContext,
+  ): void;
+  function decorate<T extends new (...args: never[]) => unknown>(target: T): T | void;
+  function decorate(...args: unknown[]): unknown {
+    const cls = asObject(args[0]);
+    if (!cls) return undefined;
+
+    if (trace) ensureClassMeta(cls, trace);
+
+    for (const dec of decorators) {
+      const fn: (...a: unknown[]) => unknown = dec;
+      fn(...args);
+    }
+
+    return match(args[1])
+      .with(tc39ClassContextPattern, () => undefined)
+      .otherwise(() => cls);
   }
   return decorate;
 };
@@ -247,8 +277,8 @@ export const createClassDecorator = <TProps extends object>(props?: TProps): Cla
   defineClassDecorator(captureStackTrace(), props ?? emptyProps);
 
 export const createMethodDecorator = <TProps extends object>(props?: TProps): MethodDecoratorFn =>
-  defineMethodDecorator(captureStackTrace(), props ?? emptyProps);
+  defineMethodDecorator(undefined, props ?? emptyProps);
 
 export const createPropertyDecorator = <TProps extends object>(
   props?: TProps,
-): PropertyDecoratorFn => definePropertyDecorator(captureStackTrace(), props ?? emptyProps);
+): PropertyDecoratorFn => definePropertyDecorator(undefined, props ?? emptyProps);

--- a/packages/decorator-metadata/src/runtime/decorators.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.ts
@@ -259,12 +259,15 @@ export const composeClassDecorators = (...decorators: ClassDecoratorFn[]): Class
 
     for (const dec of decorators) {
       const fn: (...a: unknown[]) => unknown = dec;
-      fn(...args);
+      const result = fn(...args);
+      if (result !== undefined) {
+        args[0] = result;
+      }
     }
 
     return match(args[1])
       .with(tc39ClassContextPattern, () => undefined)
-      .otherwise(() => cls);
+      .otherwise(() => args[0]);
   }
   return decorate;
 };

--- a/packages/decorator-metadata/src/runtime/decorators.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.ts
@@ -121,6 +121,9 @@ export const defineClassDecorator = <TProps extends object, E extends Error = Er
   props: TProps,
   options?: DefineClassDecoratorOptions<E>,
 ): ClassDecoratorFn => {
+  // When no explicit trace is provided, defer captureStackTrace() to decorate()
+  // so the stack reflects the actual decoration site, not the factory call site.
+  const getTrace = trace !== undefined ? () => trace : captureStackTrace;
   /** @throws {E} */
   function decorate<T extends abstract new (...args: never[]) => unknown>(
     value: T,
@@ -139,7 +142,7 @@ export const defineClassDecorator = <TProps extends object, E extends Error = Er
       if (err) throw err;
     }
 
-    setClassMetadata(cls, trace, props);
+    setClassMetadata(cls, getTrace(), props);
 
     return match(args[1])
       .with(tc39ClassContextPattern, (ctx) => {

--- a/packages/decorator-metadata/src/runtime/position.ts
+++ b/packages/decorator-metadata/src/runtime/position.ts
@@ -21,6 +21,30 @@ const defaultIsFrameworkPath = (path: string): boolean => {
   );
 };
 
+// SWC, TypeScript, and Babel inject decorator helpers into transpiled output.
+// These helpers appear in user files but at synthesized positions that don't
+// correspond to any real TypeScript source line.
+const TRANSPILER_HELPER_NAMES = new Set([
+  'applyClassDecs', // SWC TC39 decorator helper
+  '__decorate', // TypeScript legacy experimentalDecorators
+  '_decorate', // Babel decorator helper
+  'applyDecs', // SWC older decorator helper
+  'applyDecs2305', // SWC versioned decorator helper
+]);
+
+const isTranspilerHelperFrame = (line: string): boolean => {
+  // Property accessor frames from transpiler-generated objects show "[as name]"
+  // in V8 stack traces — these are synthesized by SWC/Babel and have no
+  // corresponding source position.
+  if (line.includes('[as ')) return true;
+
+  const match = line.match(/^\s+at\s+([^\s(]+)/);
+  if (!match?.[1]) return false;
+  // Strip leading qualifiers like "Array.", "Object.", etc.
+  const name = match[1].split('.').pop() ?? '';
+  return TRANSPILER_HELPER_NAMES.has(name);
+};
+
 const tryParseMatch = (
   match: RegExpMatchArray | null,
   isFrameworkPath: (path: string) => boolean,
@@ -55,6 +79,10 @@ const findFirstUserPosition = (
   const lines = stack.split('\n').slice(2);
   for (const line of lines) {
     if (!line) continue;
+    // Skip transpiler-generated decorator helper frames even when they appear
+    // inside user files — their line numbers map to synthesized positions in
+    // the transpiled output, not to meaningful TypeScript source locations.
+    if (isTranspilerHelperFrame(line)) continue;
     const pos = parsePositionFromStackLine(line, isFrameworkPath);
     if (pos) return pos;
   }

--- a/packages/decorator-metadata/src/runtime/position.ts
+++ b/packages/decorator-metadata/src/runtime/position.ts
@@ -17,7 +17,8 @@ const defaultIsFrameworkPath = (path: string): boolean => {
   const normalized = path.replace(/\\/g, '/');
   return (
     normalized.includes('/node_modules/') ||
-    normalized.includes('/packages/decorator-metadata/src/runtime/')
+    normalized.includes('/packages/decorator-metadata/src/runtime/') ||
+    normalized.startsWith('node:')
   );
 };
 
@@ -30,6 +31,12 @@ const TRANSPILER_HELPER_NAMES = new Set([
   '_decorate', // Babel decorator helper
   'applyDecs', // SWC older decorator helper
   'applyDecs2305', // SWC versioned decorator helper
+  // SWC TC39 2022-03 member decorator helpers
+  'memberDec',
+  'applyMemberDec',
+  'applyMemberDecs',
+  'applyDecs2203R',
+  '_apply_decs_2203_r',
 ]);
 
 const isTranspilerHelperFrame = (line: string): boolean => {
@@ -72,17 +79,34 @@ const parsePositionFromStackLine = (
   return tryParseMatch(atMatch, isFrameworkPath);
 };
 
+// Returns true if the frame has no named function — just a bare file path.
+// Pattern: "    at /path/to/file.ts:line:col" (no function name before the path).
+const isAnonymousPathFrame = (line: string): boolean =>
+  /^\s+at\s+\//.test(line) || /^\s+at\s+[a-zA-Z]:\\/.test(line);
+
 const findFirstUserPosition = (
   stack: string,
   isFrameworkPath: (path: string) => boolean,
 ): Position | undefined => {
   const lines = stack.split('\n').slice(2);
+  let prevWasHelperFrame = false;
   for (const line of lines) {
     if (!line) continue;
     // Skip transpiler-generated decorator helper frames even when they appear
     // inside user files — their line numbers map to synthesized positions in
     // the transpiled output, not to meaningful TypeScript source locations.
-    if (isTranspilerHelperFrame(line)) continue;
+    if (isTranspilerHelperFrame(line)) {
+      prevWasHelperFrame = true;
+      continue;
+    }
+    // Anonymous continuation frames that immediately follow a transpiler helper
+    // frame are synthesized by the transpiler and do not correspond to real
+    // TypeScript source positions.
+    if (prevWasHelperFrame && isAnonymousPathFrame(line)) {
+      prevWasHelperFrame = true;
+      continue;
+    }
+    prevWasHelperFrame = false;
     const pos = parsePositionFromStackLine(line, isFrameworkPath);
     if (pos) return pos;
   }

--- a/packages/decorator-metadata/src/runtime/store.ts
+++ b/packages/decorator-metadata/src/runtime/store.ts
@@ -44,6 +44,18 @@ export const setClassMetadata = (
 
 export const getClassMetadata = (cls: object): ClassMeta | undefined => classStore.get(cls);
 
+export const ensureClassMeta = (cls: object, trace: StackTrace): void => {
+  const existing = classStore.get(cls);
+  if (existing?.trace) return;
+  const base = existing ?? emptyMeta();
+  classStore.set(cls, {
+    trace,
+    props: base.props,
+    methods: base.methods,
+    properties: base.properties,
+  });
+};
+
 const upsertMethod = (
   methods: readonly MethodMeta[],
   name: string,

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   composeClassDecorators,
+  composeMethodDecorators,
+  composePropertyDecorators,
   createClassDecorator,
   createMethodDecorator,
   createPropertyDecorator,
@@ -463,6 +465,50 @@ describe('define* primitives', () => {
     const meta = getClassMetadata(Foo);
     expect(meta?.properties).toHaveLength(1);
     expect(meta?.properties[0]?.props).toEqual([{ decorator: 'Column', nullable: false }]);
+  });
+});
+describe('compose* functions', () => {
+  it('composeMethodDecorators combines multiple method decorators', () => {
+    const Controller = () => createClassDecorator({});
+    const Route = (method: string, path: string) =>
+      createMethodDecorator({ decorator: 'Route', method, path });
+    const Query = (path: string) =>
+      composeMethodDecorators(Route('GET', path), createMethodDecorator({ decorator: 'Query' }));
+
+    @Controller()
+    class TestController {
+      @Query('/users')
+      getUsers() {}
+    }
+
+    const meta = getClassMetadata(TestController);
+    expect(meta?.methods).toHaveLength(1);
+    expect(meta?.methods[0]?.props).toEqual([
+      { decorator: 'Route', method: 'GET', path: '/users' },
+      { decorator: 'Query' },
+    ]);
+  });
+
+  it('composePropertyDecorators combines multiple property decorators', () => {
+    const Entity = () => createClassDecorator({});
+    const Column = (opts?: { nullable?: boolean }) =>
+      createPropertyDecorator({ decorator: 'Column', nullable: opts?.nullable ?? false });
+    const Searchable = () => createPropertyDecorator({ decorator: 'Searchable' });
+    const SearchableColumn = (opts?: { nullable?: boolean }) =>
+      composePropertyDecorators(Column(opts), Searchable());
+
+    @Entity()
+    class User {
+      @SearchableColumn()
+      name!: string;
+    }
+
+    const meta = getClassMetadata(User);
+    expect(meta?.properties).toHaveLength(1);
+    expect(meta?.properties[0]?.props).toEqual([
+      { decorator: 'Column', nullable: false },
+      { decorator: 'Searchable' },
+    ]);
   });
 });
 /* eslint-enable complexity */

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 import { describe, expect, it } from 'vitest';
 import {
+  composeClassDecorators,
   createClassDecorator,
   createMethodDecorator,
   createPropertyDecorator,
@@ -160,6 +161,28 @@ describe('trace capture timing', () => {
 
     expect(pos?.sourceFile).toContain('runtime.test.ts');
     expect(pos?.line).toBeGreaterThan(0);
+  });
+
+  it('composeClassDecorators captures trace at decoration site, not child factory time', () => {
+    const Controller = (path: string) => createClassDecorator({ path });
+    const Marker = () => createClassDecorator({ type: 'marker' });
+
+    // composeClassDecorators is defined here (factory time), but the trace must
+    // resolve to the @GraphqlController call site below, not this line.
+    const composeDefinitionLine = resolvePosition(captureStackTrace())?.line ?? 0;
+    const GraphqlController = (path: string) => composeClassDecorators(Controller(path), Marker());
+
+    @GraphqlController('/api')
+    class UserResolver {}
+
+    const meta = getClassMetadata(UserResolver);
+    const pos = resolvePosition(meta?.trace);
+
+    expect(pos?.sourceFile).toContain('runtime.test.ts');
+    expect(pos?.line).toBeGreaterThan(0);
+    // The trace must point after the compose definition, not at or before it.
+    expect(pos?.line).toBeGreaterThan(composeDefinitionLine);
+    expect(meta?.props).toEqual([{ path: '/api' }, { type: 'marker' }]);
   });
 });
 

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -148,6 +148,21 @@ describe('metadata store', () => {
   });
 });
 
+describe('trace capture timing', () => {
+  it('createClassDecorator captures trace at decoration time, not factory time', () => {
+    const Controller = (basePath: string) => createClassDecorator({ basePath });
+
+    @Controller('/api')
+    class TestClass {}
+
+    const meta = getClassMetadata(TestClass);
+    const pos = resolvePosition(meta?.trace);
+
+    expect(pos?.sourceFile).toContain('runtime.test.ts');
+    expect(pos?.line).toBeGreaterThan(0);
+  });
+});
+
 describe('decorator factories', () => {
   it('createClassDecorator stores metadata on class', () => {
     const Controller = (basePath: string) => createClassDecorator({ basePath });
@@ -225,14 +240,15 @@ describe('define* primitives', () => {
     expect(meta?.props).toEqual([{ decorator: 'Controller', basePath: '/api' }]);
   });
 
-  it('defineClassDecorator with undefined trace still saves metadata', () => {
+  it('defineClassDecorator with undefined trace captures trace at decoration time', () => {
     const Controller = () => defineClassDecorator(undefined, { decorator: 'Controller' });
 
     @Controller()
     class Foo {}
 
     const meta = getClassMetadata(Foo);
-    expect(meta?.trace).toBeUndefined();
+    // When no explicit trace is provided, captureStackTrace() is called at decoration time.
+    expect(meta?.trace).toBeDefined();
     expect(meta?.props).toEqual([{ decorator: 'Controller' }]);
   });
 


### PR DESCRIPTION
## Summary

- Add `composeClassDecorators`, `composeMethodDecorators`, `composePropertyDecorators` for combining multiple decorators
- Fix trace capture to happen at decoration time for proper source location tracking
- Add transpiler helper frame filtering for SWC/TypeScript/Babel compatibility

## Usage

```typescript
const GraphqlController = (path: string) =>
  composeClassDecorators(
    Controller(path),
    createClassDecorator({ decorator: 'GraphqlController' })
  );

@GraphqlController('/api')
class UserResolver {}
```

## Test Plan

- [x] All 568 tests pass
- [x] Compose functions correctly merge props from multiple decorators
- [x] Trace points to class definition location, not decorator factory

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782135716&installation_id=133048706&pr_number=202&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F202&signature=1ccc74ed9df485bb35da7105c13c490dcab9c2cf21ba17fe09de825a92b6b188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added composition functions to combine multiple class, method, and property decorators into single composite decorators.

* **Improvements**
  * Stack traces now display more accurate source positions for decorated code. Improved detection of framework-generated decorator helper frames in stack traces helps debugging focus on actual user code rather than internal decorator operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->