### PR TITLE
fix(core): recognize moved decorator files in isCoreDecoratorPath

### DIFF
--- a/packages/core/src/modules/http/routing/metadata.ts
+++ b/packages/core/src/modules/http/routing/metadata.ts
@@ -11,8 +11,13 @@ const FRAMEWORK_PATH_PATTERNS = [
 
 const isTestFile = (path: string): boolean => /\.(test|spec)\./.test(path);
 
-const isCoreDecoratorPath = (path: string): boolean =>
-  path.includes('/packages/core/src/modules/') && path.includes('/decorators/');
+const DECORATOR_FILES = ['/controller.ts', '/http-method.ts'] as const;
+
+const isCoreDecoratorPath = (path: string): boolean => {
+  if (!path.includes('/packages/core/src/modules/')) return false;
+  if (path.includes('/decorators/')) return true;
+  return DECORATOR_FILES.some((f) => path.endsWith(f));
+};
 
 const isCoreNonModulePath = (path: string): boolean =>
   path.includes('/packages/core/') && !path.includes('/modules/');


### PR DESCRIPTION
## Summary

- Add `DECORATOR_FILES` list to explicitly match `controller.ts` and `http-method.ts` as framework paths
- After PR #211 moved decorator files from `/decorators/` to `/routing/`, `isCoreDecoratorPath` no longer recognized them, causing `getSourcePosition` to return the decorator definition file instead of the user's source file

## Test plan

- [x] All tests pass locally (98 passed)
- [x] Specifically fixes `captures source file path in metadata` test in `controller.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782198711&installation_id=133048706&pr_number=214&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F214&signature=db287b7721eba4f5b84a725f6cfe73b5e012b7f75dd76793c22fe7ed3e9de68e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal decorator detection logic for more precise framework file classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->