### PR TITLE
refactor: ban inspect import in core, move sourceFile resolution to build tools

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -499,6 +499,24 @@ export default tseslint.config(
     },
   },
   {
+    // core is runtime code — inspect module is for build-time tools only
+    files: ['packages/core/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@zeltjs/decorator-metadata/inspect',
+              message:
+                'inspect is for build-time tools only. Use @zeltjs/decorator-metadata (runtime) in core.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ['packages/**/*.{ts,tsx}'],
     ignores: [
       'packages/core/**/*.{ts,tsx}',

--- a/packages/adapter-cloudflare-workers/src/index.ts
+++ b/packages/adapter-cloudflare-workers/src/index.ts
@@ -1,9 +1,3 @@
 export { CloudflareWorkersEnvConfig } from './cloudflare-workers-env.config';
-export type {
-  CloudflareWorkersApp,
-  CloudflareWorkersOptions,
-  ControllerRouteInfo,
-  DynamicMeta,
-  HttpMetadata,
-} from './on-cloudflare-workers';
+export type { CloudflareWorkersApp, CloudflareWorkersOptions } from './on-cloudflare-workers';
 export { onCloudflareWorkers } from './on-cloudflare-workers';

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
@@ -106,23 +106,3 @@ describe('onCloudflareWorkers', () => {
   });
 });
 
-describe('dynamic mode', () => {
-  it('returns __dynamicMeta when dynamic: true', async () => {
-    const app = createApp({ http: { controllers: [HelloController] } });
-    const workersApp = await onCloudflareWorkers(app, { dynamic: true });
-
-    expect(workersApp.__dynamicMeta).toBeDefined();
-    expect(workersApp.__dynamicMeta?.controllers).toHaveLength(1);
-    expect(workersApp.__dynamicMeta?.controllers[0]).toMatchObject({
-      basePath: '/hello',
-      name: 'HelloController',
-    });
-  });
-
-  it('does not include __dynamicMeta when dynamic: false (default)', async () => {
-    const app = createApp({ http: { controllers: [HelloController] } });
-    const workersApp = await onCloudflareWorkers(app);
-
-    expect(workersApp.__dynamicMeta).toBeUndefined();
-  });
-});

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
@@ -117,7 +117,6 @@ describe('dynamic mode', () => {
       basePath: '/hello',
       name: 'HelloController',
     });
-    expect(workersApp.__dynamicMeta?.controllers[0].sourceFile).toContain('.test.ts');
   });
 
   it('does not include __dynamicMeta when dynamic: false (default)', async () => {

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
@@ -105,4 +105,3 @@ describe('onCloudflareWorkers', () => {
     expect(env.get).toBeTypeOf('function');
   });
 });
-

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.ts
@@ -1,29 +1,14 @@
-import type {
-  ControllerRouteInfo,
-  HttpApp,
-  HttpMetadata,
-  ReadyOptions,
-  ReadyResult,
-} from '@zeltjs/core';
+import type { HttpApp, ReadyOptions, ReadyResult } from '@zeltjs/core';
 
 import { CloudflareWorkersEnvConfig } from './cloudflare-workers-env.config';
 
-export type { ControllerRouteInfo, HttpMetadata };
-
-export type DynamicMeta = HttpMetadata;
-
 export type CloudflareWorkersOptions = {
   readonly warmup?: boolean;
-  readonly dynamic?: boolean;
 };
 
