### PR TITLE
refactor(decorator-metadata): unify decorator API and restructure internals

### DIFF
--- a/packages/decorator-metadata/src/inspect/get-type-metadata.ts
+++ b/packages/decorator-metadata/src/inspect/get-type-metadata.ts
@@ -32,12 +32,12 @@ type TSTypeChecker = import('typescript').TypeChecker;
 type ExtractTypeFn = (type: import('typescript').Type) => TypeInfo;
 
 type StoredMethodMeta = {
-  readonly name: string;
+  readonly name: string | symbol;
   readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
 };
 type StoredPropertyMeta = {
-  readonly name: string;
+  readonly name: string | symbol;
   readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
 };
@@ -89,25 +89,27 @@ const extractMethodInfo = (
   checker: TSTypeChecker,
   extractType: ExtractTypeFn,
 ): MethodInfo => {
-  const methodNode = findMethodInClass(classNode, m.name, ts);
   const params: ParamInfo[] = [];
   let returnType: TypeInfo = { kind: 'unknown' };
 
-  if (methodNode) {
-    const sig = checker.getSignatureFromDeclaration(methodNode);
-    if (sig) {
-      for (const param of sig.getParameters()) {
-        const paramType = checker.getTypeOfSymbol(param);
-        params.push({ name: param.getName(), type: extractType(paramType) });
-      }
+  if (typeof m.name === 'string') {
+    const methodNode = findMethodInClass(classNode, m.name, ts);
+    if (methodNode) {
+      const sig = checker.getSignatureFromDeclaration(methodNode);
+      if (sig) {
+        for (const param of sig.getParameters()) {
+          const paramType = checker.getTypeOfSymbol(param);
+          params.push({ name: param.getName(), type: extractType(paramType) });
+        }
 
-      let retType = sig.getReturnType();
-      const retTypeStr = checker.typeToString(retType);
-      if (retTypeStr.startsWith('Promise<')) {
-        const typeRef = retType as import('typescript').TypeReference;
-        retType = typeRef.typeArguments?.[0] ?? retType;
+        let retType = sig.getReturnType();
+        const retTypeStr = checker.typeToString(retType);
+        if (retTypeStr.startsWith('Promise<')) {
+          const typeRef = retType as import('typescript').TypeReference;
+          retType = typeRef.typeArguments?.[0] ?? retType;
+        }
+        returnType = extractType(retType);
       }
-      returnType = extractType(retType);
     }
   }
 
@@ -122,16 +124,18 @@ const extractPropertyInfo = (
   checker: TSTypeChecker,
   extractType: ExtractTypeFn,
 ): PropertyInfo => {
-  const propNode = findPropertyInClass(classNode, p.name, ts);
   let type: TypeInfo = { kind: 'unknown' };
   let optional = false;
 
-  if (propNode) {
-    const propSymbol = checker.getSymbolAtLocation(propNode.name);
-    if (propSymbol) {
-      const propType = checker.getTypeOfSymbol(propSymbol);
-      type = extractType(propType);
-      optional = (propSymbol.flags & ts.SymbolFlags.Optional) !== 0;
+  if (typeof p.name === 'string') {
+    const propNode = findPropertyInClass(classNode, p.name, ts);
+    if (propNode) {
+      const propSymbol = checker.getSymbolAtLocation(propNode.name);
+      if (propSymbol) {
+        const propType = checker.getTypeOfSymbol(propSymbol);
+        type = extractType(propType);
+        optional = (propSymbol.flags & ts.SymbolFlags.Optional) !== 0;
+      }
     }
   }
 

--- a/packages/decorator-metadata/src/inspect/types.ts
+++ b/packages/decorator-metadata/src/inspect/types.ts
@@ -32,7 +32,7 @@ export type ParamInfo = {
 };
 
 export type MethodInfo = {
-  readonly name: string;
+  readonly name: string | symbol;
   readonly pos: Position | undefined;
   readonly props: readonly object[];
   readonly params: readonly ParamInfo[];
@@ -40,7 +40,7 @@ export type MethodInfo = {
 };
 
 export type PropertyInfo = {
-  readonly name: string;
+  readonly name: string | symbol;
   readonly pos: Position | undefined;
   readonly props: readonly object[];
   readonly type: TypeInfo;

--- a/packages/decorator-metadata/src/runtime/decorators.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.ts
@@ -100,7 +100,7 @@ const adaptClassContext = (handler: ClassHandler): ClassDecoratorFn => {
   return decorate;
 };
 
-type MethodHandler = (classKey: object, name: string, isStatic: boolean) => void;
+type MethodHandler = (classKey: object, name: string | symbol, isStatic: boolean) => void;
 
 const adaptMethodContext = (handler: MethodHandler): MethodDecoratorFn => {
   function decorate(
@@ -118,13 +118,15 @@ const adaptMethodContext = (handler: MethodHandler): MethodDecoratorFn => {
 
     return match(contextOrName)
       .with(tc39MethodContextPattern, (ctx) => {
-        if (typeof ctx.name !== 'string') return undefined;
+        if (typeof ctx.name !== 'string' && typeof ctx.name !== 'symbol') return undefined;
         if (!ctx.metadata) return undefined;
         handler(ctx.metadata, ctx.name, ctx.static ?? false);
         return undefined;
       })
       .otherwise(() => {
-        if (typeof contextOrName !== 'string') return undefined;
+        if (typeof contextOrName !== 'string' && typeof contextOrName !== 'symbol') {
+          return undefined;
+        }
         const classKey = asObject(target);
         if (!classKey) return undefined;
         const isStatic = typeof target === 'function';
@@ -135,7 +137,7 @@ const adaptMethodContext = (handler: MethodHandler): MethodDecoratorFn => {
   return decorate;
 };
 
-type PropertyHandler = (classKey: object, name: string) => void;
+type PropertyHandler = (classKey: object, name: string | symbol) => void;
 
 const adaptPropertyContext = (handler: PropertyHandler): PropertyDecoratorFn => {
   function decorate(value: undefined, context: ClassFieldDecoratorContext): void;
@@ -146,13 +148,15 @@ const adaptPropertyContext = (handler: PropertyHandler): PropertyDecoratorFn => 
 
     return match(contextOrName)
       .with(tc39FieldContextPattern, (ctx) => {
-        if (typeof ctx.name !== 'string') return undefined;
+        if (typeof ctx.name !== 'string' && typeof ctx.name !== 'symbol') return undefined;
         if (!ctx.metadata) return undefined;
         handler(ctx.metadata, ctx.name);
         return undefined;
       })
       .otherwise(() => {
-        if (typeof contextOrName !== 'string') return undefined;
+        if (typeof contextOrName !== 'string' && typeof contextOrName !== 'symbol') {
+          return undefined;
+        }
         const classKey = asObject(target);
         if (!classKey) return undefined;
         handler(classKey, contextOrName);

--- a/packages/decorator-metadata/src/runtime/decorators.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.ts
@@ -1,50 +1,48 @@
 import { match, P } from 'ts-pattern';
 
-import type { StackTrace } from './position';
 import { captureStackTrace } from './position';
 import {
+  aggregateMembers,
   ensureClassMeta,
   getClassMetadata,
-  setClassMetadata,
-  setMethodMetadata,
-  setPropertyMetadata,
+  recordClass,
+  recordMethod,
+  recordProperty,
 } from './store';
 
-type PendingEntry = {
-  readonly name: string;
-  readonly trace: StackTrace | undefined;
-  readonly props: object;
+// =============================================================================
+// Types
+// =============================================================================
+
+export type ClassDecoratorOptions<E extends Error = Error> = {
+  readonly rejectIfApplied?: (existing: readonly object[]) => E | undefined;
 };
 
-// pendingMethods / pendingFields are keyed on the "shared key" for the class:
-//   - TC39: context.metadata (a fresh object created per class)
-//   - legacy: cls.prototype (the shared prototype object)
-// Both paths converge in flushPendingToClass(cls, sharedKey).
-const pendingMethods = new WeakMap<object, PendingEntry[]>();
-const pendingFields = new WeakMap<object, PendingEntry[]>();
-
-const appendEntry = (
-  store: WeakMap<object, PendingEntry[]>,
-  meta: object,
-  entry: PendingEntry,
-): void => {
-  const list = store.get(meta) ?? [];
-  store.set(meta, [...list, entry]);
+export type MethodDecoratorOptions<E extends Error = Error> = {
+  readonly rejectStatic?: () => E;
 };
 
-const flushPendingToClass = (cls: object, sharedKey: object): void => {
-  for (const { name, trace, props } of pendingMethods.get(sharedKey) ?? []) {
-    setMethodMetadata(cls, name, trace, props);
-  }
-  for (const { name, trace, props } of pendingFields.get(sharedKey) ?? []) {
-    setPropertyMetadata(cls, name, trace, props);
-  }
-  pendingMethods.delete(sharedKey);
-  pendingFields.delete(sharedKey);
+export type ClassDecoratorFn = {
+  <T extends abstract new (...args: never[]) => unknown>(
+    value: T,
+    context: ClassDecoratorContext,
+  ): void;
+  <T extends new (...args: never[]) => unknown>(target: T): T | undefined;
 };
 
-// TC39 decorator context detection. Legacy decorators never pass a `kind` field
-// in their second argument, so we discriminate on its presence with ts-pattern.
+export type MethodDecoratorFn = {
+  (value: (...args: never[]) => unknown, context: ClassMethodDecoratorContext): void;
+  (target: object, propertyKey: string | symbol, descriptor?: PropertyDescriptor): void;
+};
+
+export type PropertyDecoratorFn = {
+  (value: undefined, context: ClassFieldDecoratorContext): void;
+  (target: object, propertyKey: string | symbol): void;
+};
+
+// =============================================================================
+// Adapter Layer - Normalize TC39/Legacy differences
+// =============================================================================
 
 const tc39ClassContextPattern = {
   kind: 'class' as const,
@@ -66,8 +64,6 @@ const tc39FieldContextPattern = {
 };
 
 const getPrototypeKey = (cls: object): object => {
-  // Class constructors are functions and their `prototype` is non-enumerable,
-  // so we go through the Function shape rather than a structural pattern.
   if (typeof cls !== 'function') return cls;
   const proto: unknown = cls.prototype;
   return typeof proto === 'object' && proto !== null ? proto : cls;
@@ -79,145 +75,69 @@ const asObject = (v: unknown): object | undefined => {
   return undefined;
 };
 
-export type ClassDecoratorOptions<E extends Error = Error> = {
-  /**
-   * Inspect the props already attached to the class before this decorator runs.
-   * Return an Error to abort the application, or undefined to proceed.
-   *
-   * Callers decide the rejection rule (e.g. "no duplicate decorator name") —
-   * this package stays agnostic about the props shape. The error type E is
-   * propagated to call sites so consumers keep their concrete error class.
-   */
-  readonly rejectIfApplied?: (existing: readonly object[]) => E | undefined;
-};
+type ClassHandler = (cls: object, classKey: object) => void;
 
-export type MethodDecoratorOptions<E extends Error = Error> = {
-  readonly rejectStatic?: () => E;
-};
-
-// Overloaded signatures so the same decorator works under both TC39 (the
-// `(value, context)` form) and legacy `experimentalDecorators` (the
-// `(target)` / `(target, propertyKey, descriptor)` forms).
-
-export type ClassDecoratorFn = {
-  <T extends abstract new (...args: never[]) => unknown>(
-    value: T,
-    context: ClassDecoratorContext,
-  ): void;
-  <T extends new (...args: never[]) => unknown>(target: T): T | void;
-};
-
-export type MethodDecoratorFn = {
-  (value: (...args: never[]) => unknown, context: ClassMethodDecoratorContext): void;
-  (target: object, propertyKey: string | symbol, descriptor?: PropertyDescriptor): void;
-};
-
-export type PropertyDecoratorFn = {
-  (value: undefined, context: ClassFieldDecoratorContext): void;
-  (target: object, propertyKey: string | symbol): void;
-};
-
-const defineClassDecorator = <TProps extends object, E extends Error = Error>(
-  trace: StackTrace | undefined,
-  props: TProps,
-  options?: ClassDecoratorOptions<E>,
-): ClassDecoratorFn => {
-  // When no explicit trace is provided, defer captureStackTrace() to decorate()
-  // so the stack reflects the actual decoration site, not the factory call site.
-  const getTrace = trace !== undefined ? () => trace : captureStackTrace;
-  /** @throws {E} */
+const adaptClassContext = (handler: ClassHandler): ClassDecoratorFn => {
   function decorate<T extends abstract new (...args: never[]) => unknown>(
     value: T,
     context: ClassDecoratorContext,
   ): void;
-  /** @throws {E} */
-  function decorate<T extends new (...args: never[]) => unknown>(target: T): T | void;
-  /** @throws {E} */
+  function decorate<T extends new (...args: never[]) => unknown>(target: T): T | undefined;
   function decorate(...args: unknown[]): unknown {
     const cls = asObject(args[0]);
     if (!cls) return undefined;
 
-    if (options?.rejectIfApplied) {
-      const existing = getClassMetadata(cls)?.props ?? [];
-      const err: E | undefined = options.rejectIfApplied(existing);
-      if (err) throw err;
-    }
-
-    setClassMetadata(cls, getTrace(), props);
-
     return match(args[1])
       .with(tc39ClassContextPattern, (ctx) => {
-        if (ctx.metadata) flushPendingToClass(cls, ctx.metadata);
-        // TC39: returning a function would be adopted as the replacement class,
-        // so return undefined to leave the class unchanged.
+        if (ctx.metadata) handler(cls, ctx.metadata);
         return undefined;
       })
       .otherwise(() => {
-        // Legacy class decorator: pendingKey lives on the prototype.
-        flushPendingToClass(cls, getPrototypeKey(cls));
+        handler(cls, getPrototypeKey(cls));
         return cls;
       });
   }
   return decorate;
 };
 
-const defineMethodDecorator = <TProps extends object, E extends Error = Error>(
-  trace: StackTrace | undefined,
-  props: TProps,
-  options?: MethodDecoratorOptions<E>,
-): MethodDecoratorFn => {
-  const getTrace = trace !== undefined ? () => trace : captureStackTrace;
-  /** @throws {E} */
+type MethodHandler = (classKey: object, name: string, isStatic: boolean) => void;
+
+const adaptMethodContext = (handler: MethodHandler): MethodDecoratorFn => {
   function decorate(
     value: (...args: never[]) => unknown,
     context: ClassMethodDecoratorContext,
   ): void;
-  /** @throws {E} */
   function decorate(
     target: object,
     propertyKey: string | symbol,
     descriptor?: PropertyDescriptor,
   ): void;
-  /** @throws {E} */
   function decorate(...args: unknown[]): unknown {
     const target = args[0];
     const contextOrName = args[1];
 
     return match(contextOrName)
       .with(tc39MethodContextPattern, (ctx) => {
-        if (ctx.static && options?.rejectStatic) {
-          const err: E = options.rejectStatic();
-          throw err;
-        }
         if (typeof ctx.name !== 'string') return undefined;
         if (!ctx.metadata) return undefined;
-        appendEntry(pendingMethods, ctx.metadata, { name: ctx.name, trace: getTrace(), props });
+        handler(ctx.metadata, ctx.name, ctx.static ?? false);
         return undefined;
       })
       .otherwise(() => {
-        // Legacy path. target is the prototype for instance methods or the
-        // class itself for static methods; isStatic is derived from typeof
-        // target.
-        const isStatic = typeof target === 'function';
-        if (isStatic && options?.rejectStatic) {
-          const err: E = options.rejectStatic();
-          throw err;
-        }
         if (typeof contextOrName !== 'string') return undefined;
-        const sharedKey = asObject(target);
-        if (!sharedKey) return undefined;
-        appendEntry(pendingMethods, sharedKey, { name: contextOrName, trace: getTrace(), props });
+        const classKey = asObject(target);
+        if (!classKey) return undefined;
+        const isStatic = typeof target === 'function';
+        handler(classKey, contextOrName, isStatic);
         return undefined;
       });
   }
   return decorate;
 };
 
-const definePropertyDecorator = <TProps extends object>(
-  trace: StackTrace | undefined,
-  props: TProps,
-): PropertyDecoratorFn => {
-  const getTrace = trace !== undefined ? () => trace : captureStackTrace;
+type PropertyHandler = (classKey: object, name: string) => void;
+
+const adaptPropertyContext = (handler: PropertyHandler): PropertyDecoratorFn => {
   function decorate(value: undefined, context: ClassFieldDecoratorContext): void;
   function decorate(target: object, propertyKey: string | symbol): void;
   function decorate(...args: unknown[]): unknown {
@@ -228,29 +148,80 @@ const definePropertyDecorator = <TProps extends object>(
       .with(tc39FieldContextPattern, (ctx) => {
         if (typeof ctx.name !== 'string') return undefined;
         if (!ctx.metadata) return undefined;
-        appendEntry(pendingFields, ctx.metadata, { name: ctx.name, trace: getTrace(), props });
+        handler(ctx.metadata, ctx.name);
         return undefined;
       })
       .otherwise(() => {
         if (typeof contextOrName !== 'string') return undefined;
-        const sharedKey = asObject(target);
-        if (!sharedKey) return undefined;
-        appendEntry(pendingFields, sharedKey, { name: contextOrName, trace: getTrace(), props });
+        const classKey = asObject(target);
+        if (!classKey) return undefined;
+        handler(classKey, contextOrName);
         return undefined;
       });
   }
   return decorate;
 };
 
-export const composeClassDecorators = (...decorators: ClassDecoratorFn[]): ClassDecoratorFn => {
-  // Capture trace at compose-call time (when the user factory returns the decorator),
-  // not inside decorate() which runs inside a transpiler helper and loses the user frame.
+// =============================================================================
+// Public API
+// =============================================================================
+
+export const createClassDecorator = <TProps extends object, E extends Error = Error>(
+  props: TProps,
+  options?: ClassDecoratorOptions<E>,
+): ClassDecoratorFn => {
   const trace = captureStackTrace();
+
+  return adaptClassContext((cls, classKey) => {
+    if (options?.rejectIfApplied) {
+      const existing = getClassMetadata(cls)?.props ?? [];
+      const err: E | undefined = options.rejectIfApplied(existing);
+      if (err) throw err;
+    }
+
+    recordClass(cls, trace, props);
+    aggregateMembers(cls, classKey);
+  });
+};
+
+export const createMethodDecorator = <TProps extends object, E extends Error = Error>(
+  props: TProps,
+  options?: MethodDecoratorOptions<E>,
+): MethodDecoratorFn => {
+  const trace = captureStackTrace();
+
+  return adaptMethodContext((classKey, name, isStatic) => {
+    if (isStatic && options?.rejectStatic) {
+      const err: E = options.rejectStatic();
+      throw err;
+    }
+
+    recordMethod(classKey, name, trace, props);
+  });
+};
+
+export const createPropertyDecorator = <TProps extends object>(
+  props: TProps,
+): PropertyDecoratorFn => {
+  const trace = captureStackTrace();
+
+  return adaptPropertyContext((classKey, name) => {
+    recordProperty(classKey, name, trace, props);
+  });
+};
+
+// =============================================================================
+// Compose API
+// =============================================================================
+
+export const composeClassDecorators = (...decorators: ClassDecoratorFn[]): ClassDecoratorFn => {
+  const trace = captureStackTrace();
+
   function decorate<T extends abstract new (...args: never[]) => unknown>(
     value: T,
     context: ClassDecoratorContext,
   ): void;
-  function decorate<T extends new (...args: never[]) => unknown>(target: T): T | void;
+  function decorate<T extends new (...args: never[]) => unknown>(target: T): T | undefined;
   function decorate(...args: unknown[]): unknown {
     const cls = asObject(args[0]);
     if (!cls) return undefined;
@@ -306,17 +277,3 @@ export const composePropertyDecorators = (
   }
   return decorate;
 };
-
-export const createClassDecorator = <TProps extends object, E extends Error = Error>(
-  props: TProps,
-  options?: ClassDecoratorOptions<E>,
-): ClassDecoratorFn => defineClassDecorator(captureStackTrace(), props, options);
-
-export const createMethodDecorator = <TProps extends object, E extends Error = Error>(
-  props: TProps,
-  options?: MethodDecoratorOptions<E>,
-): MethodDecoratorFn => defineMethodDecorator(captureStackTrace(), props, options);
-
-export const createPropertyDecorator = <TProps extends object>(
-  props: TProps,
-): PropertyDecoratorFn => definePropertyDecorator(captureStackTrace(), props);

--- a/packages/decorator-metadata/src/runtime/store.ts
+++ b/packages/decorator-metadata/src/runtime/store.ts
@@ -1,13 +1,13 @@
 import type { StackTrace } from './position';
 
 export type MethodMeta = {
-  readonly name: string;
+  readonly name: string | symbol;
   readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
 };
 
 export type PropertyMeta = {
-  readonly name: string;
+  readonly name: string | symbol;
   readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
 };
@@ -20,7 +20,7 @@ export type ClassMeta = {
 };
 
 type MemberRecord = {
-  readonly name: string;
+  readonly name: string | symbol;
   readonly trace: StackTrace | undefined;
   readonly props: object;
 };
@@ -43,7 +43,7 @@ const emptyMeta = (): ClassMeta => ({
 
 export const recordMethod = (
   classKey: object,
-  name: string,
+  name: string | symbol,
   trace: StackTrace | undefined,
   props: object,
 ): void => {
@@ -53,7 +53,7 @@ export const recordMethod = (
 
 export const recordProperty = (
   classKey: object,
-  name: string,
+  name: string | symbol,
   trace: StackTrace | undefined,
   props: object,
 ): void => {

--- a/packages/decorator-metadata/src/runtime/store.ts
+++ b/packages/decorator-metadata/src/runtime/store.ts
@@ -19,7 +19,18 @@ export type ClassMeta = {
   readonly properties: readonly PropertyMeta[];
 };
 
+type MemberRecord = {
+  readonly name: string;
+  readonly trace: StackTrace | undefined;
+  readonly props: object;
+};
+
+// Storage: final metadata
 const classStore = new WeakMap<object, ClassMeta>();
+
+// Records: temporary storage for members before class is finalized
+const methodRecords = new WeakMap<object, MemberRecord[]>();
+const propertyRecords = new WeakMap<object, MemberRecord[]>();
 
 const emptyMeta = (): ClassMeta => ({
   trace: undefined,
@@ -28,11 +39,29 @@ const emptyMeta = (): ClassMeta => ({
   properties: [],
 });
 
-export const setClassMetadata = (
-  cls: object,
+// --- Record functions (member responsibility) ---
+
+export const recordMethod = (
+  classKey: object,
+  name: string,
   trace: StackTrace | undefined,
   props: object,
 ): void => {
+  const list = methodRecords.get(classKey) ?? [];
+  methodRecords.set(classKey, [...list, { name, trace, props }]);
+};
+
+export const recordProperty = (
+  classKey: object,
+  name: string,
+  trace: StackTrace | undefined,
+  props: object,
+): void => {
+  const list = propertyRecords.get(classKey) ?? [];
+  propertyRecords.set(classKey, [...list, { name, trace, props }]);
+};
+
+export const recordClass = (cls: object, trace: StackTrace | undefined, props: object): void => {
   const existing = classStore.get(cls) ?? emptyMeta();
   classStore.set(cls, {
     trace: existing.trace ?? trace,
@@ -41,6 +70,66 @@ export const setClassMetadata = (
     properties: existing.properties,
   });
 };
+
+// --- Aggregate function (class additional responsibility) ---
+
+const upsertMethod = (
+  methods: readonly MethodMeta[],
+  record: MemberRecord,
+): readonly MethodMeta[] => {
+  const existing = methods.find((m) => m.name === record.name);
+  if (!existing) {
+    return [...methods, { name: record.name, trace: record.trace, props: [record.props] }];
+  }
+  const updated: MethodMeta = {
+    name: existing.name,
+    trace: existing.trace ?? record.trace,
+    props: [...existing.props, record.props],
+  };
+  return methods.map((m) => (m === existing ? updated : m));
+};
+
+const upsertProperty = (
+  properties: readonly PropertyMeta[],
+  record: MemberRecord,
+): readonly PropertyMeta[] => {
+  const existing = properties.find((p) => p.name === record.name);
+  if (!existing) {
+    return [...properties, { name: record.name, trace: record.trace, props: [record.props] }];
+  }
+  const updated: PropertyMeta = {
+    name: existing.name,
+    trace: existing.trace ?? record.trace,
+    props: [...existing.props, record.props],
+  };
+  return properties.map((p) => (p === existing ? updated : p));
+};
+
+export const aggregateMembers = (cls: object, classKey: object): void => {
+  const existing = classStore.get(cls) ?? emptyMeta();
+
+  let methods = existing.methods;
+  for (const record of methodRecords.get(classKey) ?? []) {
+    methods = upsertMethod(methods, record);
+  }
+
+  let properties = existing.properties;
+  for (const record of propertyRecords.get(classKey) ?? []) {
+    properties = upsertProperty(properties, record);
+  }
+
+  classStore.set(cls, {
+    trace: existing.trace,
+    props: existing.props,
+    methods,
+    properties,
+  });
+
+  methodRecords.delete(classKey);
+  propertyRecords.delete(classKey);
+};
+
+// --- Query ---
 
 export const getClassMetadata = (cls: object): ClassMeta | undefined => classStore.get(cls);
 
@@ -53,71 +142,5 @@ export const ensureClassMeta = (cls: object, trace: StackTrace): void => {
     props: base.props,
     methods: base.methods,
     properties: base.properties,
-  });
-};
-
-const upsertMethod = (
-  methods: readonly MethodMeta[],
-  name: string,
-  trace: StackTrace | undefined,
-  props: object,
-): readonly MethodMeta[] => {
-  const existing = methods.find((m) => m.name === name);
-  if (!existing) {
-    return [...methods, { name, trace, props: [props] }];
-  }
-  const updated: MethodMeta = {
-    name: existing.name,
-    trace: existing.trace ?? trace,
-    props: [...existing.props, props],
-  };
-  return methods.map((m) => (m === existing ? updated : m));
-};
-
-const upsertProperty = (
-  properties: readonly PropertyMeta[],
-  name: string,
-  trace: StackTrace | undefined,
-  props: object,
-): readonly PropertyMeta[] => {
-  const existing = properties.find((p) => p.name === name);
-  if (!existing) {
-    return [...properties, { name, trace, props: [props] }];
-  }
-  const updated: PropertyMeta = {
-    name: existing.name,
-    trace: existing.trace ?? trace,
-    props: [...existing.props, props],
-  };
-  return properties.map((p) => (p === existing ? updated : p));
-};
-
-export const setMethodMetadata = (
-  cls: object,
-  name: string,
-  trace: StackTrace | undefined,
-  props: object,
-): void => {
-  const existing = classStore.get(cls) ?? emptyMeta();
-  classStore.set(cls, {
-    trace: existing.trace,
-    props: existing.props,
-    methods: upsertMethod(existing.methods, name, trace, props),
-    properties: existing.properties,
-  });
-};
-
-export const setPropertyMetadata = (
-  cls: object,
-  name: string,
-  trace: StackTrace | undefined,
-  props: object,
-): void => {
-  const existing = classStore.get(cls) ?? emptyMeta();
-  classStore.set(cls, {
-    trace: existing.trace,
-    props: existing.props,
-    methods: existing.methods,
-    properties: upsertProperty(existing.properties, name, trace, props),
   });
 };

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable complexity */
+/* biome-ignore-all lint/complexity/noStaticOnlyClass: test fixtures */
 import { describe, expect, it } from 'vitest';
 import {
   composeClassDecorators,
@@ -11,10 +12,11 @@ import {
 import type { StackTrace } from '../runtime/position';
 import { captureStackTrace, resolvePosition } from '../runtime/position';
 import {
+  aggregateMembers,
   getClassMetadata,
-  setClassMetadata,
-  setMethodMetadata,
-  setPropertyMetadata,
+  recordClass,
+  recordMethod,
+  recordProperty,
 } from '../runtime/store';
 
 describe('captureStackTrace and resolvePosition', () => {
@@ -70,10 +72,12 @@ describe('captureStackTrace and resolvePosition', () => {
 describe('metadata store', () => {
   const mockTrace: StackTrace = { _brand: 'StackTrace', error: new Error() };
 
-  it('stores and retrieves class metadata', () => {
+  it('recordClass stores class metadata', () => {
     class TestClass {}
+    const classKey = {};
 
-    setClassMetadata(TestClass, mockTrace, { basePath: '/api' });
+    recordClass(TestClass, mockTrace, { basePath: '/api' });
+    aggregateMembers(TestClass, classKey);
     const meta = getClassMetadata(TestClass);
 
     expect(meta?.trace).toBe(mockTrace);
@@ -82,11 +86,13 @@ describe('metadata store', () => {
     expect(meta?.properties).toEqual([]);
   });
 
-  it('stores and retrieves method metadata', () => {
+  it('recordMethod + aggregateMembers stores method metadata', () => {
     class TestClass {}
+    const classKey = {};
 
-    setClassMetadata(TestClass, mockTrace, {});
-    setMethodMetadata(TestClass, 'getUser', mockTrace, { method: 'GET' });
+    recordMethod(classKey, 'getUser', mockTrace, { method: 'GET' });
+    recordClass(TestClass, mockTrace, {});
+    aggregateMembers(TestClass, classKey);
 
     const meta = getClassMetadata(TestClass);
     expect(meta?.methods).toHaveLength(1);
@@ -95,11 +101,13 @@ describe('metadata store', () => {
     expect(meta?.methods[0]?.props).toEqual([{ method: 'GET' }]);
   });
 
-  it('stores and retrieves property metadata', () => {
+  it('recordProperty + aggregateMembers stores property metadata', () => {
     class TestClass {}
+    const classKey = {};
 
-    setClassMetadata(TestClass, mockTrace, {});
-    setPropertyMetadata(TestClass, 'name', mockTrace, { nullable: false });
+    recordProperty(classKey, 'name', mockTrace, { nullable: false });
+    recordClass(TestClass, mockTrace, {});
+    aggregateMembers(TestClass, classKey);
 
     const meta = getClassMetadata(TestClass);
     expect(meta?.properties).toHaveLength(1);
@@ -115,7 +123,9 @@ describe('metadata store', () => {
 
   it('accepts undefined trace and still stores metadata', () => {
     class TestClass {}
-    setClassMetadata(TestClass, undefined, { kind: 'X' });
+    const classKey = {};
+    recordClass(TestClass, undefined, { kind: 'X' });
+    aggregateMembers(TestClass, classKey);
     const meta = getClassMetadata(TestClass);
     expect(meta?.trace).toBeUndefined();
     expect(meta?.props).toEqual([{ kind: 'X' }]);
@@ -123,8 +133,10 @@ describe('metadata store', () => {
 
   it('appends props when the same class is decorated multiple times', () => {
     class TestClass {}
-    setClassMetadata(TestClass, mockTrace, { decorator: 'Controller', basePath: '/api' });
-    setClassMetadata(TestClass, mockTrace, { decorator: 'UseMiddleware', middlewares: ['auth'] });
+    const classKey = {};
+    recordClass(TestClass, mockTrace, { decorator: 'Controller', basePath: '/api' });
+    recordClass(TestClass, mockTrace, { decorator: 'UseMiddleware', middlewares: ['auth'] });
+    aggregateMembers(TestClass, classKey);
     const meta = getClassMetadata(TestClass);
     expect(meta?.props).toEqual([
       { decorator: 'Controller', basePath: '/api' },
@@ -134,11 +146,14 @@ describe('metadata store', () => {
 
   it('appends props when the same method receives multiple decorators', () => {
     class TestClass {}
-    setMethodMetadata(TestClass, 'handler', mockTrace, { decorator: 'Route', method: 'GET' });
-    setMethodMetadata(TestClass, 'handler', mockTrace, {
+    const classKey = {};
+    recordMethod(classKey, 'handler', mockTrace, { decorator: 'Route', method: 'GET' });
+    recordMethod(classKey, 'handler', mockTrace, {
       decorator: 'Authorized',
       roles: ['admin'],
     });
+    recordClass(TestClass, mockTrace, {});
+    aggregateMembers(TestClass, classKey);
     const meta = getClassMetadata(TestClass);
     expect(meta?.methods).toHaveLength(1);
     expect(meta?.methods[0]?.props).toEqual([

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -101,6 +101,21 @@ describe('metadata store', () => {
     expect(meta?.methods[0]?.props).toEqual([{ method: 'GET' }]);
   });
 
+  it('recordMethod supports symbol-named methods', () => {
+    class TestClass {}
+    const classKey = {};
+    const sym = Symbol('handler');
+
+    recordMethod(classKey, sym, mockTrace, { method: 'POST' });
+    recordClass(TestClass, mockTrace, {});
+    aggregateMembers(TestClass, classKey);
+
+    const meta = getClassMetadata(TestClass);
+    expect(meta?.methods).toHaveLength(1);
+    expect(meta?.methods[0]?.name).toBe(sym);
+    expect(meta?.methods[0]?.props).toEqual([{ method: 'POST' }]);
+  });
+
   it('recordProperty + aggregateMembers stores property metadata', () => {
     class TestClass {}
     const classKey = {};
@@ -114,6 +129,21 @@ describe('metadata store', () => {
     expect(meta?.properties[0]?.name).toBe('name');
     expect(meta?.properties[0]?.trace).toBe(mockTrace);
     expect(meta?.properties[0]?.props).toEqual([{ nullable: false }]);
+  });
+
+  it('recordProperty supports symbol-named properties', () => {
+    class TestClass {}
+    const classKey = {};
+    const sym = Symbol('secret');
+
+    recordProperty(classKey, sym, mockTrace, { encrypted: true });
+    recordClass(TestClass, mockTrace, {});
+    aggregateMembers(TestClass, classKey);
+
+    const meta = getClassMetadata(TestClass);
+    expect(meta?.properties).toHaveLength(1);
+    expect(meta?.properties[0]?.name).toBe(sym);
+    expect(meta?.properties[0]?.props).toEqual([{ encrypted: true }]);
   });
 
   it('returns undefined for class without metadata', () => {


### PR DESCRIPTION
## Summary

- Unify `define*` and `create*` APIs into single `create*` API with options parameter
- Restructure internal code based on decorator responsibilities:
  - Adapter layer: TC39/Legacy input normalization
  - Record/Aggregate pattern: Class decorator records + aggregates, Method/Property decorators only record
- Rename `sharedKey` to `classKey` for clarity

## Changes

- Remove `defineClassDecorator`, `defineMethodDecorator`, `definePropertyDecorator`
- Add options parameter to `createClassDecorator` and `createMethodDecorator`
- Separate adapter functions: `adaptClassContext`, `adaptMethodContext`, `adaptPropertyContext`
- Replace `set*` with `record*`/`aggregateMembers` based on responsibility

## Test plan

- [x] All existing tests pass
- [x] Build succeeds
- [x] TypeScript type-check passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782179545&installation_id=133048706&pr_number=206&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F206&signature=327bf069ed654125ecbac968ee35d8cd6e4dfbac68c01e6c5506caa0e83b6f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalized decorator behavior across legacy and modern implementations and simplified metadata handling for more consistent decoration results.
* **Type**
  * Broadened member name support to include symbols and tightened legacy decorator return types for more accurate behavior.
* **Tests**
  * Updated test suite to exercise the new record-then-aggregate metadata flow and verify ordering and trace handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->