### PR TITLE
feat(decorator-metadata): add getDependencies API for AST-based dependency extraction

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -180,8 +180,10 @@ export default tseslint.config(
       'max-lines': ['warn', { max: 1000, skipBlankLines: true, skipComments: true }],
       'import-x/no-namespace': 'off',
       '@9wick/strict-type-rules/nestjs-like-di-for-needle-di': 'off',
+      '@9wick/strict-type-rules/no-as-assertion': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
   {

--- a/packages/decorator-metadata/src/inspect/ast-utils.ts
+++ b/packages/decorator-metadata/src/inspect/ast-utils.ts
@@ -9,10 +9,12 @@ export const findClassAtPosition = (
   ts: TypeScriptModule,
 ): TSClassDeclaration | undefined => {
   const find = (node: TSNode): TSClassDeclaration | undefined => {
+    const childHit = ts.forEachChild(node, find);
+    if (childHit) return childHit;
     if (ts.isClassDeclaration(node) && node.pos <= pos && pos < node.end) {
       return node;
     }
-    return ts.forEachChild(node, find);
+    return undefined;
   };
   return find(sourceFile);
 };

--- a/packages/decorator-metadata/src/inspect/ast-utils.ts
+++ b/packages/decorator-metadata/src/inspect/ast-utils.ts
@@ -1,0 +1,32 @@
+type TypeScriptModule = typeof import('typescript');
+type TSSourceFile = import('typescript').SourceFile;
+type TSClassDeclaration = import('typescript').ClassDeclaration;
+type TSNode = import('typescript').Node;
+
+export const findClassAtPosition = (
+  sourceFile: TSSourceFile,
+  pos: number,
+  ts: TypeScriptModule,
+): TSClassDeclaration | undefined => {
+  const find = (node: TSNode): TSClassDeclaration | undefined => {
+    if (ts.isClassDeclaration(node) && node.pos <= pos && pos < node.end) {
+      return node;
+    }
+    return ts.forEachChild(node, find);
+  };
+  return find(sourceFile);
+};
+
+export const findClassByName = (
+  sourceFile: TSSourceFile,
+  name: string,
+  ts: TypeScriptModule,
+): TSClassDeclaration | undefined => {
+  const find = (node: TSNode): TSClassDeclaration | undefined => {
+    if (ts.isClassDeclaration(node) && node.name !== undefined && node.name.text === name) {
+      return node;
+    }
+    return ts.forEachChild(node, find);
+  };
+  return find(sourceFile);
+};

--- a/packages/decorator-metadata/src/inspect/get-dependencies.ts
+++ b/packages/decorator-metadata/src/inspect/get-dependencies.ts
@@ -5,6 +5,7 @@ import { errAsync, okAsync } from 'neverthrow';
 
 import { resolvePosition } from '../runtime/position';
 import { getInternalClassMetadata } from '../runtime/store';
+import { findClassAtPosition, findClassByName } from './ast-utils';
 import type { ProgramCacheError } from './program-cache';
 import { getOrCreateProgram } from './program-cache';
 import type { DependencyInfo, GetDependenciesOptions, InspectError } from './types';
@@ -12,40 +13,24 @@ import type { DependencyInfo, GetDependenciesOptions, InspectError } from './typ
 type TypeScriptModule = typeof import('typescript');
 type TSSourceFile = import('typescript').SourceFile;
 type TSClassDeclaration = import('typescript').ClassDeclaration;
-type TSNode = import('typescript').Node;
 type TSTypeChecker = import('typescript').TypeChecker;
 
 const DEFAULT_TSCONFIG = './tsconfig.json';
+const CONFIG_DECORATOR_NAME = 'Config';
 
-const findClassAtPosition = (
-  sourceFile: TSSourceFile,
-  pos: number,
+const isConfigDecorator = (
+  expr: import('typescript').Expression,
   ts: TypeScriptModule,
-): TSClassDeclaration | undefined => {
-  const find = (node: TSNode): TSClassDeclaration | undefined => {
-    if (ts.isClassDeclaration(node) && node.pos <= pos && pos < node.end) {
-      return node;
-    }
-    return ts.forEachChild(node, find);
-  };
-  return find(sourceFile);
-};
-
-// When the decorator factory is stored in a variable before being applied,
-// the trace points to the factory call site rather than the class declaration.
-// Fall back to name-based lookup to handle that pattern.
-const findClassByName = (
-  sourceFile: TSSourceFile,
-  name: string,
-  ts: TypeScriptModule,
-): TSClassDeclaration | undefined => {
-  const find = (node: TSNode): TSClassDeclaration | undefined => {
-    if (ts.isClassDeclaration(node) && node.name !== undefined && node.name.text === name) {
-      return node;
-    }
-    return ts.forEachChild(node, find);
-  };
-  return find(sourceFile);
+): boolean => {
+  // Handle @Config (identifier)
+  if (ts.isIdentifier(expr)) {
+    return expr.text === CONFIG_DECORATOR_NAME;
+  }
+  // Handle @Config() (call expression)
+  if (ts.isCallExpression(expr) && ts.isIdentifier(expr.expression)) {
+    return expr.expression.text === CONFIG_DECORATOR_NAME;
+  }
+  return false;
 };
 
 const hasConfigDecoratorOnClass = (
@@ -54,11 +39,7 @@ const hasConfigDecoratorOnClass = (
 ): boolean => {
   if (!ts.isClassDeclaration(decl)) return false;
   return (
-    decl.modifiers?.some((m) => {
-      if (!ts.isDecorator(m)) return false;
-      const expr = m.expression;
-      return ts.isIdentifier(expr) && expr.text === 'Config';
-    }) ?? false
+    decl.modifiers?.some((m) => ts.isDecorator(m) && isConfigDecorator(m.expression, ts)) ?? false
   );
 };
 

--- a/packages/decorator-metadata/src/inspect/get-dependencies.ts
+++ b/packages/decorator-metadata/src/inspect/get-dependencies.ts
@@ -1,0 +1,178 @@
+import { resolve } from 'node:path';
+
+import type { ResultAsync } from 'neverthrow';
+import { errAsync, okAsync } from 'neverthrow';
+
+import { resolvePosition } from '../runtime/position';
+import { getInternalClassMetadata } from '../runtime/store';
+import type { ProgramCacheError } from './program-cache';
+import { getOrCreateProgram } from './program-cache';
+import type { DependencyInfo, GetDependenciesOptions, InspectError } from './types';
+
+type TypeScriptModule = typeof import('typescript');
+type TSSourceFile = import('typescript').SourceFile;
+type TSClassDeclaration = import('typescript').ClassDeclaration;
+type TSNode = import('typescript').Node;
+type TSTypeChecker = import('typescript').TypeChecker;
+
+const DEFAULT_TSCONFIG = './tsconfig.json';
+
+const findClassAtPosition = (
+  sourceFile: TSSourceFile,
+  pos: number,
+  ts: TypeScriptModule,
+): TSClassDeclaration | undefined => {
+  const find = (node: TSNode): TSClassDeclaration | undefined => {
+    if (ts.isClassDeclaration(node) && node.pos <= pos && pos < node.end) {
+      return node;
+    }
+    return ts.forEachChild(node, find);
+  };
+  return find(sourceFile);
+};
+
+// When the decorator factory is stored in a variable before being applied,
+// the trace points to the factory call site rather than the class declaration.
+// Fall back to name-based lookup to handle that pattern.
+const findClassByName = (
+  sourceFile: TSSourceFile,
+  name: string,
+  ts: TypeScriptModule,
+): TSClassDeclaration | undefined => {
+  const find = (node: TSNode): TSClassDeclaration | undefined => {
+    if (ts.isClassDeclaration(node) && node.name !== undefined && node.name.text === name) {
+      return node;
+    }
+    return ts.forEachChild(node, find);
+  };
+  return find(sourceFile);
+};
+
+const hasConfigDecoratorOnClass = (
+  decl: import('typescript').Declaration,
+  ts: TypeScriptModule,
+): boolean => {
+  if (!ts.isClassDeclaration(decl)) return false;
+  return (
+    decl.modifiers?.some((m) => {
+      if (!ts.isDecorator(m)) return false;
+      const expr = m.expression;
+      return ts.isIdentifier(expr) && expr.text === 'Config';
+    }) ?? false
+  );
+};
+
+const findModuleSpecifier = (
+  sourceFile: TSSourceFile,
+  identifierName: string,
+  ts: TypeScriptModule,
+): string => {
+  const importDecl = sourceFile.statements.find((stmt) => {
+    if (!ts.isImportDeclaration(stmt)) return false;
+    const namedBindings = stmt.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) return false;
+    return namedBindings.elements.some((e) => e.name.text === identifierName);
+  });
+  if (!importDecl || !ts.isImportDeclaration(importDecl)) return '';
+  if (!ts.isStringLiteral(importDecl.moduleSpecifier)) return '';
+  return importDecl.moduleSpecifier.text;
+};
+
+const extractDepFromParam = (
+  param: import('typescript').ParameterDeclaration,
+  ts: TypeScriptModule,
+  checker: TSTypeChecker,
+  sourceFile: TSSourceFile,
+): DependencyInfo | undefined => {
+  if (!param.initializer || !ts.isCallExpression(param.initializer)) return undefined;
+
+  const callExpr = param.initializer;
+  const callee = callExpr.expression;
+  if (!ts.isIdentifier(callee) || callee.text !== 'inject') return undefined;
+
+  const arg = callExpr.arguments[0];
+  if (!arg || !ts.isIdentifier(arg)) return undefined;
+
+  const symbol = checker.getSymbolAtLocation(arg);
+  if (!symbol) return undefined;
+
+  const decl = symbol.getDeclarations()?.[0];
+  if (!decl) return undefined;
+
+  return {
+    className: arg.text,
+    sourceFile: decl.getSourceFile().fileName,
+    moduleSpecifier: findModuleSpecifier(sourceFile, arg.text, ts),
+    hasConfigDecorator: hasConfigDecoratorOnClass(decl, ts),
+  };
+};
+
+const extractInjectCalls = (
+  classNode: TSClassDeclaration,
+  ts: TypeScriptModule,
+  checker: TSTypeChecker,
+  sourceFile: TSSourceFile,
+): DependencyInfo[] => {
+  const ctor = classNode.members.find((m) => ts.isConstructorDeclaration(m));
+  if (!ctor || !ts.isConstructorDeclaration(ctor)) {
+    return [];
+  }
+
+  return ctor.parameters.flatMap((param) => {
+    const dep = extractDepFromParam(param, ts, checker, sourceFile);
+    return dep ? [dep] : [];
+  });
+};
+
+export const getDependencies = (
+  cls: new (...args: never[]) => unknown,
+  options?: GetDependenciesOptions,
+): ResultAsync<readonly DependencyInfo[], InspectError | ProgramCacheError> => {
+  const storedMeta = getInternalClassMetadata(cls);
+  if (!storedMeta) {
+    return errAsync({
+      code: 'NO_METADATA',
+      message: `No decorator metadata found for class ${cls.name}`,
+    });
+  }
+
+  const storedPos = resolvePosition(storedMeta.trace);
+  if (!storedPos) {
+    return errAsync({
+      code: 'POSITION_INVALID',
+      message: `No source position captured for class ${cls.name}`,
+    });
+  }
+
+  const tsconfigPath = resolve(options?.tsconfig ?? DEFAULT_TSCONFIG);
+
+  return getOrCreateProgram(tsconfigPath).andThen((cached) => {
+    const { program, checker, ts } = cached;
+
+    const sourceFile = program.getSourceFile(storedPos.sourceFile);
+    if (!sourceFile) {
+      return errAsync<readonly DependencyInfo[], InspectError>({
+        code: 'SOURCE_NOT_FOUND',
+        message: `Source file not found: ${storedPos.sourceFile}`,
+      });
+    }
+
+    const pos = ts.getPositionOfLineAndCharacter(
+      sourceFile,
+      storedPos.line - 1,
+      storedPos.column - 1,
+    );
+
+    const classNode =
+      findClassAtPosition(sourceFile, pos, ts) ?? findClassByName(sourceFile, cls.name, ts);
+    if (!classNode || !ts.isClassDeclaration(classNode)) {
+      return errAsync<readonly DependencyInfo[], InspectError>({
+        code: 'POSITION_INVALID',
+        message: `No class found at position ${storedPos.line}:${storedPos.column} or by name ${cls.name}`,
+      });
+    }
+
+    const deps = extractInjectCalls(classNode, ts, checker, sourceFile);
+    return okAsync(deps);
+  });
+};

--- a/packages/decorator-metadata/src/inspect/get-dependencies.ts
+++ b/packages/decorator-metadata/src/inspect/get-dependencies.ts
@@ -77,7 +77,10 @@ const extractDepFromParam = (
   const symbol = checker.getSymbolAtLocation(arg);
   if (!symbol) return undefined;
 
-  const decl = symbol.getDeclarations()?.[0];
+  const resolvedSymbol =
+    (symbol.flags & ts.SymbolFlags.Alias) !== 0 ? checker.getAliasedSymbol(symbol) : symbol;
+
+  const decl = resolvedSymbol.getDeclarations()?.find((d) => ts.isClassDeclaration(d));
   if (!decl) return undefined;
 
   return {

--- a/packages/decorator-metadata/src/inspect/get-dependencies.ts
+++ b/packages/decorator-metadata/src/inspect/get-dependencies.ts
@@ -59,6 +59,18 @@ const findModuleSpecifier = (
   return importDecl.moduleSpecifier.text;
 };
 
+const resolveClassDeclaration = (
+  symbol: import('typescript').Symbol,
+  ts: TypeScriptModule,
+  checker: TSTypeChecker,
+): import('typescript').ClassDeclaration | undefined => {
+  const resolved =
+    (symbol.flags & ts.SymbolFlags.Alias) !== 0 ? checker.getAliasedSymbol(symbol) : symbol;
+  return resolved.getDeclarations()?.find((d) => ts.isClassDeclaration(d)) as
+    | import('typescript').ClassDeclaration
+    | undefined;
+};
+
 const extractDepFromParam = (
   param: import('typescript').ParameterDeclaration,
   ts: TypeScriptModule,
@@ -67,20 +79,16 @@ const extractDepFromParam = (
 ): DependencyInfo | undefined => {
   if (!param.initializer || !ts.isCallExpression(param.initializer)) return undefined;
 
-  const callExpr = param.initializer;
-  const callee = callExpr.expression;
+  const callee = param.initializer.expression;
   if (!ts.isIdentifier(callee) || callee.text !== 'inject') return undefined;
 
-  const arg = callExpr.arguments[0];
+  const arg = param.initializer.arguments[0];
   if (!arg || !ts.isIdentifier(arg)) return undefined;
 
   const symbol = checker.getSymbolAtLocation(arg);
   if (!symbol) return undefined;
 
-  const resolvedSymbol =
-    (symbol.flags & ts.SymbolFlags.Alias) !== 0 ? checker.getAliasedSymbol(symbol) : symbol;
-
-  const decl = resolvedSymbol.getDeclarations()?.find((d) => ts.isClassDeclaration(d));
+  const decl = resolveClassDeclaration(symbol, ts, checker);
   if (!decl) return undefined;
 
   return {

--- a/packages/decorator-metadata/src/inspect/get-type-metadata.ts
+++ b/packages/decorator-metadata/src/inspect/get-type-metadata.ts
@@ -6,6 +6,7 @@ import { errAsync, okAsync } from 'neverthrow';
 import type { Position, StackTrace } from '../runtime/position';
 import { resolvePosition } from '../runtime/position';
 import { getInternalClassMetadata } from '../runtime/store';
+import { findClassAtPosition } from './ast-utils';
 import type { ProgramCacheError } from './program-cache';
 import { getOrCreateProgram } from './program-cache';
 import { createTypeExtractor } from './type-extractor';
@@ -26,8 +27,6 @@ type TypeScriptModule = typeof import('typescript');
 type TSClassDeclaration = import('typescript').ClassDeclaration;
 type TSMethodDeclaration = import('typescript').MethodDeclaration;
 type TSPropertyDeclaration = import('typescript').PropertyDeclaration;
-type TSSourceFile = import('typescript').SourceFile;
-type TSNode = import('typescript').Node;
 type TSTypeChecker = import('typescript').TypeChecker;
 type ExtractTypeFn = (type: import('typescript').Type) => TypeInfo;
 
@@ -40,20 +39,6 @@ type StoredPropertyMeta = {
   readonly name: string | symbol;
   readonly trace: StackTrace | undefined;
   readonly props: readonly object[];
-};
-
-const findClassAtPosition = (
-  sourceFile: TSSourceFile,
-  pos: number,
-  ts: TypeScriptModule,
-): TSClassDeclaration | undefined => {
-  const find = (node: TSNode): TSClassDeclaration | undefined => {
-    if (ts.isClassDeclaration(node) && node.pos <= pos && pos < node.end) {
-      return node;
-    }
-    return ts.forEachChild(node, find);
-  };
-  return find(sourceFile);
 };
 
 const findMethodInClass = (

--- a/packages/decorator-metadata/src/inspect/index.ts
+++ b/packages/decorator-metadata/src/inspect/index.ts
@@ -1,11 +1,14 @@
 export { getClassMetadata } from '../runtime/store';
+export { getDependencies } from './get-dependencies';
 export { getTypeMetadata } from './get-type-metadata';
 export { clearProgramCache } from './program-cache';
 export type { GetSourcePositionOptions } from './source-position';
 export { getSourcePosition } from './source-position';
 export type {
   ClassMetadata,
+  DependencyInfo,
   ExpandStrategy,
+  GetDependenciesOptions,
   InspectError,
   InspectErrorCode,
   InspectOptions,

--- a/packages/decorator-metadata/src/inspect/types.ts
+++ b/packages/decorator-metadata/src/inspect/types.ts
@@ -72,3 +72,18 @@ export type InspectOptions = {
   readonly tsconfig?: string;
   readonly expandStrategy?: ExpandStrategy;
 };
+
+// --- getDependencies types ---
+
+export type GetDependenciesOptions = {
+  readonly recursive?: boolean;
+  readonly maxDepth?: number;
+  readonly tsconfig?: string;
+};
+
+export type DependencyInfo = {
+  readonly className: string;
+  readonly sourceFile: string;
+  readonly moduleSpecifier: string;
+  readonly hasConfigDecorator: boolean;
+};

--- a/packages/decorator-metadata/src/inspect/types.ts
+++ b/packages/decorator-metadata/src/inspect/types.ts
@@ -76,8 +76,6 @@ export type InspectOptions = {
 // --- getDependencies types ---
 
 export type GetDependenciesOptions = {
-  readonly recursive?: boolean;
-  readonly maxDepth?: number;
   readonly tsconfig?: string;
 };
 

--- a/packages/decorator-metadata/src/test/fixtures/deps/multi-dep.ts
+++ b/packages/decorator-metadata/src/test/fixtures/deps/multi-dep.ts
@@ -1,0 +1,21 @@
+import { createClassDecorator } from '../../../index';
+
+const Service = createClassDecorator({ type: 'service' });
+const inject = <T>(_cls: new (...args: never[]) => T): T => {
+  return {} as T;
+};
+
+@Service
+export class DepA {}
+
+@Service
+export class DepB {}
+
+@Service
+export class DepC {}
+
+@Service
+export class MultiDepService {
+  // biome-ignore lint/complexity/noUselessConstructor: fixture for AST-based inject() extraction tests
+  constructor(_a = inject(DepA), _b = inject(DepB), _c = inject(DepC)) {}
+}

--- a/packages/decorator-metadata/src/test/fixtures/deps/no-dep.ts
+++ b/packages/decorator-metadata/src/test/fixtures/deps/no-dep.ts
@@ -1,0 +1,10 @@
+import { createClassDecorator } from '../../../index';
+
+const Service = createClassDecorator({ type: 'service' });
+
+@Service
+export class NoDepService {
+  getValue(): string {
+    return 'value';
+  }
+}

--- a/packages/decorator-metadata/src/test/fixtures/deps/single-dep.ts
+++ b/packages/decorator-metadata/src/test/fixtures/deps/single-dep.ts
@@ -1,0 +1,15 @@
+import { createClassDecorator } from '../../../index';
+
+const Service = createClassDecorator({ type: 'service' });
+const inject = <T>(_cls: new (...args: never[]) => T): T => {
+  return {} as T;
+};
+
+@Service
+export class DependencyA {}
+
+@Service
+export class SingleDepService {
+  // biome-ignore lint/complexity/noUselessConstructor: fixture for AST-based inject() extraction tests
+  constructor(_dep = inject(DependencyA)) {}
+}

--- a/packages/decorator-metadata/src/test/fixtures/deps/with-config.ts
+++ b/packages/decorator-metadata/src/test/fixtures/deps/with-config.ts
@@ -1,0 +1,20 @@
+import { createClassDecorator } from '../../../index';
+
+const Config = createClassDecorator({ decorator: 'Config' });
+const Service = createClassDecorator({ type: 'service' });
+const inject = <T>(_cls: new (...args: never[]) => T): T => {
+  return {} as T;
+};
+
+@Config
+export class TestConfig {
+  get value(): string {
+    return 'test';
+  }
+}
+
+@Service
+export class ServiceWithConfig {
+  // biome-ignore lint/complexity/noUselessConstructor: fixture for AST-based inject() extraction tests
+  constructor(_config = inject(TestConfig)) {}
+}

--- a/packages/decorator-metadata/src/test/get-dependencies.test.ts
+++ b/packages/decorator-metadata/src/test/get-dependencies.test.ts
@@ -67,4 +67,17 @@ describe('getDependencies', () => {
     expect(result.value[0]?.className).toBe('TestConfig');
     expect(result.value[0]?.hasConfigDecorator).toBe(true);
   });
+
+  it('returns error for class without decorator metadata', async () => {
+    class PlainClass {}
+
+    const result = await getDependencies(PlainClass, {
+      tsconfig: resolve(__dirname, '../../tsconfig.json'),
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('NO_METADATA');
+    }
+  });
 });

--- a/packages/decorator-metadata/src/test/get-dependencies.test.ts
+++ b/packages/decorator-metadata/src/test/get-dependencies.test.ts
@@ -21,4 +21,22 @@ describe('getDependencies', () => {
     expect(result.value).toHaveLength(1);
     expect(result.value[0]?.className).toBe('DependencyA');
   });
+
+  it('extracts multiple dependencies from constructor', async () => {
+    const { MultiDepService } = await import('./fixtures/deps/multi-dep');
+
+    const result = await getDependencies(MultiDepService, {
+      tsconfig: resolve(__dirname, '../../tsconfig.json'),
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value).toHaveLength(3);
+
+    const classNames = result.value.map((d) => d.className);
+    expect(classNames).toContain('DepA');
+    expect(classNames).toContain('DepB');
+    expect(classNames).toContain('DepC');
+  });
 });

--- a/packages/decorator-metadata/src/test/get-dependencies.test.ts
+++ b/packages/decorator-metadata/src/test/get-dependencies.test.ts
@@ -1,0 +1,24 @@
+import { resolve } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { clearProgramCache, getDependencies } from '../inspect/index';
+
+describe('getDependencies', () => {
+  beforeAll(() => {
+    clearProgramCache();
+  });
+
+  it('extracts single dependency from constructor inject()', async () => {
+    const { SingleDepService } = await import('./fixtures/deps/single-dep');
+
+    const result = await getDependencies(SingleDepService, {
+      tsconfig: resolve(__dirname, '../../tsconfig.json'),
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0].className).toBe('DependencyA');
+  });
+});

--- a/packages/decorator-metadata/src/test/get-dependencies.test.ts
+++ b/packages/decorator-metadata/src/test/get-dependencies.test.ts
@@ -52,4 +52,19 @@ describe('getDependencies', () => {
 
     expect(result.value).toHaveLength(0);
   });
+
+  it('detects hasConfigDecorator for @Config classes', async () => {
+    const { ServiceWithConfig } = await import('./fixtures/deps/with-config');
+
+    const result = await getDependencies(ServiceWithConfig, {
+      tsconfig: resolve(__dirname, '../../tsconfig.json'),
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.className).toBe('TestConfig');
+    expect(result.value[0]?.hasConfigDecorator).toBe(true);
+  });
 });

--- a/packages/decorator-metadata/src/test/get-dependencies.test.ts
+++ b/packages/decorator-metadata/src/test/get-dependencies.test.ts
@@ -19,6 +19,6 @@ describe('getDependencies', () => {
     if (!result.isOk()) return;
 
     expect(result.value).toHaveLength(1);
-    expect(result.value[0].className).toBe('DependencyA');
+    expect(result.value[0]?.className).toBe('DependencyA');
   });
 });

--- a/packages/decorator-metadata/src/test/get-dependencies.test.ts
+++ b/packages/decorator-metadata/src/test/get-dependencies.test.ts
@@ -39,4 +39,17 @@ describe('getDependencies', () => {
     expect(classNames).toContain('DepB');
     expect(classNames).toContain('DepC');
   });
+
+  it('returns empty array for class with no dependencies', async () => {
+    const { NoDepService } = await import('./fixtures/deps/no-dep');
+
+    const result = await getDependencies(NoDepService, {
+      tsconfig: resolve(__dirname, '../../tsconfig.json'),
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Add `getDependencies()` function to extract class dependencies via AST analysis
- Detect `inject()` calls in constructor parameters without runtime overhead
- Support `hasConfigDecorator` detection for `@Config` and `@Config()` patterns
- Extract shared AST utilities to `ast-utils.ts` module

## Motivation

Enables static analysis of class dependencies for the upcoming `config:eject` CLI command (Laravel-like config publish). This approach avoids runtime tracking overhead.

## Changes

### New Files
- `packages/decorator-metadata/src/inspect/get-dependencies.ts` - Main implementation
- `packages/decorator-metadata/src/inspect/ast-utils.ts` - Shared AST utilities
- `packages/decorator-metadata/src/test/fixtures/deps/` - Test fixtures

### Modified Files
- `packages/decorator-metadata/src/inspect/types.ts` - Added `DependencyInfo`, `GetDependenciesOptions`
- `packages/decorator-metadata/src/inspect/index.ts` - Export new API
- `packages/decorator-metadata/src/inspect/get-type-metadata.ts` - Use shared `findClassAtPosition`

## API

\`\`\`typescript
export type DependencyInfo = {
  readonly className: string;
  readonly sourceFile: string;
  readonly moduleSpecifier: string;
  readonly hasConfigDecorator: boolean;
};

export const getDependencies = (
  cls: new (...args: never[]) => unknown,
  options?: GetDependenciesOptions,
): ResultAsync<readonly DependencyInfo[], InspectError | ProgramCacheError>;
\`\`\`

## Test plan

- [x] Single dependency extraction
- [x] Multiple dependencies extraction
- [x] No dependencies returns empty array
- [x] `@Config` decorator detection
- [x] Error case: class without decorator metadata

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782299390&installation_id=133048706&pr_number=224&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F224&signature=2eae13dd8b25e04599a1bfb2f88f28debbc4cb6e1c9e300f6c5f5b00073c441a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dependency inspection to extract constructor-injected dependencies (class names, source locations, module specifiers, and config-decorator detection).

* **Refactor**
  * Consolidated TypeScript AST helpers into a shared helper module for reuse.

* **Tests**
  * Added test fixtures and a test suite validating dependency extraction across single, multiple, none, and config-decorated scenarios.

* **Chores**
  * Relaxed lint rules for test/fixture files to allow certain type assertions and unsafe-return patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->