### PR TITLE
refactor(decorator-metadata): unify create* and define* APIs

### DIFF
--- a/packages/core/src/built-in-service/config/decorator.ts
+++ b/packages/core/src/built-in-service/config/decorator.ts
@@ -1,8 +1,7 @@
 import { registerAsLeaf } from '../../kernel/di/leaf';
-import { defineInjectableClassDecorator } from '../../kernel/internal/decorator-helpers';
+import { createInjectableClassDecorator } from '../../kernel/internal/decorator-helpers';
 
-export const Config = defineInjectableClassDecorator(
-  undefined,
+export const Config = createInjectableClassDecorator(
   { decorator: 'Config' } as const,
   { afterApply: registerAsLeaf },
   { unique: true },

--- a/packages/core/src/kernel/internal/decorator-helpers.ts
+++ b/packages/core/src/kernel/internal/decorator-helpers.ts
@@ -1,6 +1,6 @@
 import { injectable } from '@needle-di/core';
-import type { ClassDecoratorFn, StackTrace } from '@zeltjs/decorator-metadata';
-import { defineClassDecorator } from '@zeltjs/decorator-metadata';
+import type { ClassDecoratorFn } from '@zeltjs/decorator-metadata';
+import { createClassDecorator } from '@zeltjs/decorator-metadata';
 import { match } from 'ts-pattern';
 
 import { ZeltDecoratorUsageError } from '../errors';
@@ -14,7 +14,7 @@ export type InjectableClassDecoratorHooks = {
   readonly afterApply?: (cls: InjectableClass) => void;
 };
 
-export type DefineInjectableClassDecoratorOptions = {
+export type CreateInjectableClassDecoratorOptions = {
   /**
    * When true, applying the same-named decorator (matched by props.decorator)
    * more than once to the same class throws ZeltDecoratorUsageError.
@@ -36,14 +36,12 @@ const buildUniqueGuard =
   };
 
 /** @throws {ZeltDecoratorUsageError} */
-export const defineInjectableClassDecorator = <TProps extends { decorator: string }>(
-  trace: StackTrace | undefined,
+export const createInjectableClassDecorator = <TProps extends { decorator: string }>(
   props: TProps,
   hooks?: InjectableClassDecoratorHooks,
-  options?: DefineInjectableClassDecoratorOptions,
+  options?: CreateInjectableClassDecoratorOptions,
 ): ClassDecoratorFn => {
-  const base = defineClassDecorator<TProps, ZeltDecoratorUsageError>(
-    trace,
+  const base = createClassDecorator<TProps, ZeltDecoratorUsageError>(
     props,
     options?.unique ? { rejectIfApplied: buildUniqueGuard(props.decorator) } : undefined,
   );

--- a/packages/core/src/kernel/internal/decorator-position.test.ts
+++ b/packages/core/src/kernel/internal/decorator-position.test.ts
@@ -1,10 +1,11 @@
+import { captureStackTrace } from '@zeltjs/decorator-metadata';
 import { describe, expect, it } from 'vitest';
 
-import { captureStackTraceForCore, resolvePositionForCore } from './decorator-position';
+import { resolvePositionForCore } from './decorator-position';
 
-describe('captureStackTraceForCore and resolvePositionForCore', () => {
-  it('captures stack trace and resolves to user file position', () => {
-    const trace = captureStackTraceForCore();
+describe('resolvePositionForCore', () => {
+  it('resolves stack trace to user file position', () => {
+    const trace = captureStackTrace();
     expect(trace).toBeDefined();
 
     const pos = resolvePositionForCore(trace);

--- a/packages/core/src/kernel/internal/decorator-position.ts
+++ b/packages/core/src/kernel/internal/decorator-position.ts
@@ -1,12 +1,10 @@
 import type { Position, StackTrace } from '@zeltjs/decorator-metadata';
-import { captureStackTrace, resolvePosition } from '@zeltjs/decorator-metadata';
+import { resolvePosition } from '@zeltjs/decorator-metadata';
 
 const isCoreFrameworkPath = (path: string): boolean =>
   path.includes('/node_modules/') ||
   (path.includes('/packages/core/') && !/\.(test|spec)\./.test(path)) ||
   path.includes('/packages/decorator-metadata/');
-
-export const captureStackTraceForCore = (): StackTrace | undefined => captureStackTrace();
 
 export const resolvePositionForCore = (trace: StackTrace | undefined): Position | undefined =>
   resolvePosition(trace, { isFrameworkPath: isCoreFrameworkPath });

--- a/packages/core/src/modules/command/decorator.ts
+++ b/packages/core/src/modules/command/decorator.ts
@@ -1,6 +1,5 @@
 import { registerAsTransient } from '../../kernel/di/transient';
-import { defineInjectableClassDecorator } from '../../kernel/internal/decorator-helpers';
-import { captureStackTraceForCore } from '../../kernel/internal/decorator-position';
+import { createInjectableClassDecorator } from '../../kernel/internal/decorator-helpers';
 
 type CommandOptions = {
   readonly name: string;
@@ -8,8 +7,7 @@ type CommandOptions = {
 };
 
 export const Command = (options: CommandOptions) =>
-  defineInjectableClassDecorator(
-    captureStackTraceForCore(),
+  createInjectableClassDecorator(
     options.description
       ? {
           decorator: 'Command' as const,

--- a/packages/core/src/modules/http/decorators/authorized.ts
+++ b/packages/core/src/modules/http/decorators/authorized.ts
@@ -1,18 +1,13 @@
-import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
+import { createMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel/errors';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
 import type { RequestContextSchema } from '../primitives/get-context';
 
 type Roles = RequestContextSchema['authRoles'];
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Authorized = (roles: Roles = []) =>
-  defineMethodDecorator(
-    captureStackTraceForCore(),
-    { decorator: 'Authorized' as const, roles } as const,
-    {
-      rejectStatic: () =>
-        new ZeltDecoratorUsageError({ decoratorName: 'Authorized', reason: 'static_method' }),
-    },
-  );
+  createMethodDecorator({ decorator: 'Authorized' as const, roles } as const, {
+    rejectStatic: () =>
+      new ZeltDecoratorUsageError({ decoratorName: 'Authorized', reason: 'static_method' }),
+  });

--- a/packages/core/src/modules/http/decorators/controller.ts
+++ b/packages/core/src/modules/http/decorators/controller.ts
@@ -1,11 +1,7 @@
-import { defineInjectableClassDecorator } from '../../../kernel/internal/decorator-helpers';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
+import { createInjectableClassDecorator } from '../../../kernel/internal/decorator-helpers';
 
 /** @throws {ZeltLifecycleStateError | ZeltDecoratorUsageError} */
 export const Controller = (basePath: string) =>
-  defineInjectableClassDecorator(
-    captureStackTraceForCore(),
-    { decorator: 'Controller', basePath } as const,
-    undefined,
-    { unique: true },
-  );
+  createInjectableClassDecorator({ decorator: 'Controller', basePath } as const, undefined, {
+    unique: true,
+  });

--- a/packages/core/src/modules/http/decorators/error-handler.ts
+++ b/packages/core/src/modules/http/decorators/error-handler.ts
@@ -1,11 +1,10 @@
-import { defineInjectableClassDecorator } from '../../../kernel/internal/decorator-helpers';
+import { createInjectableClassDecorator } from '../../../kernel/internal/decorator-helpers';
 
 // `@ErrorHandler` is applied without invocation (`@ErrorHandler` not
 // `@ErrorHandler()`), so the decorator function itself is exported. Source
 // position is not needed for ErrorHandler — only the `decorator` tag is used
 // by collectors.
-export const ErrorHandler = defineInjectableClassDecorator(
-  undefined,
+export const ErrorHandler = createInjectableClassDecorator(
   { decorator: 'ErrorHandler' } as const,
   undefined,
   { unique: true },

--- a/packages/core/src/modules/http/decorators/http-method.ts
+++ b/packages/core/src/modules/http/decorators/http-method.ts
@@ -1,19 +1,14 @@
-import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
+import { createMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel/errors';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
 import type { HttpMethod } from '../internal/metadata';
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 const makeDecorator = (method: HttpMethod) => (path: string) =>
-  defineMethodDecorator(
-    captureStackTraceForCore(),
-    { decorator: 'Route' as const, method, path } as const,
-    {
-      rejectStatic: () =>
-        new ZeltDecoratorUsageError({ decoratorName: method, reason: 'static_method' }),
-    },
-  );
+  createMethodDecorator({ decorator: 'Route' as const, method, path } as const, {
+    rejectStatic: () =>
+      new ZeltDecoratorUsageError({ decoratorName: method, reason: 'static_method' }),
+  });
 
 export const Get = makeDecorator('GET');
 export const Post = makeDecorator('POST');

--- a/packages/core/src/modules/http/decorators/middleware.ts
+++ b/packages/core/src/modules/http/decorators/middleware.ts
@@ -1,7 +1,6 @@
-import { defineInjectableClassDecorator } from '../../../kernel/internal/decorator-helpers';
+import { createInjectableClassDecorator } from '../../../kernel/internal/decorator-helpers';
 
-export const Middleware = defineInjectableClassDecorator(
-  undefined,
+export const Middleware = createInjectableClassDecorator(
   { decorator: 'Middleware' } as const,
   undefined,
   { unique: true },

--- a/packages/core/src/modules/http/decorators/skip-middleware.ts
+++ b/packages/core/src/modules/http/decorators/skip-middleware.ts
@@ -1,16 +1,11 @@
-import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
+import { createMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel/errors';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
 import type { MiddlewareIdentifier } from '../middleware/types';
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const SkipMiddleware = (...skipped: MiddlewareIdentifier[]) =>
-  defineMethodDecorator(
-    captureStackTraceForCore(),
-    { decorator: 'SkipMiddleware' as const, skipped } as const,
-    {
-      rejectStatic: () =>
-        new ZeltDecoratorUsageError({ decoratorName: 'SkipMiddleware', reason: 'static_method' }),
-    },
-  );
+  createMethodDecorator({ decorator: 'SkipMiddleware' as const, skipped } as const, {
+    rejectStatic: () =>
+      new ZeltDecoratorUsageError({ decoratorName: 'SkipMiddleware', reason: 'static_method' }),
+  });

--- a/packages/core/src/modules/http/decorators/use-middleware.ts
+++ b/packages/core/src/modules/http/decorators/use-middleware.ts
@@ -1,8 +1,7 @@
-import { defineClassDecorator, defineMethodDecorator } from '@zeltjs/decorator-metadata';
+import { createClassDecorator, createMethodDecorator } from '@zeltjs/decorator-metadata';
 import { match, P } from 'ts-pattern';
 
 import { ZeltDecoratorUsageError } from '../../../kernel/errors';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
 import type { MiddlewareInput } from '../middleware/types';
 
 const tc39ClassPattern = { kind: 'class' as const, metadata: P.nonNullable };
@@ -26,10 +25,9 @@ type UseMiddlewareFn = {
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const UseMiddleware = (...middlewares: MiddlewareInput[]): UseMiddlewareFn => {
-  const trace = captureStackTraceForCore();
   const props = { decorator: 'UseMiddleware' as const, middlewares };
-  const classDecorate = defineClassDecorator(trace, props);
-  const methodDecorate = defineMethodDecorator(trace, props, {
+  const classDecorate = createClassDecorator(props);
+  const methodDecorate = createMethodDecorator(props, {
     rejectStatic: () =>
       new ZeltDecoratorUsageError({ decoratorName: 'UseMiddleware', reason: 'static_method' }),
   });

--- a/packages/core/src/modules/scheduler/decorators/cron.ts
+++ b/packages/core/src/modules/scheduler/decorators/cron.ts
@@ -1,7 +1,6 @@
-import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
+import { createMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel/errors';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
 
 type CronOptions = {
   readonly tz?: string;
@@ -9,8 +8,7 @@ type CronOptions = {
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const Cron = (expression: string, options?: CronOptions) =>
-  defineMethodDecorator(
-    captureStackTraceForCore(),
+  createMethodDecorator(
     {
       decorator: 'Schedule' as const,
       cronExpression: expression,

--- a/packages/core/src/modules/scheduler/decorators/daily.ts
+++ b/packages/core/src/modules/scheduler/decorators/daily.ts
@@ -1,7 +1,6 @@
-import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
+import { createMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel/errors';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
 
 type DailyOptions = {
   readonly hour: number;
@@ -13,8 +12,7 @@ type DailyOptions = {
 export const Daily = (options: DailyOptions) => {
   const minute = options.minute ?? 0;
   const cronExpression = `${minute} ${options.hour} * * *`;
-  return defineMethodDecorator(
-    captureStackTraceForCore(),
+  return createMethodDecorator(
     {
       decorator: 'Schedule' as const,
       cronExpression,

--- a/packages/core/src/modules/scheduler/decorators/every.ts
+++ b/packages/core/src/modules/scheduler/decorators/every.ts
@@ -1,7 +1,6 @@
-import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
+import { createMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel/errors';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
 
 type EveryOptions =
   | { readonly minutes: number; readonly seconds?: never }
@@ -13,12 +12,8 @@ export const Every = (options: EveryOptions) => {
     options.seconds !== undefined
       ? `*/${options.seconds} * * * * *`
       : `*/${options.minutes} * * * *`;
-  return defineMethodDecorator(
-    captureStackTraceForCore(),
-    { decorator: 'Schedule' as const, cronExpression } as const,
-    {
-      rejectStatic: () =>
-        new ZeltDecoratorUsageError({ decoratorName: 'Every', reason: 'static_method' }),
-    },
-  );
+  return createMethodDecorator({ decorator: 'Schedule' as const, cronExpression } as const, {
+    rejectStatic: () =>
+      new ZeltDecoratorUsageError({ decoratorName: 'Every', reason: 'static_method' }),
+  });
 };

--- a/packages/core/src/modules/scheduler/decorators/hourly.ts
+++ b/packages/core/src/modules/scheduler/decorators/hourly.ts
@@ -1,7 +1,6 @@
-import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
+import { createMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel/errors';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
 
 type HourlyOptions = {
   readonly minute?: number;
@@ -12,8 +11,7 @@ type HourlyOptions = {
 export const Hourly = (options?: HourlyOptions) => {
   const minute = options?.minute ?? 0;
   const cronExpression = `${minute} * * * *`;
-  return defineMethodDecorator(
-    captureStackTraceForCore(),
+  return createMethodDecorator(
     {
       decorator: 'Schedule' as const,
       cronExpression,

--- a/packages/core/src/modules/scheduler/decorators/scheduled.ts
+++ b/packages/core/src/modules/scheduler/decorators/scheduled.ts
@@ -1,11 +1,5 @@
-import { defineInjectableClassDecorator } from '../../../kernel/internal/decorator-helpers';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
+import { createInjectableClassDecorator } from '../../../kernel/internal/decorator-helpers';
 
 /** @throws {ZeltLifecycleStateError | ZeltDecoratorUsageError} */
 export const Scheduled = () =>
-  defineInjectableClassDecorator(
-    captureStackTraceForCore(),
-    { decorator: 'Scheduled' } as const,
-    undefined,
-    { unique: true },
-  );
+  createInjectableClassDecorator({ decorator: 'Scheduled' } as const, undefined, { unique: true });

--- a/packages/core/src/modules/scheduler/decorators/weekly.ts
+++ b/packages/core/src/modules/scheduler/decorators/weekly.ts
@@ -1,7 +1,6 @@
-import { defineMethodDecorator } from '@zeltjs/decorator-metadata';
+import { createMethodDecorator } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel/errors';
-import { captureStackTraceForCore } from '../../../kernel/internal/decorator-position';
 
 type DayOfWeek = 'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday';
 
@@ -27,8 +26,7 @@ export const Weekly = (options: WeeklyOptions) => {
   const minute = options.minute ?? 0;
   const cronDay = dayToCron[options.day];
   const cronExpression = `${minute} ${options.hour} * * ${cronDay}`;
-  return defineMethodDecorator(
-    captureStackTraceForCore(),
+  return createMethodDecorator(
     {
       decorator: 'Schedule' as const,
       cronExpression,

--- a/packages/decorator-metadata/README.md
+++ b/packages/decorator-metadata/README.md
@@ -56,7 +56,7 @@ pnpm add @zeltjs/decorator-metadata
 
 ## Usage
 
-### Runtime API — `create*` (simple)
+### Runtime API — `create*`
 
 Create decorators that capture metadata at definition time:
 
@@ -85,30 +85,17 @@ class UserController {
 }
 ```
 
-`createClassDecorator` / `createMethodDecorator` / `createPropertyDecorator` capture the source position via `Error.stack` at the moment the factory is called. They are thin shortcuts over `define*` (below).
+`createClassDecorator` / `createMethodDecorator` / `createPropertyDecorator` capture the source position via `Error.stack` at the moment the factory is called.
 
 **Note:** Decorator identifiers (e.g. `'Get'`, `'Column'`) are not captured automatically. Include a `decorator` field in `props` to distinguish between decorator types when reading metadata.
 
-### Runtime API — `define*` (advanced, framework authors)
+### Options
 
-When you wrap `create*` inside your own helper, the captured source position points to the wrapper, not the user's code. Use `define*` to inject the position explicitly and to opt into additional behaviour:
+Both `createClassDecorator` and `createMethodDecorator` accept an optional second argument for advanced behavior:
 
 ```typescript
-import {
-  defineClassDecorator,
-  defineMethodDecorator,
-  definePropertyDecorator,
-  getCallerPosition,
-} from '@zeltjs/decorator-metadata';
-
-// Custom framework-path filter so the stack walker skips your own wrapper.
-const skipFrameworkFrames = (path: string) =>
-  path.includes('/node_modules/') ||
-  path.includes('/packages/my-framework/src/');
-
 const Route = (method: 'GET' | 'POST', path: string) =>
-  defineMethodDecorator(
-    getCallerPosition({ isFrameworkPath: skipFrameworkFrames }),
+  createMethodDecorator(
     { decorator: 'Route', method, path },
     {
       // Throw a framework-specific error if applied to a static method.
@@ -117,8 +104,7 @@ const Route = (method: 'GET' | 'POST', path: string) =>
   );
 
 const Singleton = () =>
-  defineClassDecorator(
-    getCallerPosition({ isFrameworkPath: skipFrameworkFrames }),
+  createClassDecorator(
     { decorator: 'Singleton' },
     {
       // Reject duplicate application (e.g. `@Singleton @Singleton class C {}`).
@@ -130,27 +116,21 @@ const Singleton = () =>
   );
 ```
 
-**`defineMethodDecorator` options:**
+**`createMethodDecorator` options:**
 
 | Option | Type | Description |
 |---|---|---|
 | `rejectStatic` | `() => Error` | When provided, applying the decorator to a static method throws the returned error. |
 
-**`defineClassDecorator` options:**
+**`createClassDecorator` options:**
 
 | Option | Type | Description |
 |---|---|---|
 | `rejectIfApplied` | `(existing: readonly object[]) => Error \| undefined` | Inspect props already attached to the class. Return an `Error` to abort, or `undefined` to proceed. Lets framework authors implement custom rules such as "no duplicate decorator name" without this package knowing the props shape. |
 
-**`getCallerPosition` options:**
-
-| Option | Type | Description |
-|---|---|---|
-| `isFrameworkPath` | `(path: string) => boolean` | Replaces the default filter (which skips `node_modules` and this package's own runtime). Return `true` for any path that should be considered framework code and skipped during stack walking. |
-
 ### Legacy decorator support
 
-The same `create*` / `define*` factories work transparently with TypeScript's legacy `experimentalDecorators` syntax. Internally the package detects whether the second argument carries a TC39 `kind` field; otherwise it falls back to legacy semantics:
+The `create*` factories work transparently with TypeScript's legacy `experimentalDecorators` syntax. Internally the package detects whether the second argument carries a TC39 `kind` field; otherwise it falls back to legacy semantics:
 
 - **Class**: `(target)` — `cls.prototype` is used as the shared key for flushing pending method/field entries.
 - **Method**: `(target, propertyKey, descriptor)` — `target` is the prototype for instance methods or the class itself for static methods; `isStatic` is derived from `typeof target`.

--- a/packages/decorator-metadata/src/index.ts
+++ b/packages/decorator-metadata/src/index.ts
@@ -1,8 +1,8 @@
 export type {
   ClassDecoratorFn,
-  DefineClassDecoratorOptions,
-  DefineMethodDecoratorOptions,
+  ClassDecoratorOptions,
   MethodDecoratorFn,
+  MethodDecoratorOptions,
   PropertyDecoratorFn,
 } from './runtime/decorators';
 export {
@@ -12,9 +12,6 @@ export {
   createClassDecorator,
   createMethodDecorator,
   createPropertyDecorator,
-  defineClassDecorator,
-  defineMethodDecorator,
-  definePropertyDecorator,
 } from './runtime/decorators';
 export type { Position, ResolvePositionOptions, StackTrace } from './runtime/position';
 export { captureStackTrace, resolvePosition } from './runtime/position';

--- a/packages/decorator-metadata/src/runtime/decorators.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.ts
@@ -79,7 +79,7 @@ const asObject = (v: unknown): object | undefined => {
   return undefined;
 };
 
-export type DefineClassDecoratorOptions<E extends Error = Error> = {
+export type ClassDecoratorOptions<E extends Error = Error> = {
   /**
    * Inspect the props already attached to the class before this decorator runs.
    * Return an Error to abort the application, or undefined to proceed.
@@ -91,7 +91,7 @@ export type DefineClassDecoratorOptions<E extends Error = Error> = {
   readonly rejectIfApplied?: (existing: readonly object[]) => E | undefined;
 };
 
-export type DefineMethodDecoratorOptions<E extends Error = Error> = {
+export type MethodDecoratorOptions<E extends Error = Error> = {
   readonly rejectStatic?: () => E;
 };
 
@@ -117,10 +117,10 @@ export type PropertyDecoratorFn = {
   (target: object, propertyKey: string | symbol): void;
 };
 
-export const defineClassDecorator = <TProps extends object, E extends Error = Error>(
+const defineClassDecorator = <TProps extends object, E extends Error = Error>(
   trace: StackTrace | undefined,
   props: TProps,
-  options?: DefineClassDecoratorOptions<E>,
+  options?: ClassDecoratorOptions<E>,
 ): ClassDecoratorFn => {
   // When no explicit trace is provided, defer captureStackTrace() to decorate()
   // so the stack reflects the actual decoration site, not the factory call site.
@@ -161,10 +161,10 @@ export const defineClassDecorator = <TProps extends object, E extends Error = Er
   return decorate;
 };
 
-export const defineMethodDecorator = <TProps extends object, E extends Error = Error>(
+const defineMethodDecorator = <TProps extends object, E extends Error = Error>(
   trace: StackTrace | undefined,
   props: TProps,
-  options?: DefineMethodDecoratorOptions<E>,
+  options?: MethodDecoratorOptions<E>,
 ): MethodDecoratorFn => {
   const getTrace = trace !== undefined ? () => trace : captureStackTrace;
   /** @throws {E} */
@@ -213,7 +213,7 @@ export const defineMethodDecorator = <TProps extends object, E extends Error = E
   return decorate;
 };
 
-export const definePropertyDecorator = <TProps extends object>(
+const definePropertyDecorator = <TProps extends object>(
   trace: StackTrace | undefined,
   props: TProps,
 ): PropertyDecoratorFn => {
@@ -307,16 +307,16 @@ export const composePropertyDecorators = (
   return decorate;
 };
 
-// `props ?? {}` widens to `TProps | {}`; constraining `TProps` to `object`
-// (which `{}` satisfies) lets us pass it directly without an assertion.
-const emptyProps: object = {};
+export const createClassDecorator = <TProps extends object, E extends Error = Error>(
+  props: TProps,
+  options?: ClassDecoratorOptions<E>,
+): ClassDecoratorFn => defineClassDecorator(captureStackTrace(), props, options);
 
-export const createClassDecorator = <TProps extends object>(props?: TProps): ClassDecoratorFn =>
-  defineClassDecorator(captureStackTrace(), props ?? emptyProps);
-
-export const createMethodDecorator = <TProps extends object>(props?: TProps): MethodDecoratorFn =>
-  defineMethodDecorator(undefined, props ?? emptyProps);
+export const createMethodDecorator = <TProps extends object, E extends Error = Error>(
+  props: TProps,
+  options?: MethodDecoratorOptions<E>,
+): MethodDecoratorFn => defineMethodDecorator(captureStackTrace(), props, options);
 
 export const createPropertyDecorator = <TProps extends object>(
-  props?: TProps,
-): PropertyDecoratorFn => definePropertyDecorator(undefined, props ?? emptyProps);
+  props: TProps,
+): PropertyDecoratorFn => definePropertyDecorator(captureStackTrace(), props);

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -7,9 +7,6 @@ import {
   createClassDecorator,
   createMethodDecorator,
   createPropertyDecorator,
-  defineClassDecorator,
-  defineMethodDecorator,
-  definePropertyDecorator,
 } from '../runtime/decorators';
 import type { StackTrace } from '../runtime/position';
 import { captureStackTrace, resolvePosition } from '../runtime/position';
@@ -251,37 +248,21 @@ describe('decorator factories', () => {
   });
 });
 
-describe('define* primitives', () => {
-  it('defineClassDecorator accepts injected trace and saves metadata', () => {
-    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
-    const Controller = (basePath: string) =>
-      defineClassDecorator(fakeTrace, { decorator: 'Controller', basePath });
-
-    @Controller('/api')
-    class Foo {}
-
-    const meta = getClassMetadata(Foo);
-    expect(meta?.trace).toBe(fakeTrace);
-    expect(meta?.props).toEqual([{ decorator: 'Controller', basePath: '/api' }]);
-  });
-
-  it('defineClassDecorator with undefined trace captures trace at decoration time', () => {
-    const Controller = () => defineClassDecorator(undefined, { decorator: 'Controller' });
+describe('create* options', () => {
+  it('createClassDecorator captures trace at factory call time', () => {
+    const Controller = () => createClassDecorator({ decorator: 'Controller' });
 
     @Controller()
     class Foo {}
 
     const meta = getClassMetadata(Foo);
-    // When no explicit trace is provided, captureStackTrace() is called at decoration time.
     expect(meta?.trace).toBeDefined();
     expect(meta?.props).toEqual([{ decorator: 'Controller' }]);
   });
 
-  it('defineMethodDecorator rejectStatic throws via injected error factory on static methods', () => {
-    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
+  it('createMethodDecorator rejectStatic throws on static methods', () => {
     const Get = () =>
-      defineMethodDecorator(
-        fakeTrace,
+      createMethodDecorator(
         { decorator: 'Route', method: 'GET' },
         { rejectStatic: () => new Error('static not allowed for GET') },
       );
@@ -297,30 +278,24 @@ describe('define* primitives', () => {
     expect(apply).toThrow(/static not allowed for GET/);
   });
 
-  it('defineMethodDecorator without rejectStatic accepts static methods', () => {
-    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
-    const Tag = () => defineMethodDecorator(fakeTrace, { decorator: 'Tag' });
+  it('createMethodDecorator without rejectStatic accepts static methods', () => {
+    const Tag = () => createMethodDecorator({ decorator: 'Tag' });
 
     class Foo {
       @Tag()
       static handler() {}
     }
 
-    // No metadata is captured because static methods don't share the class's
-    // context.metadata, but no throw either.
     const meta = getClassMetadata(Foo);
-    // Either no methods at all, or no Tag prop captured — both acceptable.
     expect(meta?.methods.find((m) => m.name === 'handler')).toBeUndefined();
   });
 
-  it('defineClassDecorator rejectIfApplied callback can veto a second application', () => {
-    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
+  it('createClassDecorator rejectIfApplied callback can veto a second application', () => {
     const Once = () =>
-      defineClassDecorator(
-        fakeTrace,
+      createClassDecorator(
         { decorator: 'Once' },
         {
-          rejectIfApplied: (existing) =>
+          rejectIfApplied: (existing: readonly object[]) =>
             existing.some((p) => (p as { decorator?: string }).decorator === 'Once')
               ? new Error('Once already applied')
               : undefined,
@@ -337,14 +312,9 @@ describe('define* primitives', () => {
     expect(apply).toThrow(/Once already applied/);
   });
 
-  it('defineClassDecorator rejectIfApplied returns undefined when no conflict', () => {
-    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
+  it('createClassDecorator rejectIfApplied returns undefined when no conflict', () => {
     const Marker = () =>
-      defineClassDecorator(
-        fakeTrace,
-        { decorator: 'Marker' },
-        { rejectIfApplied: () => undefined },
-      );
+      createClassDecorator({ decorator: 'Marker' }, { rejectIfApplied: () => undefined });
 
     @Marker()
     class Foo {}
@@ -352,11 +322,10 @@ describe('define* primitives', () => {
     expect(getClassMetadata(Foo)?.props).toEqual([{ decorator: 'Marker' }]);
   });
 
-  it('defineClassDecorator stacks multiple decorators by appending props', () => {
-    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
+  it('createClassDecorator stacks multiple decorators by appending props', () => {
     const Controller = (basePath: string) =>
-      defineClassDecorator(fakeTrace, { decorator: 'Controller', basePath });
-    const UseAuth = () => defineClassDecorator(fakeTrace, { decorator: 'UseAuth' });
+      createClassDecorator({ decorator: 'Controller', basePath });
+    const UseAuth = () => createClassDecorator({ decorator: 'UseAuth' });
 
     @UseAuth()
     @Controller('/users')
@@ -369,17 +338,10 @@ describe('define* primitives', () => {
     ]);
   });
 
-  // The decorator factories below are invoked directly (without `@`) so the
-  // tests don't depend on `experimentalDecorators` being enabled for tsx.
-  // Each test exercises the legacy-style call signature: classes get `(target)`,
-  // instance methods get `(prototype, name, descriptor)`, static methods get
-  // `(class, name, descriptor)`, and fields get `(prototype, name)`.
   describe('legacy decorator support', () => {
-    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
-
     it('legacy class decorator stores metadata and returns the target', () => {
       class Foo {}
-      const apply = defineClassDecorator(fakeTrace, { decorator: 'Controller', basePath: '/x' });
+      const apply = createClassDecorator({ decorator: 'Controller', basePath: '/x' });
       const result = (apply as unknown as (target: unknown) => unknown)(Foo);
       expect(result).toBe(Foo);
       const meta = getClassMetadata(Foo);
@@ -388,13 +350,13 @@ describe('define* primitives', () => {
 
     it('legacy instance method flushes via legacy class decorator', () => {
       class Foo {}
-      const method = defineMethodDecorator(fakeTrace, { decorator: 'Route', method: 'GET' });
+      const method = createMethodDecorator({ decorator: 'Route', method: 'GET' });
       (method as unknown as (target: unknown, name: string, desc: object) => void)(
         Foo.prototype,
         'handler',
         { value: () => {} },
       );
-      const cls = defineClassDecorator(fakeTrace, { decorator: 'Controller' });
+      const cls = createClassDecorator({ decorator: 'Controller' });
       (cls as unknown as (target: unknown) => void)(Foo);
       const meta = getClassMetadata(Foo);
       expect(meta?.methods).toHaveLength(1);
@@ -404,8 +366,7 @@ describe('define* primitives', () => {
 
     it('legacy static method invokes rejectStatic factory', () => {
       class Foo {}
-      const method = defineMethodDecorator(
-        fakeTrace,
+      const method = createMethodDecorator(
         { decorator: 'Route' },
         { rejectStatic: () => new Error('static not allowed (legacy)') },
       );
@@ -420,9 +381,9 @@ describe('define* primitives', () => {
 
     it('legacy property decorator flushes via legacy class decorator', () => {
       class Foo {}
-      const field = definePropertyDecorator(fakeTrace, { decorator: 'Column', nullable: false });
+      const field = createPropertyDecorator({ decorator: 'Column', nullable: false });
       (field as unknown as (target: unknown, name: string) => void)(Foo.prototype, 'name');
-      const cls = defineClassDecorator(fakeTrace, { decorator: 'Container' });
+      const cls = createClassDecorator({ decorator: 'Container' });
       (cls as unknown as (target: unknown) => void)(Foo);
       const meta = getClassMetadata(Foo);
       expect(meta?.properties).toHaveLength(1);
@@ -431,7 +392,7 @@ describe('define* primitives', () => {
     });
 
     it('TC39 class decorator returns undefined to avoid replacement', () => {
-      const apply = defineClassDecorator(fakeTrace, { decorator: 'Controller' });
+      const apply = createClassDecorator({ decorator: 'Controller' });
       class Foo {}
       const ctx: ClassDecoratorContext = {
         kind: 'class',
@@ -447,11 +408,10 @@ describe('define* primitives', () => {
     });
   });
 
-  it('definePropertyDecorator accepts injected pos', () => {
-    const fakeTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
-    const Container = () => defineClassDecorator(fakeTrace, { decorator: 'Container' });
+  it('createPropertyDecorator saves metadata', () => {
+    const Container = () => createClassDecorator({ decorator: 'Container' });
     const Column = (opts?: { nullable?: boolean }) =>
-      definePropertyDecorator(fakeTrace, {
+      createPropertyDecorator({
         decorator: 'Column',
         nullable: opts?.nullable ?? false,
       });


### PR DESCRIPTION
## Summary

- Unify `define*` and `create*` decorator APIs into a single `create*` API
- Remove the confusing distinction between two similar-sounding APIs that did slightly different things
- `create*` now accepts an optional `options` parameter for advanced use cases (`rejectIfApplied`, `rejectStatic`)
- Trace is always captured internally - no manual injection needed

## Changes

**decorator-metadata package:**
- `createClassDecorator(props, options?)` replaces `defineClassDecorator`
- `createMethodDecorator(props, options?)` replaces `defineMethodDecorator`
- `createPropertyDecorator(props)` replaces `definePropertyDecorator`
- Type renames: `DefineClassDecoratorOptions` → `ClassDecoratorOptions`, `DefineMethodDecoratorOptions` → `MethodDecoratorOptions`

**core package:**
- `defineInjectableClassDecorator` → `createInjectableClassDecorator` (trace argument removed)
- All decorator files migrated to unified `create*` API
- Removed `captureStackTraceForCore` (no longer needed)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @zeltjs/decorator-metadata test` passes
- [x] `pnpm --filter @zeltjs/core test` passes
- [x] `pnpm test` passes (all 567 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782177787&installation_id=133048706&pr_number=204&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F204&signature=274e7201e645bc233b62c9afef6a59c078379dae726e51b362828357cd7b2395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated decorator-metadata API documentation to clarify decorator factory usage patterns and source position capture behavior.

* **Refactor**
  * Simplified internal decorator factory implementations across multiple modules, improving code maintainability without affecting end-user functionality.
  * Streamlined source position tracking mechanisms in decorator utilities.

* **Tests**
  * Updated test coverage to validate refactored decorator factory behaviors and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->