### PR TITLE
refactor(core): remove Disposable interface, unify into Lifecycle

### DIFF
--- a/integration/hooks/src/lifecycle-spy.ts
+++ b/integration/hooks/src/lifecycle-spy.ts
@@ -1,4 +1,4 @@
-import type { Disposable, Lifecycle } from '@zeltjs/core';
+import type { Lifecycle } from '@zeltjs/core';
 import { Injectable, inject, LifecycleManager } from '@zeltjs/core';
 
 export type SpyEvent = {
@@ -64,18 +64,15 @@ export class SecondSpy implements Lifecycle {
 }
 
 @Injectable()
-export class DisposableSpy implements Disposable {
+export class DisposableSpy implements Lifecycle {
   shutdownCalls = 0;
 
-  // Disposable has no startup, but LifecycleManager only accepts Lifecycle.
-  // We bridge with an inline no-op startup so the shutdown side is still registered in order.
   constructor(private readonly lifecycleManager: LifecycleManager = inject(LifecycleManager)) {
-    this.lifecycleManager.register({
-      startup: async () => {
-        activeLog.current?.push({ source: 'disposable', phase: 'startup' });
-      },
-      shutdown: () => this.shutdown(),
-    });
+    this.lifecycleManager.register(this);
+  }
+
+  async startup(): Promise<void> {
+    activeLog.current?.push({ source: 'disposable', phase: 'startup' });
   }
 
   async shutdown(): Promise<void> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,7 +34,7 @@ export {
   PrettyFormatterConfig,
   withLogContext,
 } from './built-in-service/logger';
-export type { Disposable, Lifecycle } from './kernel';
+export type { Lifecycle } from './kernel';
 export { LifecycleManager } from './kernel';
 // DI primitives
 // DI

--- a/packages/core/src/kernel/index.ts
+++ b/packages/core/src/kernel/index.ts
@@ -1,2 +1,2 @@
-export type { Disposable, Lifecycle } from './lifecycle.lib';
+export type { Lifecycle } from './lifecycle.lib';
 export { LifecycleManager } from './lifecycle.lib';

--- a/packages/core/src/kernel/lifecycle.lib.ts
+++ b/packages/core/src/kernel/lifecycle.lib.ts
@@ -2,13 +2,10 @@ import { injectable } from '@needle-di/core';
 import type { ReadyValue } from './internal';
 import { createReadyValue, disposeReadyValue, sealReadyValue } from './internal';
 
-export interface Disposable {
-  shutdown(): Promise<void>;
-}
-
-export interface Lifecycle<TReady = void> extends Disposable {
+export interface Lifecycle<TReady = void> {
   /** @throws {ZeltNotImplementedError} */
-  startup(): Promise<TReady>;
+  startup(): Promise<TReady> | TReady;
+  shutdown(): Promise<void> | void;
 }
 
 type WarmupHandler = () => Promise<void>;


### PR DESCRIPTION
## Summary
- Remove dead `Disposable` interface (0 usages in packages/)
- Unify into single `Lifecycle` interface with both `startup()` and `shutdown()` required
- Allow sync returns: `startup(): Promise<T> | T`, `shutdown(): Promise<void> | void`
- Remove bridge code in integration tests

## Test plan
- [x] `pnpm test` in packages/core passes
- [x] Integration tests in integration/hooks pass

Closes #421ed20f

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782601278&installation_id=133048706&pr_number=236&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F236&signature=71df10f042f15f05b44dd66220a867e2be2fcfa0b083e15a70fdbfc14efb35d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ライフサイクル管理インターフェースを改善し、初期化・シャットダウン処理が同期・非同期両方に対応するようになりました。
  * API簡素化のため、一部の型定義を整理しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->