### PR TITLE
fix(hono-client): strip file:// protocol from sourceFile path

### DIFF
--- a/packages/hono-client/src/generator/emit.lib.test.ts
+++ b/packages/hono-client/src/generator/emit.lib.test.ts
@@ -1,8 +1,31 @@
 import { Controller } from '@zeltjs/core';
 import { describe, expect, it } from 'vitest';
 
-import { emitAppType } from './emit.lib';
+import { emitAppType, toRelativeImport } from './emit.lib';
 import type { ControllerClass, HttpMetadata } from './generator.types';
+
+describe('toRelativeImport', () => {
+  it('handles file:// URL by stripping protocol and converting to relative path', () => {
+    const distDir = '/app/generated';
+    const fileUrl = 'file:///app/src/controllers/userController.ts';
+    const result = toRelativeImport(distDir, fileUrl);
+    expect(result).toBe('../src/controllers/userController');
+  });
+
+  it('handles normal file path', () => {
+    const distDir = '/app/generated';
+    const filePath = '/app/src/controllers/userController.ts';
+    const result = toRelativeImport(distDir, filePath);
+    expect(result).toBe('../src/controllers/userController');
+  });
+
+  it('adds ./ prefix for same directory', () => {
+    const distDir = '/app/generated';
+    const filePath = '/app/generated/types.ts';
+    const result = toRelativeImport(distDir, filePath);
+    expect(result).toBe('./types');
+  });
+});
 
 @Controller('/users')
 class UserController {

--- a/packages/hono-client/src/generator/emit.lib.test.ts
+++ b/packages/hono-client/src/generator/emit.lib.test.ts
@@ -25,6 +25,20 @@ describe('toRelativeImport', () => {
     const result = toRelativeImport(distDir, filePath);
     expect(result).toBe('./types');
   });
+
+  it('decodes percent-encoded characters in file:// URL', () => {
+    const distDir = '/app/generated';
+    const fileUrl = 'file:///app/src/controllers/user%20controller.ts';
+    const result = toRelativeImport(distDir, fileUrl);
+    expect(result).toBe('../src/controllers/user controller');
+  });
+
+  it('always uses forward slashes in output', () => {
+    const distDir = '/app/generated';
+    const filePath = '/app/src/controllers/userController.ts';
+    const result = toRelativeImport(distDir, filePath);
+    expect(result).not.toContain('\\');
+  });
 });
 
 @Controller('/users')

--- a/packages/hono-client/src/generator/emit.lib.ts
+++ b/packages/hono-client/src/generator/emit.lib.ts
@@ -1,4 +1,5 @@
 import { relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { ZeltDecoratorUsageError } from '@zeltjs/core';
 import { getSourcePosition } from '@zeltjs/decorator-metadata/inspect';
@@ -12,11 +13,13 @@ import type {
 
 const stripTsExtension = (p: string): string => p.replace(/\.tsx?$/, '');
 
-const stripFileProtocol = (p: string): string => (p.startsWith('file://') ? p.slice(7) : p);
+const toFilePath = (p: string): string => (p.startsWith('file://') ? fileURLToPath(p) : p);
+
+const toPosixPath = (p: string): string => p.replaceAll('\\', '/');
 
 export const toRelativeImport = (distDir: string, modulePath: string): string => {
-  const normalizedPath = stripFileProtocol(modulePath);
-  const rel = stripTsExtension(relative(distDir, normalizedPath));
+  const filePath = toFilePath(modulePath);
+  const rel = toPosixPath(stripTsExtension(relative(distDir, filePath)));
   return rel.startsWith('.') ? rel : `./${rel}`;
 };
 

--- a/packages/hono-client/src/generator/emit.lib.ts
+++ b/packages/hono-client/src/generator/emit.lib.ts
@@ -12,8 +12,11 @@ import type {
 
 const stripTsExtension = (p: string): string => p.replace(/\.tsx?$/, '');
 
-const toRelativeImport = (distDir: string, modulePath: string): string => {
-  const rel = stripTsExtension(relative(distDir, modulePath));
+const stripFileProtocol = (p: string): string => (p.startsWith('file://') ? p.slice(7) : p);
+
+export const toRelativeImport = (distDir: string, modulePath: string): string => {
+  const normalizedPath = stripFileProtocol(modulePath);
+  const rel = stripTsExtension(relative(distDir, normalizedPath));
   return rel.startsWith('.') ? rel : `./${rel}`;
 };
 


### PR DESCRIPTION
## Summary

- Fix invalid import paths generated when running via tsx
- Strip `file://` protocol from sourceFile before relative path calculation
- Add unit tests for `toRelativeImport` function

## Problem

When running `@zeltjs/hono-client generate` via tsx, controller metadata contains `file:///Users/...` format URLs. The `relative()` function doesn't handle these correctly, producing invalid import paths like `../../../file:/Users/...`.

## Solution

Add `stripFileProtocol()` helper that removes `file://` prefix before path calculation.

## Test plan

- [x] Unit tests for file:// URL handling
- [x] Unit tests for normal file paths
- [x] All existing tests pass

Closes #e787dfad

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782599713&installation_id=133048706&pr_number=234&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F234&signature=3ff1697d6f495afbe28fb9ffdb214c87fc905f02283b83bc94be1d19f7f1c51d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 内部パス処理に関する挙動を検証する包括的なテストを追加しました（ファイルURL処理、相対化、エンコード復号、区切り文字統一などを検証）。

* **Chores**
  * 既存の内部ユーティリティを公開シンボルとして公開し、生成処理外から参照可能にしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->