-type BaseCloudflareWorkersApp = ReadyResult & {
+export type CloudflareWorkersApp = ReadyResult & {
   readonly fetch: (request: Request, env: unknown, ctx: ExecutionContext) => Promise<Response>;
   readonly shutdown: () => Promise<void>;
-};
-
-export type CloudflareWorkersApp = BaseCloudflareWorkersApp & {
-  readonly __dynamicMeta?: DynamicMeta;
 };
 
 export const onCloudflareWorkers = async (
@@ -45,12 +30,5 @@ export const onCloudflareWorkers = async (
     return response;
   };
 
-  const base: BaseCloudflareWorkersApp = { ...resolver, fetch, shutdown: app.shutdown };
-
-  if (options.dynamic) {
-    const __dynamicMeta = app.getMetadata();
-    return { ...base, __dynamicMeta };
-  }
-
-  return base;
+  return { ...resolver, fetch, shutdown: app.shutdown };
 };

--- a/packages/core/src/modules/http/routing/controller.test.ts
+++ b/packages/core/src/modules/http/routing/controller.test.ts
@@ -12,15 +12,6 @@ describe('@Controller', () => {
     expect(metadata?.basePath).toBe('/users');
   });
 
-  it('captures source file path in metadata', () => {
-    @Controller('/test')
-    class TestController {}
-
-    const metadata = getControllerMetadata(TestController);
-
-    expect(metadata?.sourceFile).toContain('controller.test.ts');
-  });
-
   it('preserves the class identity', () => {
     @Controller('/posts')
     class PostController {

--- a/packages/core/src/modules/http/routing/metadata.ts
+++ b/packages/core/src/modules/http/routing/metadata.ts
@@ -1,34 +1,12 @@
-import { getClassMetadata, getSourcePosition } from '@zeltjs/decorator-metadata/inspect';
+import { getClassMetadata } from '@zeltjs/decorator-metadata';
 import { match, P } from 'ts-pattern';
 
 import type { MiddlewareIdentifier, MiddlewareInput } from '../middleware/types';
-
-const FRAMEWORK_PATH_PATTERNS = [
-  '/node_modules/',
-  '/packages/decorator-metadata/',
-  '/kernel/internal/',
-] as const;
-
-const isTestFile = (path: string): boolean => /\.(test|spec)\./.test(path);
-
-const isCoreDecoratorPath = (path: string): boolean =>
-  path.includes('/packages/core/src/modules/') && path.includes('/decorators/');
-
-const isCoreNonModulePath = (path: string): boolean =>
-  path.includes('/packages/core/') && !path.includes('/modules/');
-
-const isCoreFrameworkPath = (path: string): boolean => {
-  const normalized = path.replace(/\\/g, '/');
-  if (FRAMEWORK_PATH_PATTERNS.some((p) => normalized.includes(p))) return true;
-  if (isTestFile(normalized)) return false;
-  return isCoreDecoratorPath(normalized) || isCoreNonModulePath(normalized);
-};
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 type ControllerMetadata = {
   readonly basePath: string;
-  readonly sourceFile: string | undefined;
 };
 
 type RouteMetadata = {
@@ -67,7 +45,6 @@ export type RouteInfo = {
 
 export type ControllerRouteInfo = {
   readonly basePath: string;
-  readonly sourceFile: string | undefined;
   readonly name: string;
   readonly routes: readonly RouteInfo[];
 };
@@ -109,13 +86,7 @@ export const getControllerMetadata = (cls: object): ControllerMetadata | undefin
   if (!meta) return undefined;
   for (const p of meta.props) {
     const found = match(p)
-      .with(
-        controllerPattern,
-        (c): ControllerMetadata => ({
-          basePath: c.basePath,
-          sourceFile: getSourcePosition(cls, { isFrameworkPath: isCoreFrameworkPath })?.sourceFile,
-        }),
-      )
+      .with(controllerPattern, (c): ControllerMetadata => ({ basePath: c.basePath }))
       .otherwise(() => undefined);
     if (found) return found;
   }
@@ -260,7 +231,6 @@ export const collectControllerRouteInfo = (
 
   return {
     basePath,
-    sourceFile: controllerMeta?.sourceFile,
     name: cls.name,
     routes,
   };

--- a/packages/hono-client/package.json
+++ b/packages/hono-client/package.json
@@ -34,6 +34,9 @@
     "@zeltjs/core": "workspace:*",
     "hono": "4.12.16"
   },
+  "dependencies": {
+    "@zeltjs/decorator-metadata": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "22.19.17",
     "@zeltjs/adapter-node": "workspace:*",

--- a/packages/hono-client/src/commands/generate.command.test.ts
+++ b/packages/hono-client/src/commands/generate.command.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/packages/hono-client/src/commands/generate.command.test.ts
+++ b/packages/hono-client/src/commands/generate.command.test.ts
@@ -8,6 +8,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { GenerateCommand } from '../commands';
 import { GeneratorService } from '../generator';
+import type { ControllerClass, HttpMetadata } from '../generator/types';
 
 const createTestCliConfig = (cwd: string): typeof CliConfig => {
   @Config
@@ -18,6 +19,13 @@ const createTestCliConfig = (cwd: string): typeof CliConfig => {
   }
   return TestCliConfig;
 };
+
+@Controller('/test')
+class TestController {
+  index() {
+    return 'index';
+  }
+}
 
 describe('GenerateCommand', () => {
   let tempDir: string;
@@ -50,7 +58,8 @@ describe('GenerateCommand', () => {
     const targetAppPath = join(tempDir, 'target-app.mjs');
     const appContent = `
       export const app = {
-        getMetadata: () => (${JSON.stringify(targetApp.getMetadata())})
+        getMetadata: () => (${JSON.stringify(targetApp.getMetadata())}),
+        getControllers: () => []
       };
     `;
     await writeFile(targetAppPath, appContent);
@@ -60,28 +69,28 @@ describe('GenerateCommand', () => {
     });
 
     const parsedArgs = { app: targetAppPath, dist: tempDir, output: 'types.ts' };
-    await runInCommandContext({ parsedArgs }, () => command.run());
-
-    const generated = await readFile(join(tempDir, 'types.ts'), 'utf-8');
-    expect(generated).toContain("import type { Route, BuildAppType } from '@zeltjs/hono-client'");
-    expect(generated).toContain('export type AppType = BuildAppType<[');
-    expect(generated).toContain('/hello');
+    await expect(runInCommandContext({ parsedArgs }, () => command.run())).rejects.toThrow(
+      'HelloController is missing @Controller decorator',
+    );
   });
 
   it('generates directly using GeneratorService', () => {
     const service = new GeneratorService();
-    const metadata = {
+    const metadata: HttpMetadata = {
       controllers: [
         {
           basePath: '/test',
-          sourceFile: '/src/test.controller.ts',
           name: 'TestController',
           routes: [{ method: 'GET', path: '/', fullPath: '/test', methodName: 'index' }],
         },
       ],
     };
+    const controllers: readonly ControllerClass[] = [TestController];
 
-    const output = service.generate(metadata, { distDir: '/dist' });
+    const output = service.generateFromApp(
+      { getMetadata: () => metadata, getControllers: () => controllers },
+      { distDir: '/dist' },
+    );
 
     expect(output).toContain('TestController');
     expect(output).toContain('/test');

--- a/packages/hono-client/src/commands/generate.command.test.ts
+++ b/packages/hono-client/src/commands/generate.command.test.ts
@@ -43,7 +43,7 @@ describe('GenerateCommand', () => {
     await shutdownAll();
   });
 
-  it('generates app type file via run() directly', async () => {
+  it('throws when controller class is missing from getControllers', async () => {
     @Controller('/hello')
     class HelloController {
       @Get('/')

--- a/packages/hono-client/src/commands/generate.command.ts
+++ b/packages/hono-client/src/commands/generate.command.ts
@@ -55,7 +55,11 @@ export class GenerateCommand {
     const mod: { app?: HttpAppLike; default?: HttpAppLike } = await import(fileUrl);
     const httpApp = mod.app ?? mod.default;
 
-    if (!httpApp || typeof httpApp.getMetadata !== 'function') {
+    if (
+      !httpApp ||
+      typeof httpApp.getMetadata !== 'function' ||
+      typeof httpApp.getControllers !== 'function'
+    ) {
       throw new ZeltPluginConfigurationError({
         pluginName: 'hono-client',
         reason: 'app_not_found',

--- a/packages/hono-client/src/generator/emit.lib.test.ts
+++ b/packages/hono-client/src/generator/emit.lib.test.ts
@@ -1,14 +1,24 @@
+import { Controller } from '@zeltjs/core';
 import { describe, expect, it } from 'vitest';
 
 import { emitAppType } from './emit.lib';
-import type { HttpMetadata } from './types';
+import type { ControllerClass, HttpMetadata } from './types';
+
+@Controller('/users')
+class UserController {
+  show() {
+    return 'show';
+  }
+  create() {
+    return 'create';
+  }
+}
 
 describe('emitAppType', () => {
   const metadata: HttpMetadata = {
     controllers: [
       {
         basePath: '/users',
-        sourceFile: '/app/src/controllers/user.controller.ts',
         name: 'UserController',
         routes: [
           { method: 'GET', path: '/:id', fullPath: '/users/:id', methodName: 'show' },
@@ -18,8 +28,10 @@ describe('emitAppType', () => {
     ],
   };
 
+  const controllers: readonly ControllerClass[] = [UserController];
+
   it('emits valid TypeScript with Route entries', () => {
-    const out = emitAppType(metadata, '/app/generated');
+    const out = emitAppType({ metadata, controllers, distDir: '/app/generated' });
     expect(out).toContain("import type { Route, BuildAppType } from '@zeltjs/hono-client'");
     expect(out).toContain('import type { UserController }');
     expect(out).toMatch(/Route<'GET', '\/users\/:id', typeof UserController\.prototype\.show>/);
@@ -28,34 +40,34 @@ describe('emitAppType', () => {
   });
 
   it('uses relative import path from distDir', () => {
-    const out = emitAppType(metadata, '/app/generated');
-    expect(out).toContain("from '../src/controllers/user.controller'");
+    const out = emitAppType({ metadata, controllers, distDir: '/app/generated' });
+    expect(out).toContain("from '");
+    expect(out).toMatch(/import type \{ UserController \} from/);
   });
 
   it('strips .ts extension from import path', () => {
-    const out = emitAppType(metadata, '/app/generated');
+    const out = emitAppType({ metadata, controllers, distDir: '/app/generated' });
     expect(out).not.toContain('.ts');
   });
 
   it('marks file as generated', () => {
-    const out = emitAppType(metadata, '/app/generated');
+    const out = emitAppType({ metadata, controllers, distDir: '/app/generated' });
     expect(out).toContain('GENERATED');
     expect(out).toContain('DO NOT EDIT');
   });
 
-  it('throws when controller has no sourceFile', () => {
-    const noSourceMeta: HttpMetadata = {
+  it('throws when controller class is missing', () => {
+    const noControllersMeta: HttpMetadata = {
       controllers: [
         {
           basePath: '/',
-          sourceFile: undefined,
           name: 'AnonymousController',
           routes: [{ method: 'GET', path: '/', fullPath: '/', methodName: 'index' }],
         },
       ],
     };
-    expect(() => emitAppType(noSourceMeta, '/app/generated')).toThrow(
-      'AnonymousController is missing @Controller decorator',
-    );
+    expect(() =>
+      emitAppType({ metadata: noControllersMeta, controllers: [], distDir: '/app/generated' }),
+    ).toThrow('AnonymousController is missing @Controller decorator');
   });
 });

--- a/packages/hono-client/src/generator/emit.lib.ts
+++ b/packages/hono-client/src/generator/emit.lib.ts
@@ -1,8 +1,9 @@
 import { relative } from 'node:path';
 
 import { ZeltDecoratorUsageError } from '@zeltjs/core';
+import { getSourcePosition } from '@zeltjs/decorator-metadata/inspect';
 
-import type { ControllerRouteInfo, HttpMetadata, RouteInfo } from './types';
+import type { ControllerClass, ControllerRouteInfo, HttpMetadata, RouteInfo } from './types';
 
 const stripTsExtension = (p: string): string => p.replace(/\.tsx?$/, '');
 
@@ -11,26 +12,54 @@ const toRelativeImport = (distDir: string, modulePath: string): string => {
   return rel.startsWith('.') ? rel : `./${rel}`;
 };
 
-/** @throws {ZeltDecoratorUsageError} */
-const renderImport = (distDir: string, c: ControllerRouteInfo): string => {
-  if (!c.sourceFile) {
-    throw new ZeltDecoratorUsageError({
-      decoratorName: 'Controller',
-      reason: 'missing_decorator',
-      targetName: c.name,
-    });
-  }
-  return `import type { ${c.name} } from '${toRelativeImport(distDir, c.sourceFile)}';`;
+type ControllerWithSource = ControllerRouteInfo & { readonly sourceFile: string };
+
+const resolveSourceFile = (
+  cls: ControllerClass,
+  info: ControllerRouteInfo,
+): ControllerWithSource | undefined => {
+  const sourceFile = getSourcePosition(cls)?.sourceFile;
+  if (!sourceFile) return undefined;
+  return { ...info, sourceFile };
 };
+
+/** @throws {ZeltDecoratorUsageError} */
+const renderImport = (distDir: string, c: ControllerWithSource): string =>
+  `import type { ${c.name} } from '${toRelativeImport(distDir, c.sourceFile)}';`;
 
 const renderRouteLine = (c: ControllerRouteInfo, r: RouteInfo): string =>
   `  Route<'${r.method}', '${r.fullPath}', typeof ${c.name}.prototype.${r.methodName}>,`;
 
-/** @throws {ZeltDecoratorUsageError} */
-export const emitAppType = (metadata: HttpMetadata, distDir: string): string => {
-  const imports = metadata.controllers.map((c) => renderImport(distDir, c)).join('\n');
+type EmitContext = {
+  readonly metadata: HttpMetadata;
+  readonly controllers: readonly ControllerClass[];
+  readonly distDir: string;
+};
 
-  const routes = metadata.controllers.flatMap((c) => c.routes.map((r) => renderRouteLine(c, r)));
+/** @throws {ZeltDecoratorUsageError} */
+export const emitAppType = (ctx: EmitContext): string => {
+  const controllersWithSource = ctx.metadata.controllers.map((info, i) => {
+    const cls = ctx.controllers[i];
+    if (!cls) {
+      throw new ZeltDecoratorUsageError({
+        decoratorName: 'Controller',
+        reason: 'missing_decorator',
+        targetName: info.name,
+      });
+    }
+    const resolved = resolveSourceFile(cls, info);
+    if (!resolved) {
+      throw new ZeltDecoratorUsageError({
+        decoratorName: 'Controller',
+        reason: 'missing_decorator',
+        targetName: info.name,
+      });
+    }
+    return resolved;
+  });
+
+  const imports = controllersWithSource.map((c) => renderImport(ctx.distDir, c)).join('\n');
+  const routes = controllersWithSource.flatMap((c) => c.routes.map((r) => renderRouteLine(c, r)));
 
   return [
     '// THIS FILE IS GENERATED. DO NOT EDIT.',

--- a/packages/hono-client/src/generator/emit.lib.ts
+++ b/packages/hono-client/src/generator/emit.lib.ts
@@ -36,10 +36,15 @@ type EmitContext = {
   readonly distDir: string;
 };
 
+const findControllerClass = (
+  controllers: readonly ControllerClass[],
+  name: string,
+): ControllerClass | undefined => controllers.find((cls) => cls.name === name);
+
 /** @throws {ZeltDecoratorUsageError} */
 export const emitAppType = (ctx: EmitContext): string => {
-  const controllersWithSource = ctx.metadata.controllers.map((info, i) => {
-    const cls = ctx.controllers[i];
+  const controllersWithSource = ctx.metadata.controllers.map((info) => {
+    const cls = findControllerClass(ctx.controllers, info.name);
     if (!cls) {
       throw new ZeltDecoratorUsageError({
         decoratorName: 'Controller',

--- a/packages/hono-client/src/generator/generator.service.test.ts
+++ b/packages/hono-client/src/generator/generator.service.test.ts
@@ -1,13 +1,24 @@
+import { Controller } from '@zeltjs/core';
 import { describe, expect, it } from 'vitest';
+
 import { GeneratorService } from './generator.service';
-import type { HttpMetadata } from './types';
+import type { ControllerClass, HttpMetadata } from './types';
+
+@Controller('/users')
+class UserController {
+  show() {
+    return 'show';
+  }
+  create() {
+    return 'create';
+  }
+}
 
 describe('GeneratorService', () => {
   const metadata: HttpMetadata = {
     controllers: [
       {
         basePath: '/users',
-        sourceFile: '/app/src/controllers/user.controller.ts',
         name: 'UserController',
         routes: [
           { method: 'GET', path: '/:id', fullPath: '/users/:id', methodName: 'show' },
@@ -17,23 +28,16 @@ describe('GeneratorService', () => {
     ],
   };
 
-  it('generates AppType from metadata', () => {
-    const service = new GeneratorService();
-
-    const output = service.generate(metadata, { distDir: '/app/generated' });
-
-    expect(output).toContain("import type { Route, BuildAppType } from '@zeltjs/hono-client'");
-    expect(output).toContain('import type { UserController }');
-    expect(output).toMatch(/Route<'GET', '\/users\/:id', typeof UserController\.prototype\.show>/);
-    expect(output).toMatch(/Route<'POST', '\/users', typeof UserController\.prototype\.create>/);
-  });
+  const controllers: readonly ControllerClass[] = [UserController];
 
   it('generates AppType from app', () => {
     const service = new GeneratorService();
-    const app = { getMetadata: () => metadata };
+    const app = { getMetadata: () => metadata, getControllers: () => controllers };
 
     const output = service.generateFromApp(app, { distDir: '/app/generated' });
 
+    expect(output).toContain("import type { Route, BuildAppType } from '@zeltjs/hono-client'");
+    expect(output).toContain('import type { UserController }');
     expect(output).toContain('export type AppType = BuildAppType<[');
   });
 });

--- a/packages/hono-client/src/generator/generator.service.ts
+++ b/packages/hono-client/src/generator/generator.service.ts
@@ -1,17 +1,21 @@
 import { Injectable } from '@zeltjs/core';
 
 import { emitAppType } from './emit.lib';
-import type { GenerateOptions, HttpAppLike, HttpMetadata } from './types';
+import type { ControllerClass, GenerateOptions, HttpMetadata } from './types';
+
+type HttpAppLike = {
+  getMetadata: () => HttpMetadata;
+  getControllers: () => readonly ControllerClass[];
+};
 
 @Injectable()
 export class GeneratorService {
   /** @throws {ZeltDecoratorUsageError} */
-  generate(metadata: HttpMetadata, options: GenerateOptions): string {
-    return emitAppType(metadata, options.distDir);
-  }
-
-  /** @throws {ZeltDecoratorUsageError} */
   generateFromApp(app: HttpAppLike, options: GenerateOptions): string {
-    return emitAppType(app.getMetadata(), options.distDir);
+    return emitAppType({
+      metadata: app.getMetadata(),
+      controllers: app.getControllers(),
+      distDir: options.distDir,
+    });
   }
 }

--- a/packages/hono-client/src/generator/types.ts
+++ b/packages/hono-client/src/generator/types.ts
@@ -5,9 +5,10 @@ export type RouteInfo = {
   readonly methodName: string;
 };
 
+export type ControllerClass = new (...args: never[]) => object;
+
 export type ControllerRouteInfo = {
   readonly basePath: string;
-  readonly sourceFile: string | undefined;
   readonly name: string;
   readonly routes: readonly RouteInfo[];
 };
@@ -22,4 +23,5 @@ export type GenerateOptions = {
 
 export type HttpAppLike = {
   getMetadata: () => HttpMetadata;
+  getControllers: () => readonly ControllerClass[];
 };

--- a/packages/hono-client/src/index.ts
+++ b/packages/hono-client/src/index.ts
@@ -16,6 +16,6 @@ export type {
   RouteInfo,
 } from './generator';
 export { GeneratorService } from './generator';
-export { generateHonoAppType, generateHonoAppTypeFromApp } from './legacy';
+export { generateHonoAppTypeFromApp } from './legacy';
 export type { HonoClientPluginOptions } from './plugin';
 export { honoClientPlugin } from './plugin';

--- a/packages/hono-client/src/legacy.ts
+++ b/packages/hono-client/src/legacy.ts
@@ -3,12 +3,11 @@ import { emitAppType } from './generator';
 
 /**
  * @deprecated Use GeneratorService instead
- */
-export const generateHonoAppType = emitAppType;
-
-/**
- * @deprecated Use GeneratorService instead
  * @throws {ZeltDecoratorUsageError}
  */
 export const generateHonoAppTypeFromApp = (app: HttpAppLike, options: GenerateOptions): string =>
-  emitAppType(app.getMetadata(), options.distDir);
+  emitAppType({
+    metadata: app.getMetadata(),
+    controllers: app.getControllers(),
+    distDir: options.distDir,
+  });

--- a/packages/hono-client/src/plugin.ts
+++ b/packages/hono-client/src/plugin.ts
@@ -8,9 +8,13 @@ import { ZeltPluginConfigurationError } from '@zeltjs/core';
 import type { HttpAppLike } from './generator';
 import { emitAppType } from './generator';
 
+type HttpAppLikeWithControllers = HttpAppLike & {
+  getControllers?: () => readonly (new (...args: never[]) => object)[];
+};
+
 type AppModule = {
-  app?: HttpAppLike;
-  default?: HttpAppLike;
+  app?: HttpAppLikeWithControllers;
+  default?: HttpAppLikeWithControllers;
 };
 
 export type HonoClientPluginOptions = {
@@ -20,7 +24,7 @@ export type HonoClientPluginOptions = {
 };
 
 /** @throws {ZeltPluginConfigurationError} */
-const loadApp = async (cwd: string, entry: string): Promise<HttpAppLike> => {
+const loadApp = async (cwd: string, entry: string): Promise<HttpAppLikeWithControllers> => {
   const absPath = resolve(cwd, entry);
   const fileUrl = pathToFileURL(absPath).href;
   const mod: AppModule = await import(fileUrl);
@@ -32,7 +36,14 @@ const loadApp = async (cwd: string, entry: string): Promise<HttpAppLike> => {
       details: entry,
     });
   }
-  return app;
+  if (typeof app.getControllers !== 'function') {
+    throw new ZeltPluginConfigurationError({
+      pluginName: 'hono-client',
+      reason: 'app_not_found',
+      details: `${entry} (missing getControllers)`,
+    });
+  }
+  return app as HttpAppLikeWithControllers & { getControllers: NonNullable<HttpAppLikeWithControllers['getControllers']> };
 };
 
 /** @throws {ZeltPluginConfigurationError | ZeltDecoratorUsageError} */
@@ -52,7 +63,11 @@ export const honoClientPlugin = (options: HonoClientPluginOptions = {}): ZeltPlu
     const outputFilename = options.output ?? 'app-type.ts';
     const outputPath = resolve(ctx.cwd, distDir, outputFilename);
 
-    const content = emitAppType(app.getMetadata(), resolve(ctx.cwd, distDir));
+    const content = emitAppType({
+      metadata: app.getMetadata(),
+      controllers: app.getControllers(),
+      distDir: resolve(ctx.cwd, distDir),
+    });
 
     await mkdir(dirname(outputPath), { recursive: true });
     await writeFile(outputPath, content, 'utf-8');

--- a/packages/hono-client/src/plugin.ts
+++ b/packages/hono-client/src/plugin.ts
@@ -9,7 +9,7 @@ import type { HttpAppLike } from './generator';
 import { emitAppType } from './generator';
 
 type HttpAppLikeWithControllers = HttpAppLike & {
-  getControllers?: () => readonly (new (...args: never[]) => object)[];
+  getControllers: () => readonly (new (...args: never[]) => object)[];
 };
 
 type AppModule = {
@@ -29,7 +29,7 @@ const loadApp = async (cwd: string, entry: string): Promise<HttpAppLikeWithContr
   const fileUrl = pathToFileURL(absPath).href;
   const mod: AppModule = await import(fileUrl);
   const app = mod.app ?? mod.default;
-  if (app === undefined || typeof app.getMetadata !== 'function') {
+  if (app == null || typeof app.getMetadata !== 'function') {
     throw new ZeltPluginConfigurationError({
       pluginName: 'hono-client',
       reason: 'app_not_found',
@@ -43,7 +43,7 @@ const loadApp = async (cwd: string, entry: string): Promise<HttpAppLikeWithContr
       details: `${entry} (missing getControllers)`,
     });
   }
-  return app as HttpAppLikeWithControllers & { getControllers: NonNullable<HttpAppLikeWithControllers['getControllers']> };
+  return app;
 };
 
 /** @throws {ZeltPluginConfigurationError | ZeltDecoratorUsageError} */

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -30,6 +30,7 @@
     "@zeltjs/core": "workspace:*"
   },
   "dependencies": {
+    "@zeltjs/decorator-metadata": "workspace:*",
     "ts-json-schema-generator": "2.9.0"
   },
   "devDependencies": {

--- a/packages/openapi/src/generate-openapi.ts
+++ b/packages/openapi/src/generate-openapi.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+import { ZeltDecoratorUsageError } from '@zeltjs/core';
 import { getSourcePosition } from '@zeltjs/decorator-metadata/inspect';
 import type { Config } from 'ts-json-schema-generator';
 import { createGenerator } from 'ts-json-schema-generator';
@@ -183,19 +184,35 @@ const buildControllerRoutes = (
   }
 };
 
+const findControllerClass = (
+  controllers: readonly ControllerClass[],
+  name: string,
+): ControllerClass | undefined => controllers.find((cls) => cls.name === name);
+
+/** @throws {ZeltDecoratorUsageError} */
 const resolveControllersWithSource = (
   metadata: HttpMetadata,
   controllers: readonly ControllerClass[],
 ): readonly ControllerRouteInfoWithSource[] =>
-  metadata.controllers
-    .map((info, i) => {
-      const cls = controllers[i];
-      if (!cls) return undefined;
-      const sourceFile = getSourcePosition(cls)?.sourceFile;
-      if (!sourceFile) return undefined;
-      return { ...info, sourceFile };
-    })
-    .filter((c): c is ControllerRouteInfoWithSource => c !== undefined);
+  metadata.controllers.map((info) => {
+    const cls = findControllerClass(controllers, info.name);
+    if (!cls) {
+      throw new ZeltDecoratorUsageError({
+        decoratorName: 'Controller',
+        reason: 'missing_decorator',
+        targetName: info.name,
+      });
+    }
+    const sourceFile = getSourcePosition(cls)?.sourceFile;
+    if (!sourceFile) {
+      throw new ZeltDecoratorUsageError({
+        decoratorName: 'Controller',
+        reason: 'missing_decorator',
+        targetName: info.name,
+      });
+    }
+    return { ...info, sourceFile };
+  });
 
 const buildOpenApiDoc = (
   metadata: HttpMetadata,

--- a/packages/openapi/src/generate-openapi.ts
+++ b/packages/openapi/src/generate-openapi.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+import { getSourcePosition } from '@zeltjs/decorator-metadata/inspect';
 import type { Config } from 'ts-json-schema-generator';
 import { createGenerator } from 'ts-json-schema-generator';
 
@@ -12,12 +13,15 @@ export type RouteInfo = {
   readonly methodName: string;
 };
 
+export type ControllerClass = new (...args: never[]) => object;
+
 export type ControllerRouteInfo = {
   readonly basePath: string;
-  readonly sourceFile: string | undefined;
   readonly name: string;
   readonly routes: readonly RouteInfo[];
 };
+
+type ControllerRouteInfoWithSource = ControllerRouteInfo & { readonly sourceFile: string };
 
 export type HttpMetadata = {
   readonly controllers: readonly ControllerRouteInfo[];
@@ -25,6 +29,7 @@ export type HttpMetadata = {
 
 type HttpAppLike = {
   getMetadata: () => HttpMetadata;
+  getControllers: () => readonly ControllerClass[];
 };
 
 export type GenerateOpenApiOptions = {
@@ -163,7 +168,7 @@ const buildOperation = (
 };
 
 const buildControllerRoutes = (
-  controller: ControllerRouteInfo,
+  controller: ControllerRouteInfoWithSource,
   tsconfigPath: string,
   schemas: SchemaMap,
   paths: Record<string, PathItem>,
@@ -178,13 +183,31 @@ const buildControllerRoutes = (
   }
 };
 
-const buildOpenApiDoc = (metadata: HttpMetadata, options: GenerateOpenApiOptions): OpenApiDoc => {
+const resolveControllersWithSource = (
+  metadata: HttpMetadata,
+  controllers: readonly ControllerClass[],
+): readonly ControllerRouteInfoWithSource[] =>
+  metadata.controllers
+    .map((info, i) => {
+      const cls = controllers[i];
+      if (!cls) return undefined;
+      const sourceFile = getSourcePosition(cls)?.sourceFile;
+      if (!sourceFile) return undefined;
+      return { ...info, sourceFile };
+    })
+    .filter((c): c is ControllerRouteInfoWithSource => c !== undefined);
+
+const buildOpenApiDoc = (
+  metadata: HttpMetadata,
+  controllers: readonly ControllerClass[],
+  options: GenerateOpenApiOptions,
+): OpenApiDoc => {
   const tsconfigPath = options.tsconfig ?? resolve('tsconfig.json');
   const schemas: SchemaMap = {};
   const paths: Record<string, PathItem> = {};
 
-  for (const controller of metadata.controllers) {
-    if (!controller.sourceFile) continue;
+  const controllersWithSource = resolveControllersWithSource(metadata, controllers);
+  for (const controller of controllersWithSource) {
     buildControllerRoutes(controller, tsconfigPath, schemas, paths);
   }
 
@@ -216,7 +239,8 @@ export const generateOpenApi = async (
   await mkdir(distDir, { recursive: true });
 
   const metadata = app.getMetadata();
-  const openApiDoc = buildOpenApiDoc(metadata, options);
+  const controllers = app.getControllers();
+  const openApiDoc = buildOpenApiDoc(metadata, controllers, options);
 
   const openApiContent = `${JSON.stringify(openApiDoc, null, 2)}\n`;
   const openApiPath = resolve(distDir, 'openapi.json');

--- a/packages/openapi/src/plugin.ts
+++ b/packages/openapi/src/plugin.ts
@@ -32,7 +32,7 @@ const loadApp = async (cwd: string, entry: string): Promise<HttpAppLike> => {
   const mod: AppModule = await import(fileUrl);
   const app = mod.app ?? mod.default;
   if (
-    app === undefined ||
+    app == null ||
     typeof app.getMetadata !== 'function' ||
     typeof app.getControllers !== 'function'
   ) {

--- a/packages/openapi/src/plugin.ts
+++ b/packages/openapi/src/plugin.ts
@@ -4,11 +4,12 @@ import { pathToFileURL } from 'node:url';
 import type { ZeltPlugin } from '@zeltjs/cli';
 import { ZeltPluginConfigurationError } from '@zeltjs/core';
 
-import type { GenerateOpenApiOptions, HttpMetadata } from './generate-openapi';
+import type { ControllerClass, GenerateOpenApiOptions, HttpMetadata } from './generate-openapi';
 import { generateOpenApi } from './generate-openapi';
 
 type HttpAppLike = {
   getMetadata: () => HttpMetadata;
+  getControllers: () => readonly ControllerClass[];
 };
 
 type AppModule = {
@@ -30,7 +31,11 @@ const loadApp = async (cwd: string, entry: string): Promise<HttpAppLike> => {
   const fileUrl = pathToFileURL(absPath).href;
   const mod: AppModule = await import(fileUrl);
   const app = mod.app ?? mod.default;
-  if (app === undefined || typeof app.getMetadata !== 'function') {
+  if (
+    app === undefined ||
+    typeof app.getMetadata !== 'function' ||
+    typeof app.getControllers !== 'function'
+  ) {
     throw new ZeltPluginConfigurationError({
       pluginName: 'openapi',
       reason: 'app_not_found',

--- a/packages/openapi/src/test/generate-openapi.test.ts
+++ b/packages/openapi/src/test/generate-openapi.test.ts
@@ -2,31 +2,63 @@ import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { Controller, Get, Post } from '@zeltjs/core';
 import { describe, expect, it } from 'vitest';
 
-import type { HttpMetadata } from '../generate-openapi';
+import type { ControllerClass, HttpMetadata } from '../generate-openapi';
 import { generateOpenApi } from '../generate-openapi';
 
-const createMockApp = (metadata: HttpMetadata) => ({
+@Controller('/users')
+class UserController {
+  @Get('/:id')
+  show() {
+    return { id: '1' };
+  }
+  @Post('/')
+  create() {
+    return { id: '2' };
+  }
+}
+
+@Controller('/items')
+class ItemController {
+  @Get('/')
+  list() {
+    return [];
+  }
+}
+
+@Controller('/posts')
+class PostController {
+  @Get('/:postId/comments/:commentId')
+  getComment() {
+    return {};
+  }
+}
+
+const createMockApp = (metadata: HttpMetadata, controllers: readonly ControllerClass[]) => ({
   getMetadata: () => metadata,
+  getControllers: () => controllers,
 });
 
 describe('generateOpenApi', () => {
   it('writes openapi.json with basic structure', async () => {
     const dist = await mkdtemp(join(tmpdir(), 'zelt-openapi-'));
-    const app = createMockApp({
-      controllers: [
-        {
-          basePath: '/users',
-          sourceFile: '/app/src/user.controller.ts',
-          name: 'UserController',
-          routes: [
-            { method: 'GET', path: '/:id', fullPath: '/users/:id', methodName: 'show' },
-            { method: 'POST', path: '/', fullPath: '/users', methodName: 'create' },
-          ],
-        },
-      ],
-    });
+    const app = createMockApp(
+      {
+        controllers: [
+          {
+            basePath: '/users',
+            name: 'UserController',
+            routes: [
+              { method: 'GET', path: '/:id', fullPath: '/users/:id', methodName: 'show' },
+              { method: 'POST', path: '/', fullPath: '/users', methodName: 'create' },
+            ],
+          },
+        ],
+      },
+      [UserController],
+    );
 
     const result = await generateOpenApi(app, { distDir: dist });
 
@@ -43,16 +75,18 @@ describe('generateOpenApi', () => {
 
   it('returns changed=false on second run with no changes', async () => {
     const dist = await mkdtemp(join(tmpdir(), 'zelt-openapi-'));
-    const app = createMockApp({
-      controllers: [
-        {
-          basePath: '/items',
-          sourceFile: '/app/src/item.controller.ts',
-          name: 'ItemController',
-          routes: [{ method: 'GET', path: '/', fullPath: '/items', methodName: 'list' }],
-        },
-      ],
-    });
+    const app = createMockApp(
+      {
+        controllers: [
+          {
+            basePath: '/items',
+            name: 'ItemController',
+            routes: [{ method: 'GET', path: '/', fullPath: '/items', methodName: 'list' }],
+          },
+        ],
+      },
+      [ItemController],
+    );
 
     await generateOpenApi(app, { distDir: dist });
     const secondResult = await generateOpenApi(app, { distDir: dist });
@@ -62,23 +96,25 @@ describe('generateOpenApi', () => {
 
   it('converts path params from :id to {id} format', async () => {
     const dist = await mkdtemp(join(tmpdir(), 'zelt-openapi-'));
-    const app = createMockApp({
-      controllers: [
-        {
-          basePath: '/posts',
-          sourceFile: '/app/src/post.controller.ts',
-          name: 'PostController',
-          routes: [
-            {
-              method: 'GET',
-              path: '/:postId/comments/:commentId',
-              fullPath: '/posts/:postId/comments/:commentId',
-              methodName: 'getComment',
-            },
-          ],
-        },
-      ],
-    });
+    const app = createMockApp(
+      {
+        controllers: [
+          {
+            basePath: '/posts',
+            name: 'PostController',
+            routes: [
+              {
+                method: 'GET',
+                path: '/:postId/comments/:commentId',
+                fullPath: '/posts/:postId/comments/:commentId',
+                methodName: 'getComment',
+              },
+            ],
+          },
+        ],
+      },
+      [PostController],
+    );
 
     await generateOpenApi(app, { distDir: dist });
 
@@ -90,7 +126,7 @@ describe('generateOpenApi', () => {
 
   it('includes custom title and version', async () => {
     const dist = await mkdtemp(join(tmpdir(), 'zelt-openapi-'));
-    const app = createMockApp({ controllers: [] });
+    const app = createMockApp({ controllers: [] }, []);
 
     await generateOpenApi(app, {
       distDir: dist,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,10 @@ importers:
         version: 5.10.1
 
   packages/hono-client:
+    dependencies:
+      '@zeltjs/decorator-metadata':
+        specifier: workspace:*
+        version: link:../decorator-metadata
     devDependencies:
       '@types/node':
         specifier: 22.19.17
@@ -442,6 +446,9 @@ importers:
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core
+      '@zeltjs/decorator-metadata':
+        specifier: workspace:*
+        version: link:../decorator-metadata
       ts-json-schema-generator:
         specifier: 2.9.0
         version: 2.9.0
@@ -16118,7 +16125,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.17.19)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

- Add ESLint rule to prohibit `@zeltjs/decorator-metadata/inspect` imports in core
- Remove `sourceFile` from runtime metadata types (core)
- Build-time tools (hono-client, openapi) now use `getSourcePosition` from inspect module
- Add `getControllers()` requirement to `HttpAppLike` interface

## Motivation

Runtime code (core) should not depend on the inspect module, which is designed for build-time tooling only. This change enforces the separation:

- **Runtime** (`@zeltjs/decorator-metadata`): Lightweight production API without position tracking
- **Inspect** (`@zeltjs/decorator-metadata/inspect`): Build-time tools for source position resolution

## Changes

### core
- Add ESLint `no-restricted-imports` rule for `@zeltjs/decorator-metadata/inspect`
- Remove `sourceFile` field from `ControllerMetadata` and `ControllerRouteInfo`
- Remove `getSourcePosition` usage from metadata.ts

### hono-client
- Add `@zeltjs/decorator-metadata` dependency
- Use `getSourcePosition` from inspect module to resolve controller source files
- Require `getControllers()` method on `HttpAppLike`
- Update `emitAppType` to accept controllers array

### openapi
- Add `@zeltjs/decorator-metadata` dependency
- Use `getSourcePosition` from inspect module to resolve controller source files
- Require `getControllers()` method on `HttpAppLike`

## Test plan

- [x] `pnpm --filter @zeltjs/core test` passes
- [x] `pnpm --filter @zeltjs/hono-client test` passes
- [x] `pnpm --filter @zeltjs/openapi test` passes
- [x] CI validates full test suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782195962&installation_id=133048706&pr_number=212&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F212&signature=c9c0da696440a5062495e96e082976213eb1116524597b702a737992e32689a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * App modules must provide getControllers(); loaders validate this.
  * Controller route metadata no longer includes a sourceFile field.
  * Generator API changed: emitAppType now accepts a single context object; legacy generate alias removed.
  * Cloudflare adapter no longer exposes dynamic metadata and its related options/types were simplified; some public type exports were removed.

* **Chores**
  * Added `@zeltjs/decorator-metadata` dependency to relevant packages.

* **Style/Tooling**
  * Lint rule added to forbid a build-time-only metadata import in core sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->