### PR TITLE
feat(cli): add build and postBuild hooks to plugin system

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -52,21 +52,27 @@ const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
 
   await runPreBuildHooks(hookOptions);
 
-  const buildResult = await runBuildHook(hookOptions);
   let success = true;
+  let buildError: unknown;
 
-  if (!buildResult.handled) {
-    consola.start('Building...');
-    try {
+  try {
+    const buildResult = await runBuildHook(hookOptions);
+
+    if (!buildResult.handled) {
+      consola.start('Building...');
       await runTsdownBuild({ cwd, config: buildConfig });
       consola.success('Build completed');
-    } catch (error) {
-      success = false;
-      throw error;
     }
+  } catch (error) {
+    success = false;
+    buildError = error;
+  } finally {
+    await runPostBuildHooks(hookOptions, { success });
   }
 
-  await runPostBuildHooks(hookOptions, { success });
+  if (buildError !== undefined) {
+    throw buildError;
+  }
 };
 
 const handleError = (error: RunBuildError): void => {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,4 +1,5 @@
 import { NodeCliConfig } from '@zeltjs/adapter-node';
+import { createApp } from '@zeltjs/core';
 import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
@@ -6,14 +7,15 @@ import { match } from 'ts-pattern';
 import { runTsdownBuild } from '../builders/tsdown';
 import { loadZeltConfig } from '../config/loader';
 import type { BuildConfig } from '../config/schema';
-import type { ZeltBuildError, ZeltConfigLoadError } from '../errors';
+import type { ZeltBuildError, ZeltConfigLoadError, ZeltMultipleBuildHooksError } from '../errors';
 import {
   isZeltBuildError,
   isZeltConfigLoadError,
+  isZeltMultipleBuildHooksError,
   isZeltNoEntryError,
   ZeltNoEntryError,
 } from '../errors';
-import { runPreBuildHooks } from '../plugin/runner';
+import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from '../plugin/runner';
 
 const cliConfig = new NodeCliConfig();
 
@@ -26,7 +28,8 @@ type BuildArgs = {
 type RunBuildError =
   | InstanceType<typeof ZeltConfigLoadError>
   | InstanceType<typeof ZeltBuildError>
-  | InstanceType<typeof ZeltNoEntryError>;
+  | InstanceType<typeof ZeltNoEntryError>
+  | InstanceType<typeof ZeltMultipleBuildHooksError>;
 
 const resolveBuildConfig = (args: BuildArgs, buildConfig: BuildConfig | undefined) => ({
   ...buildConfig,
@@ -34,23 +37,36 @@ const resolveBuildConfig = (args: BuildArgs, buildConfig: BuildConfig | undefine
   outDir: args.outDir ?? buildConfig?.outDir,
 });
 
-/** @throws {ZeltConfigLoadError | ZeltBuildError | ZeltNoEntryError | InvalidConfigExportError} */
+/** @throws {ZeltConfigLoadError | ZeltBuildError | ZeltNoEntryError | ZeltMultipleBuildHooksError} */
 const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
   const configFile = typedArgs.config;
   const config = await loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd });
-
-  // Run preBuild hooks first
-  await runPreBuildHooks({ cwd, config });
-
   const buildConfig = resolveBuildConfig(typedArgs, config.build);
 
   if (buildConfig.entry === undefined) {
     throw new ZeltNoEntryError({});
   }
 
-  consola.start('Building...');
-  await runTsdownBuild({ cwd, config: buildConfig });
-  consola.success('Build completed');
+  const app = createApp({ http: { controllers: [] } });
+  const hookOptions = { cwd, config, app };
+
+  await runPreBuildHooks(hookOptions);
+
+  const buildResult = await runBuildHook(hookOptions);
+  let success = true;
+
+  if (!buildResult.handled) {
+    consola.start('Building...');
+    try {
+      await runTsdownBuild({ cwd, config: buildConfig });
+      consola.success('Build completed');
+    } catch (error) {
+      success = false;
+      throw error;
+    }
+  }
+
+  await runPostBuildHooks(hookOptions, { success });
 };
 
 const handleError = (error: RunBuildError): void => {
@@ -63,6 +79,9 @@ const handleError = (error: RunBuildError): void => {
     })
     .when(isZeltBuildError, () => {
       consola.error('Build failed');
+    })
+    .when(isZeltMultipleBuildHooksError, (e) => {
+      consola.error(e.message);
     })
     .otherwise(() => {});
 };
