### PR TITLE
ci: add auto version bump PR after release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,19 +42,35 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Validate tag format
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Invalid tag format: $TAG"
+            exit 1
+          fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
 
       - name: Update versions
-        run: pnpm -r exec npm version ${{ github.event.release.tag_name }} --no-git-tag-version --allow-same-version
+        run: pnpm -r exec npm version "$TAG" --no-git-tag-version --allow-same-version
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6f32688f5f1c67aaed6 # v8.0.0
         with:
-          branch: chore/bump-version-${{ github.event.release.tag_name }}
-          title: "chore: bump version to ${{ github.event.release.tag_name }}"
-          body: "Auto-generated after release ${{ github.event.release.tag_name }}"
-          commit-message: "chore: bump version to ${{ github.event.release.tag_name }}"
+          branch: chore/bump-version-${{ env.TAG }}
+          title: "chore: bump version to ${{ env.TAG }}"
+          body: "Auto-generated after release ${{ env.TAG }}"
+          commit-message: "chore: bump version to ${{ env.TAG }}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,3 +33,28 @@ jobs:
 
       - name: Publish packages
         run: pnpm -r publish --access public --no-git-checks --provenance
+
+  update-main-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: publish
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Update versions
+        run: pnpm -r exec npm version ${{ github.event.release.tag_name }} --no-git-tag-version --allow-same-version
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: chore/bump-version-${{ github.event.release.tag_name }}
+          title: "chore: bump version to ${{ github.event.release.tag_name }}"
+          body: "Auto-generated after release ${{ github.event.release.tag_name }}"
+          commit-message: "chore: bump version to ${{ github.event.release.tag_name }}"


### PR DESCRIPTION
## Summary

- Add `update-main-version` job to `.github/workflows/release-please.yml`
- After release publish, automatically creates a PR to update all package.json versions in main branch

## Why

- npm publish updates versions during release but main branch package.json stays outdated
- This causes integration test pack mode to fail due to version mismatch

## Test plan

- [ ] Verify workflow syntax is valid (YAML lint passed)
- [ ] Test on next release by checking if PR is auto-created

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782221653&installation_id=133048706&pr_number=219&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F219&signature=643f94147594765c2550a16ba3aa52a5700fbea02657c99fb6b00512702a918a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now automatically updates package versions on main after a release and opens a pull request with the version bump (supports semantic and prerelease tags).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->