@@ -96,7 +115,12 @@ export const buildCommand = defineCommand({
     try {
       await runBuild(cwd, typedArgs);
     } catch (error) {
-      if (isZeltConfigLoadError(error) || isZeltBuildError(error) || isZeltNoEntryError(error)) {
+      if (
+        isZeltConfigLoadError(error) ||
+        isZeltBuildError(error) ||
+        isZeltNoEntryError(error) ||
+        isZeltMultipleBuildHooksError(error)
+      ) {
         handleError(error);
       } else {
         throw error;

--- a/packages/cli/src/dev-server/server.ts
+++ b/packages/cli/src/dev-server/server.ts
@@ -91,8 +91,17 @@ const runHooks = async (
   const hookOptions = { cwd, config, app };
 
   await runPreBuildHooks(hookOptions);
-  await runBuildHook(hookOptions);
-  await runPostBuildHooks(hookOptions, { success: true });
+
+  let success = true;
+
+  try {
+    await runBuildHook(hookOptions);
+  } catch (error) {
+    success = false;
+    throw error;
+  } finally {
+    await runPostBuildHooks(hookOptions, { success });
+  }
 };
 
 const createShutdownHandler = (state: DevServerState) => {

--- a/packages/cli/src/dev-server/server.ts
+++ b/packages/cli/src/dev-server/server.ts
@@ -3,11 +3,12 @@ import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 
 import { NodeCliConfig } from '@zeltjs/adapter-node';
-import type { SignalHandler } from '@zeltjs/core';
+import type { App, CreateAppOptions, SignalHandler } from '@zeltjs/core';
+import { createApp } from '@zeltjs/core';
 import consola from 'consola';
 
 import type { DevConfig, ZeltConfig } from '../config/schema';
-import { runPreBuildHooks } from '../plugin/runner';
+import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from '../plugin/runner';
 
 import type { WatcherHandle } from './watcher';
 import { createWatcher } from './watcher';
@@ -24,6 +25,7 @@ type DevServerState = {
   childProcess: ChildProcess | undefined;
   watcher: WatcherHandle | undefined;
   isShuttingDown: boolean;
+  app: App<CreateAppOptions>;
 };
 
 const DEFAULT_WATCH_PATTERNS = ['./src/**/*.ts'];
@@ -81,6 +83,18 @@ const startProcess = (cwd: string, entry: string): ChildProcess => {
   return child;
 };
 
+const runHooks = async (
+  cwd: string,
+  config: ZeltConfig,
+  app: App<CreateAppOptions>,
+): Promise<void> => {
+  const hookOptions = { cwd, config, app };
+
+  await runPreBuildHooks(hookOptions);
+  await runBuildHook(hookOptions);
+  await runPostBuildHooks(hookOptions, { success: true });
+};
+
 const createShutdownHandler = (state: DevServerState) => {
   return async (): Promise<void> => {
     if (state.isShuttingDown) {
@@ -118,9 +132,9 @@ const createRestartHandler = (
     }
 
     try {
-      await runPreBuildHooks({ cwd, config });
+      await runHooks(cwd, config, state.app);
     } catch (error) {
-      consola.error('Plugin preBuild hook failed:', error);
+      consola.error('Plugin hook failed:', error);
     }
 
     state.childProcess = startProcess(cwd, entry);
@@ -144,10 +158,13 @@ const registerSignalHandlers = (onSignal: () => Promise<void>): SignalHandler =>
 export const startDevServer = async (options: DevServerOptions): Promise<void> => {
   const { cwd, config, devConfig } = options;
 
+  const app = createApp({ http: { controllers: [] } });
+
   const state: DevServerState = {
     childProcess: undefined,
     watcher: undefined,
     isShuttingDown: false,
+    app,
   };
 
   const watchPatterns = devConfig.watch ?? DEFAULT_WATCH_PATTERNS;
@@ -170,9 +187,9 @@ export const startDevServer = async (options: DevServerOptions): Promise<void> =
   });
 
   try {
-    await runPreBuildHooks({ cwd, config });
+    await runHooks(cwd, config, app);
   } catch (error) {
-    consola.error('Plugin preBuild hook failed:', error);
+    consola.error('Plugin hook failed:', error);
   }
 
   state.childProcess = startProcess(cwd, devConfig.entry);

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -39,3 +39,14 @@ export const isZeltNoCliEntryError = (
 export const isZeltCliExecutionError = (
   err: unknown,
 ): err is InstanceType<typeof ZeltCliExecutionError> => err instanceof ZeltCliExecutionError;
+
+export const ZeltMultipleBuildHooksError = defineError(
+  'ZeltMultipleBuildHooksError',
+  (ctx: { pluginNames: readonly string[] }) =>
+    `Multiple plugins define build hook: ${ctx.pluginNames.join(', ')}. Only one plugin can define a custom build.`,
+);
+
+export const isZeltMultipleBuildHooksError = (
+  err: unknown,
+): err is InstanceType<typeof ZeltMultipleBuildHooksError> =>
+  err instanceof ZeltMultipleBuildHooksError;

--- a/packages/cli/src/plugin/index.ts
+++ b/packages/cli/src/plugin/index.ts
@@ -1,2 +1,2 @@
-export { runPreBuildHooks } from './runner';
-export type { BuildContext, ZeltPlugin } from './types';
+export { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './runner';
+export type { BuildContext, BuildResult, ZeltPlugin } from './types';

--- a/packages/cli/src/plugin/runner.test.ts
+++ b/packages/cli/src/plugin/runner.test.ts
@@ -163,6 +163,20 @@ describe('runBuildHook', () => {
       app: mockApp,
     });
   });
+
+  it('handles empty plugins array', async () => {
+    const config: ZeltConfig = { ...baseConfig, plugins: [] };
+    const result = await runBuildHook({ cwd: '/test', config, app: createMockApp() });
+
+    expect(result).toEqual({ handled: false });
+  });
+
+  it('handles undefined plugins', async () => {
+    const config: ZeltConfig = { ...baseConfig };
+    const result = await runBuildHook({ cwd: '/test', config, app: createMockApp() });
+
+    expect(result).toEqual({ handled: false });
+  });
 });
 
 describe('runPostBuildHooks', () => {
@@ -217,5 +231,30 @@ describe('runPostBuildHooks', () => {
     await expect(
       runPostBuildHooks({ cwd: '/test', config, app: createMockApp() }, { success: true }),
     ).resolves.toBeUndefined();
+  });
+
+  it('handles undefined plugins', async () => {
+    const config: ZeltConfig = { ...baseConfig };
+    await expect(
+      runPostBuildHooks({ cwd: '/test', config, app: createMockApp() }, { success: true }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips plugins without postBuild hook', async () => {
+    const postBuildFn = vi.fn();
+
+    const pluginWithHook: ZeltPlugin = {
+      name: 'with-hook',
+      postBuild: postBuildFn,
+    };
+
+    const pluginWithoutHook: ZeltPlugin = {
+      name: 'without-hook',
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [pluginWithoutHook, pluginWithHook] };
+    await runPostBuildHooks({ cwd: '/test', config, app: createMockApp() }, { success: true });
+
+    expect(postBuildFn).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/plugin/runner.test.ts
+++ b/packages/cli/src/plugin/runner.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ZeltConfig } from '../config/schema';
+import { ZeltMultipleBuildHooksError } from '../errors';
 
-import { runPreBuildHooks } from './runner';
+import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './runner';
 import type { ZeltPlugin } from './types';
+
+const createMockApp = () =>
+  ({
+    ready: vi.fn(),
+    shutdown: vi.fn(),
+    getControllers: vi.fn().mockReturnValue([]),
+  }) as never;
 
 describe('runPreBuildHooks', () => {
   const baseConfig: ZeltConfig = {
@@ -29,7 +37,7 @@ describe('runPreBuildHooks', () => {
     };
 
     const config: ZeltConfig = { ...baseConfig, plugins: [plugin1, plugin2] };
-    await runPreBuildHooks({ cwd: '/test', config });
+    await runPreBuildHooks({ cwd: '/test', config, app: createMockApp() });
 
     expect(order).toEqual(['plugin1', 'plugin2']);
   });
@@ -47,23 +55,28 @@ describe('runPreBuildHooks', () => {
     };
 
     const config: ZeltConfig = { ...baseConfig, plugins: [pluginWithoutHook, pluginWithHook] };
-    await runPreBuildHooks({ cwd: '/test', config });
+    await runPreBuildHooks({ cwd: '/test', config, app: createMockApp() });
 
     expect(called).toHaveBeenCalledOnce();
   });
 
   it('handles empty plugins array', async () => {
     const config: ZeltConfig = { ...baseConfig, plugins: [] };
-    await expect(runPreBuildHooks({ cwd: '/test', config })).resolves.toBeUndefined();
+    await expect(
+      runPreBuildHooks({ cwd: '/test', config, app: createMockApp() }),
+    ).resolves.toBeUndefined();
   });
 
   it('handles undefined plugins', async () => {
     const config: ZeltConfig = { ...baseConfig };
-    await expect(runPreBuildHooks({ cwd: '/test', config })).resolves.toBeUndefined();
+    await expect(
+      runPreBuildHooks({ cwd: '/test', config, app: createMockApp() }),
+    ).resolves.toBeUndefined();
   });
 
   it('passes correct context to plugin', async () => {
     const receivedContext = vi.fn();
+    const mockApp = createMockApp();
 
     const plugin: ZeltPlugin = {
       name: 'test',
@@ -71,11 +84,138 @@ describe('runPreBuildHooks', () => {
     };
 
     const config: ZeltConfig = { ...baseConfig, plugins: [plugin] };
-    await runPreBuildHooks({ cwd: '/my/cwd', config });
+    await runPreBuildHooks({ cwd: '/my/cwd', config, app: mockApp });
 
     expect(receivedContext).toHaveBeenCalledWith({
       cwd: '/my/cwd',
       config,
+      app: mockApp,
     });
+  });
+});
+
+describe('runBuildHook', () => {
+  const baseConfig: ZeltConfig = {
+    entry: './src/app.ts',
+    build: { entry: './src/index.ts' },
+  };
+
+  it('returns handled: false when no plugin has build hook', async () => {
+    const plugin: ZeltPlugin = {
+      name: 'no-build',
+      preBuild: vi.fn(),
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [plugin] };
+    const result = await runBuildHook({ cwd: '/test', config, app: createMockApp() });
+
+    expect(result).toEqual({ handled: false });
+  });
+
+  it('runs single build hook and returns handled: true', async () => {
+    const buildFn = vi.fn();
+
+    const plugin: ZeltPlugin = {
+      name: 'custom-builder',
+      build: buildFn,
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [plugin] };
+    const result = await runBuildHook({ cwd: '/test', config, app: createMockApp() });
+
+    expect(buildFn).toHaveBeenCalledOnce();
+    expect(result).toEqual({ handled: true });
+  });
+
+  it('throws ZeltMultipleBuildHooksError when multiple plugins have build hook', async () => {
+    const plugin1: ZeltPlugin = {
+      name: 'builder1',
+      build: vi.fn(),
+    };
+
+    const plugin2: ZeltPlugin = {
+      name: 'builder2',
+      build: vi.fn(),
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [plugin1, plugin2] };
+
+    await expect(runBuildHook({ cwd: '/test', config, app: createMockApp() })).rejects.toThrow(
+      ZeltMultipleBuildHooksError,
+    );
+  });
+
+  it('passes correct context to build hook', async () => {
+    const buildFn = vi.fn();
+    const mockApp = createMockApp();
+
+    const plugin: ZeltPlugin = {
+      name: 'test',
+      build: buildFn,
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [plugin] };
+    await runBuildHook({ cwd: '/my/cwd', config, app: mockApp });
+
+    expect(buildFn).toHaveBeenCalledWith({
+      cwd: '/my/cwd',
+      config,
+      app: mockApp,
+    });
+  });
+});
+
+describe('runPostBuildHooks', () => {
+  const baseConfig: ZeltConfig = {
+    entry: './src/app.ts',
+    build: { entry: './src/index.ts' },
+  };
+
+  it('calls postBuild hooks in order', async () => {
+    const order: string[] = [];
+
+    const plugin1: ZeltPlugin = {
+      name: 'plugin1',
+      postBuild: async () => {
+        order.push('plugin1');
+      },
+    };
+
+    const plugin2: ZeltPlugin = {
+      name: 'plugin2',
+      postBuild: async () => {
+        order.push('plugin2');
+      },
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [plugin1, plugin2] };
+    await runPostBuildHooks({ cwd: '/test', config, app: createMockApp() }, { success: true });
+
+    expect(order).toEqual(['plugin1', 'plugin2']);
+  });
+
+  it('passes result to postBuild hook', async () => {
+    const postBuildFn = vi.fn();
+
+    const plugin: ZeltPlugin = {
+      name: 'test',
+      postBuild: postBuildFn,
+    };
+
+    const config: ZeltConfig = { ...baseConfig, plugins: [plugin] };
+    const mockApp = createMockApp();
+    await runPostBuildHooks({ cwd: '/test', config, app: mockApp }, { success: false });
+
+    expect(postBuildFn).toHaveBeenCalledWith(
+      { cwd: '/test', config, app: mockApp },
+      { success: false },
+    );
+  });
+
+  it('handles empty plugins array', async () => {
+    const config: ZeltConfig = { ...baseConfig, plugins: [] };
+    await expect(
+      runPostBuildHooks({ cwd: '/test', config, app: createMockApp() }, { success: true }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/cli/src/plugin/runner.ts
+++ b/packages/cli/src/plugin/runner.ts
@@ -1,24 +1,73 @@
+import type { App, CreateAppOptions } from '@zeltjs/core';
 import consola from 'consola';
 
 import type { ZeltConfig } from '../config/schema';
+import { ZeltMultipleBuildHooksError } from '../errors';
 
-import type { BuildContext, ZeltPlugin } from './types';
+import type { BuildContext, BuildResult, ZeltPlugin } from './types';
 
-export type RunPreBuildHooksOptions = {
+export type RunPluginHooksOptions = {
   readonly cwd: string;
   readonly config: ZeltConfig;
+  readonly app: App<CreateAppOptions>;
 };
 
-export const runPreBuildHooks = async (options: RunPreBuildHooksOptions): Promise<void> => {
-  const { cwd, config } = options;
+export const runPreBuildHooks = async (options: RunPluginHooksOptions): Promise<void> => {
+  const { cwd, config, app } = options;
   const plugins: readonly ZeltPlugin[] = config.plugins ?? [];
 
   for (const plugin of plugins) {
     if (plugin.preBuild !== undefined) {
       consola.info(`[${plugin.name}] Running preBuild hook...`);
-      const context: BuildContext = { cwd, config };
+      const context: BuildContext = { cwd, config, app };
       await plugin.preBuild(context);
       consola.success(`[${plugin.name}] preBuild completed`);
+    }
+  }
+};
+
+export type RunBuildHookResult = {
+  readonly handled: boolean;
+};
+
+export const runBuildHook = async (options: RunPluginHooksOptions): Promise<RunBuildHookResult> => {
+  const { cwd, config, app } = options;
+  const plugins: readonly ZeltPlugin[] = config.plugins ?? [];
+
+  const pluginsWithBuild = plugins.filter((p) => p.build !== undefined);
+
+  if (pluginsWithBuild.length > 1) {
+    throw new ZeltMultipleBuildHooksError({
+      pluginNames: pluginsWithBuild.map((p) => p.name),
+    });
+  }
+
+  const plugin = pluginsWithBuild[0];
+  if (plugin === undefined) {
+    return { handled: false };
+  }
+
+  consola.info(`[${plugin.name}] Running build hook...`);
+  const context: BuildContext = { cwd, config, app };
+  await plugin.build?.(context);
+  consola.success(`[${plugin.name}] build completed`);
+
+  return { handled: true };
+};
+
+export const runPostBuildHooks = async (
+  options: RunPluginHooksOptions,
+  result: BuildResult,
+): Promise<void> => {
+  const { cwd, config, app } = options;
+  const plugins: readonly ZeltPlugin[] = config.plugins ?? [];
+
+  for (const plugin of plugins) {
+    if (plugin.postBuild !== undefined) {
+      consola.info(`[${plugin.name}] Running postBuild hook...`);
+      const context: BuildContext = { cwd, config, app };
+      await plugin.postBuild(context, result);
+      consola.success(`[${plugin.name}] postBuild completed`);
     }
   }
 };

--- a/packages/cli/src/plugin/types.ts
+++ b/packages/cli/src/plugin/types.ts
@@ -1,11 +1,20 @@
+import type { App, CreateAppOptions } from '@zeltjs/core';
+
 import type { ZeltConfig } from '../config/schema';
 
 export type BuildContext = {
   readonly cwd: string;
   readonly config: ZeltConfig;
+  readonly app: App<CreateAppOptions>;
+};
+
+export type BuildResult = {
+  readonly success: boolean;
 };
 
 export type ZeltPlugin = {
   readonly name: string;
   readonly preBuild?: (context: BuildContext) => Promise<void>;
+  readonly build?: (context: BuildContext) => Promise<void>;
+  readonly postBuild?: (context: BuildContext, result: BuildResult) => Promise<void>;
 };


### PR DESCRIPTION
## Summary

- Add `build` and `postBuild` hooks to CLI plugin system for custom build workflows
- `build` hook is exclusive (error if multiple plugins define it)
- `BuildContext` now includes `app` instance for accessing `getControllers()`
- All hooks run on `zelt build` and `zelt dev` (including file changes)

## Motivation

Enable custom build workflows like kakera dynamic workers where plugins need to:
- Take over the build process entirely via the `build` hook
- Generate artifacts after build via the `postBuild` hook
- Access controllers via `app.getControllers()` for per-file bundling

## Changes

| File | Change |
|------|--------|
| `errors.ts` | Add `ZeltMultipleBuildHooksError` |
| `plugin/types.ts` | Add `BuildResult`, update `BuildContext` with `app`, add hooks |
| `plugin/runner.ts` | Add `runBuildHook`, `runPostBuildHooks` |
| `plugin/runner.test.ts` | Add tests for new hooks |
| `commands/build.ts` | Integrate full hook lifecycle |
| `dev-server/server.ts` | Run all hooks on startup + file changes |

## Test plan

- [x] `pnpm --filter @zeltjs/cli typecheck` passes
- [x] `pnpm --filter @zeltjs/cli test` passes (17 tests)
- [x] `pnpm biome check packages/cli/src` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782221809&installation_id=133048706&pr_number=220&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F220&signature=2b111f0814b36a6a4b94a3a0a84c43be3c14caa518ac038b2028ee59ac73485c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin lifecycle expanded with build and post-build hooks; CLI build now runs pre-build → build → post-build and reports overall success.
* **Bug Fixes**
  * Improved error handling and clearer reporting when multiple plugins conflict on the build hook.
* **Dev Tools**
  * Dev server now shares the application instance across restarts for more consistent plugin behavior.
* **Tests**
  * Updated and added tests to cover new hook behaviors and conflict cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->