### PR TITLE
chore: introduce pnpm catalog to unify shared dependency versions

### DIFF
--- a/examples/drizzle-todo/package.json
+++ b/examples/drizzle-todo/package.json
@@ -14,13 +14,13 @@
     "@zeltjs/core": "workspace:*",
     "better-sqlite3": "12.9.0",
     "drizzle-orm": "0.45.2",
-    "valibot": "1.3.1",
+    "valibot": "catalog:",
     "@zeltjs/validator-valibot": "workspace:*",
     "@zeltjs/openapi": "workspace:*"
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.13",
     "drizzle-kit": "0.31.2",
-    "tsx": "4.21.0"
+    "tsx": "catalog:"
   }
 }

--- a/examples/hello/package.json
+++ b/examples/hello/package.json
@@ -16,12 +16,12 @@
     "@zeltjs/core": "workspace:*",
     "@zeltjs/openapi": "workspace:*",
     "@zeltjs/hono-client": "workspace:*",
-    "tsdown": "0.21.10",
-    "valibot": "1.3.1",
+    "tsdown": "catalog:",
+    "valibot": "catalog:",
     "@zeltjs/validator-valibot": "workspace:*"
   },
   "devDependencies": {
-    "hono": "4.12.16",
-    "tsx": "4.21.0"
+    "hono": "catalog:",
+    "tsx": "catalog:"
   }
 }

--- a/examples/workers-url-shortener/package.json
+++ b/examples/workers-url-shortener/package.json
@@ -9,12 +9,12 @@
   },
   "dependencies": {
     "@zeltjs/core": "workspace:*",
-    "valibot": "1.3.1",
+    "valibot": "catalog:",
     "@zeltjs/validator-valibot": "workspace:*"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20260506.1",
-    "hono": "4.12.16",
+    "hono": "catalog:",
     "wrangler": "4.88.0"
   }
 }

--- a/integration/scripts/switch-mode.sh
+++ b/integration/scripts/switch-mode.sh
@@ -62,6 +62,67 @@ get_npm_version() {
   fi
 }
 
+# root pnpm-workspace.yaml の default catalog から指定キーのバージョンを取得する
+# (catalog を単一の情報源とし、integration 用 package.json への版のハードコードを避ける)
+get_catalog_version() {
+  local key="$1"
+  awk -v key="$key" '
+    /^catalog:[[:space:]]*$/ { in_cat = 1; next }
+    /^[^[:space:]]/ { in_cat = 0 }
+    in_cat {
+      line = $0
+      gsub(/^[[:space:]]+/, "", line)
+      gsub(/"/, "", line)
+      n = index(line, ":")
+      if (n > 0) {
+        k = substr(line, 1, n - 1)
+        v = substr(line, n + 1)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+        if (k == key) { print v; exit }
+      }
+    }
+  ' "$ROOT_DIR/pnpm-workspace.yaml"
+}
+
+# @zeltjs/* 各パッケージの dependencies/peerDependencies を走査し、
+# `catalog:` プロトコルで参照されている依存名を重複なく列挙する。
+# (どの依存が catalog 管理かをハードコードせず実際の package.json から導出する)
+collect_catalog_dep_names() {
+  node -e '
+    const fs = require("fs");
+    const path = require("path");
+    const dir = process.argv[1];
+    const names = new Set();
+    for (const pkg of fs.readdirSync(dir)) {
+      const pj = path.join(dir, pkg, "package.json");
+      if (!fs.existsSync(pj)) continue;
+      const json = JSON.parse(fs.readFileSync(pj, "utf8"));
+      for (const field of ["dependencies", "peerDependencies"]) {
+        for (const [name, spec] of Object.entries(json[field] || {})) {
+          if (typeof spec === "string" && spec.startsWith("catalog:")) names.add(name);
+        }
+      }
+    }
+    for (const name of [...names].sort()) console.log(name);
+  ' "$ROOT_DIR/packages"
+}
+
+# catalog 参照されている依存を default catalog の実バージョンに固定する
+# pnpm.overrides 用 JSON 断片を生成する (例: "hono": "4.12.16","valibot": "1.3.1")
+build_catalog_overrides() {
+  local fragment="" name version
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    version=$(get_catalog_version "$name")
+    if [[ -z "$version" ]]; then
+      echo "ERROR: '$name' は catalog: 参照だが default catalog に版が無い" >&2
+      exit 1
+    fi
+    fragment="$fragment\"$name\": \"$version\","
+  done < <(collect_catalog_dep_names)
+  echo "${fragment%,}"
+}
+
 generate_package_json() {
   local mode="$1"
   local integration_dir="$2"
@@ -96,6 +157,16 @@ generate_package_json() {
   deps="${deps%,}"
   overrides="${overrides%,}"
 
+  # integration テストが直接 import するライブラリ。版は root catalog を単一の情報源とする
+  local hono_ver valibot_ver to_json_schema_ver
+  hono_ver=$(get_catalog_version "hono")
+  valibot_ver=$(get_catalog_version "valibot")
+  to_json_schema_ver=$(get_catalog_version "@valibot/to-json-schema")
+
+  # @zeltjs/* が catalog: で参照する依存を実バージョンに固定する overrides 断片
+  local catalog_overrides
+  catalog_overrides=$(build_catalog_overrides)
+
   if [[ "$mode" == "public" ]]; then
     cat <<EOF
 {
@@ -112,13 +183,16 @@ generate_package_json() {
   },
   "devDependencies": {
     "vitest": "3.2.4",
-    "valibot": "1.3.1",
-    "@valibot/to-json-schema": "1.6.0",
-    "hono": "4.12.16"
+    "valibot": "$valibot_ver",
+    "@valibot/to-json-schema": "$to_json_schema_ver",
+    "hono": "$hono_ver"
   }
 }
 EOF
   else
+    # dist/pack モードは @zeltjs/* を file: でソース参照するため、各 package.json の
+    # `catalog:` 指定が workspace 外 (--ignore-workspace) で解決できない。
+    # catalog 管理の第三者ランタイム依存を overrides で実バージョンに固定して解決する。
     cat <<EOF
 {
   "name": "@integration/$name",
@@ -134,13 +208,14 @@ EOF
   },
   "devDependencies": {
     "vitest": "3.2.4",
-    "valibot": "1.3.1",
-    "@valibot/to-json-schema": "1.6.0",
-    "hono": "4.12.16"
+    "valibot": "$valibot_ver",
+    "@valibot/to-json-schema": "$to_json_schema_ver",
+    "hono": "$hono_ver"
   },
   "pnpm": {
     "overrides": {
-      $overrides
+      $overrides,
+      $catalog_overrides
     }
   }
 }

--- a/packages/adapter-electron/package.json
+++ b/packages/adapter-electron/package.json
@@ -29,7 +29,7 @@
     "@zeltjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "22.19.17"
+    "@types/node": "catalog:"
   },
   "peerDependencies": {
     "electron": ">=28.0.0"

--- a/packages/adapter-lambda/package.json
+++ b/packages/adapter-lambda/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.150",
-    "@types/node": "22.19.17"
+    "@types/node": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -30,7 +30,7 @@
     "@zeltjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "22.19.17"
+    "@types/node": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -27,13 +27,13 @@
   },
   "peerDependencies": {
     "@zeltjs/core": "workspace:*",
-    "hono": "^4.0.0"
+    "hono": "catalog:peer"
   },
   "devDependencies": {
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/testing": "workspace:*",
-    "hono": "4.12.16",
+    "hono": "catalog:",
     "jose": "6.0.11"
   },
   "volta": {

--- a/packages/auth-session/package.json
+++ b/packages/auth-session/package.json
@@ -28,13 +28,13 @@
   "peerDependencies": {
     "@zeltjs/core": "workspace:*",
     "@zeltjs/kv": "workspace:*",
-    "hono": "^4.0.0"
+    "hono": "catalog:peer"
   },
   "devDependencies": {
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/kv": "workspace:*",
-    "hono": "4.12.16"
+    "hono": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,17 +39,17 @@
     "chokidar": "5.0.0"
   },
   "peerDependencies": {
-    "typescript": ">=5.0.0"
+    "typescript": "catalog:peer"
   },
   "devDependencies": {
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "c12": "3.0.4",
     "citty": "0.1.6",
     "consola": "3.4.2",
     "ts-pattern": "5.7.1",
-    "tsdown": "0.21.10",
-    "typescript": "6.0.2",
-    "valibot": "1.3.1"
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "valibot": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,12 +35,12 @@
   },
   "dependencies": {
     "@zeltjs/decorator-metadata": "workspace:*",
-    "hono": "4.12.16"
+    "hono": "catalog:"
   },
   "devDependencies": {
     "@needle-di/core": "1.1.2",
     "@zeltjs/unsafe-type-lib": "workspace:*",
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "croner": "9.1.0",
     "neverthrow": "8.2.0",
     "ts-pattern": "5.6.2"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@zeltjs/core": "workspace:*",
-    "@types/node": "22.19.17"
+    "@types/node": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/decorator-metadata/package.json
+++ b/packages/decorator-metadata/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc -b"
   },
   "peerDependencies": {
-    "typescript": ">=5.0.0"
+    "typescript": "catalog:peer"
   },
   "peerDependenciesMeta": {
     "typescript": {
@@ -45,10 +45,10 @@
     "ts-pattern": "5.6.2"
   },
   "devDependencies": {
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "@zeltjs/unsafe-type-lib": "workspace:*",
     "neverthrow": "8.2.0",
-    "typescript": "6.0.2"
+    "typescript": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,10 +31,10 @@
   "devDependencies": {
     "@types/eslint": "^9.6.1",
     "@types/estree": "^1.0.7",
-    "@types/node": "^22.15.21",
-    "tsdown": "^0.12.6",
-    "typescript": "^5.8.3",
-    "vitest": "^4.1.5"
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "keywords": [
     "eslint",

--- a/packages/eventbus/package.json
+++ b/packages/eventbus/package.json
@@ -43,7 +43,7 @@
     }
   },
   "devDependencies": {
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/redis": "workspace:*",
     "ioredis": "5.10.1",

--- a/packages/hono-client/package.json
+++ b/packages/hono-client/package.json
@@ -32,18 +32,18 @@
     "@zeltjs/adapter-node": "workspace:*",
     "@zeltjs/cli": "workspace:*",
     "@zeltjs/core": "workspace:*",
-    "hono": "4.12.16"
+    "hono": "catalog:"
   },
   "dependencies": {
     "@zeltjs/decorator-metadata": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "@zeltjs/adapter-node": "workspace:*",
     "@zeltjs/cli": "workspace:*",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/testing": "workspace:*",
-    "hono": "4.12.16"
+    "hono": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -47,7 +47,7 @@
     "@zeltjs/core": "workspace:*",
     "@zeltjs/redis": "workspace:*",
     "@zeltjs/unsafe-type-lib": "workspace:*",
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "ioredis": "5.10.1"
   },
   "volta": {

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -34,7 +34,7 @@
     "ts-pattern": "5.7.1"
   },
   "devDependencies": {
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "@zeltjs/cli": "workspace:*"
   },
   "volta": {

--- a/packages/rate-limit/package.json
+++ b/packages/rate-limit/package.json
@@ -30,12 +30,12 @@
     "@zeltjs/kv": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/kv": "workspace:*",
     "@zeltjs/testing": "workspace:*",
     "@zeltjs/validator-valibot": "workspace:*",
-    "valibot": "1.3.1"
+    "valibot": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@zeltjs/core": "workspace:*",
     "@zeltjs/testing": "workspace:*",
-    "@types/node": "22.19.17",
+    "@types/node": "catalog:",
     "testcontainers": "10.25.0"
   },
   "volta": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@jest/globals": "29.7.0",
     "bun-types": "1.2.14",
-    "vitest": "4.1.5"
+    "vitest": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/validator-valibot/package.json
+++ b/packages/validator-valibot/package.json
@@ -32,9 +32,9 @@
   "peerDependencies": {
     "@zeltjs/core": "workspace:*",
     "@zeltjs/openapi": "workspace:*",
-    "hono": "4.12.16",
-    "valibot": "^1.0.0",
-    "@valibot/to-json-schema": "^1.0.0"
+    "hono": "catalog:",
+    "valibot": "catalog:peer",
+    "@valibot/to-json-schema": "catalog:peer"
   },
   "peerDependenciesMeta": {
     "@zeltjs/openapi": {
@@ -45,12 +45,12 @@
     }
   },
   "devDependencies": {
-    "@types/node": "22.19.17",
-    "@valibot/to-json-schema": "1.6.0",
+    "@types/node": "catalog:",
+    "@valibot/to-json-schema": "catalog:",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/openapi": "workspace:*",
-    "hono": "4.12.16",
-    "valibot": "1.3.1"
+    "hono": "catalog:",
+    "valibot": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,33 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@types/node':
+      specifier: 22.19.17
+      version: 22.19.17
+    '@valibot/to-json-schema':
+      specifier: 1.6.0
+      version: 1.6.0
+    hono:
+      specifier: 4.12.16
+      version: 4.12.16
+    tsdown:
+      specifier: 0.21.10
+      version: 0.21.10
+    tsx:
+      specifier: 4.21.0
+      version: 4.21.0
+    typescript:
+      specifier: 6.0.2
+      version: 6.0.2
+    valibot:
+      specifier: 1.3.1
+      version: 1.3.1
+    vitest:
+      specifier: 4.1.5
+      version: 4.1.5
+
 importers:
 
   .:
@@ -108,7 +135,7 @@ importers:
         specifier: 0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260506.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.2.17)
       valibot:
-        specifier: 1.3.1
+        specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.2)
     devDependencies:
       '@types/better-sqlite3':
@@ -118,7 +145,7 @@ importers:
         specifier: 0.31.2
         version: 0.31.2
       tsx:
-        specifier: 4.21.0
+        specifier: 'catalog:'
         version: 4.21.0
 
   examples/hello:
@@ -142,17 +169,17 @@ importers:
         specifier: workspace:*
         version: link:../../packages/validator-valibot
       tsdown:
-        specifier: 0.21.10
+        specifier: 'catalog:'
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2)
       valibot:
-        specifier: 1.3.1
+        specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.2)
     devDependencies:
       hono:
-        specifier: 4.12.16
+        specifier: 'catalog:'
         version: 4.12.16
       tsx:
-        specifier: 4.21.0
+        specifier: 'catalog:'
         version: 4.21.0
 
   examples/workers-url-shortener:
@@ -164,14 +191,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/validator-valibot
       valibot:
-        specifier: 1.3.1
+        specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.2)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 4.20260506.1
         version: 4.20260506.1
       hono:
-        specifier: 4.12.16
+        specifier: 'catalog:'
         version: 4.12.16
       wrangler:
         specifier: 4.88.0
@@ -207,7 +234,7 @@ importers:
         version: 42.0.1
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
 
   packages/adapter-lambda:
@@ -220,7 +247,7 @@ importers:
         specifier: 8.10.150
         version: 8.10.150
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
 
   packages/adapter-node:
@@ -233,13 +260,13 @@ importers:
         version: link:../core
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
 
   packages/auth-jwt:
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/core':
         specifier: workspace:*
@@ -248,7 +275,7 @@ importers:
         specifier: workspace:*
         version: link:../testing
       hono:
-        specifier: 4.12.16
+        specifier: 'catalog:'
         version: 4.12.16
       jose:
         specifier: 6.0.11
@@ -257,7 +284,7 @@ importers:
   packages/auth-session:
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/core':
         specifier: workspace:*
@@ -266,7 +293,7 @@ importers:
         specifier: workspace:*
         version: link:../kv
       hono:
-        specifier: 4.12.16
+        specifier: 'catalog:'
         version: 4.12.16
 
   packages/cli:
@@ -282,7 +309,7 @@ importers:
         version: 5.0.0
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       c12:
         specifier: 3.0.4
@@ -297,13 +324,13 @@ importers:
         specifier: 5.7.1
         version: 5.7.1
       tsdown:
-        specifier: 0.21.10
+        specifier: 'catalog:'
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2)
       typescript:
-        specifier: 6.0.2
+        specifier: 'catalog:'
         version: 6.0.2
       valibot:
-        specifier: 1.3.1
+        specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.2)
 
   packages/core:
@@ -312,14 +339,14 @@ importers:
         specifier: workspace:*
         version: link:../decorator-metadata
       hono:
-        specifier: 4.12.16
+        specifier: 'catalog:'
         version: 4.12.16
     devDependencies:
       '@needle-di/core':
         specifier: 1.1.2
         version: 1.1.2
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/unsafe-type-lib':
         specifier: workspace:*
@@ -337,7 +364,7 @@ importers:
   packages/db:
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/core':
         specifier: workspace:*
@@ -350,7 +377,7 @@ importers:
         version: 5.6.2
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/unsafe-type-lib':
         specifier: workspace:*
@@ -359,7 +386,7 @@ importers:
         specifier: 8.2.0
         version: 8.2.0
       typescript:
-        specifier: 6.0.2
+        specifier: 'catalog:'
         version: 6.0.2
     optionalDependencies:
       typescript-6:
@@ -379,22 +406,22 @@ importers:
         specifier: ^1.0.7
         version: 1.0.8
       '@types/node':
-        specifier: ^22.15.21
+        specifier: 'catalog:'
         version: 22.19.17
       tsdown:
-        specifier: ^0.12.6
-        version: 0.12.9(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)
+        specifier: 'catalog:'
+        version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2)
       typescript:
-        specifier: ^5.8.3
-        version: 5.9.3
+        specifier: 'catalog:'
+        version: 6.0.2
       vitest:
-        specifier: ^4.1.5
+        specifier: 'catalog:'
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/eventbus:
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/core':
         specifier: workspace:*
@@ -416,7 +443,7 @@ importers:
         version: link:../decorator-metadata
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/adapter-node':
         specifier: workspace:*
@@ -431,7 +458,7 @@ importers:
         specifier: workspace:*
         version: link:../testing
       hono:
-        specifier: 4.12.16
+        specifier: 'catalog:'
         version: 4.12.16
 
   packages/kv:
@@ -441,7 +468,7 @@ importers:
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/core':
         specifier: workspace:*
@@ -469,7 +496,7 @@ importers:
         version: 5.7.1
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/cli':
         specifier: workspace:*
@@ -478,7 +505,7 @@ importers:
   packages/rate-limit:
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/core':
         specifier: workspace:*
@@ -493,7 +520,7 @@ importers:
         specifier: workspace:*
         version: link:../validator-valibot
       valibot:
-        specifier: 1.3.1
+        specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.2)
 
   packages/redis:
@@ -503,7 +530,7 @@ importers:
         version: 5.10.1
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@zeltjs/core':
         specifier: workspace:*
@@ -531,7 +558,7 @@ importers:
         specifier: 1.2.14
         version: 1.2.14
       vitest:
-        specifier: 4.1.5
+        specifier: 'catalog:'
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/unsafe-type-lib: {}
@@ -539,10 +566,10 @@ importers:
   packages/validator-valibot:
     devDependencies:
       '@types/node':
-        specifier: 22.19.17
+        specifier: 'catalog:'
         version: 22.19.17
       '@valibot/to-json-schema':
-        specifier: 1.6.0
+        specifier: 'catalog:'
         version: 1.6.0(valibot@1.3.1(typescript@6.0.2))
       '@zeltjs/core':
         specifier: workspace:*
@@ -551,10 +578,10 @@ importers:
         specifier: workspace:*
         version: link:../openapi
       hono:
-        specifier: 4.12.16
+        specifier: 'catalog:'
         version: 4.12.16
       valibot:
-        specifier: 1.3.1
+        specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.2)
 
   website:
@@ -681,13 +708,13 @@ importers:
         specifier: 0.3.8
         version: 0.3.8(typescript@6.0.2)
       typescript:
-        specifier: ~6.0.2
+        specifier: 'catalog:'
         version: 6.0.2
       valibot:
-        specifier: 1.0.0
-        version: 1.0.0(typescript@6.0.2)
+        specifier: 'catalog:'
+        version: 1.3.1(typescript@6.0.2)
       vitest:
-        specifier: 4.1.5
+        specifier: 'catalog:'
         version: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.17.19)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: 3.114.6
@@ -5845,10 +5872,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-kit@2.2.0:
-    resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
-    engines: {node: '>=20.19.0'}
-
   ast-kit@3.0.0-beta.1:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
@@ -6013,9 +6036,6 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
-  birpc@2.9.0:
-    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
-
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
@@ -6130,10 +6150,6 @@ packages:
     peerDependenciesMeta:
       magicast:
         optional: true
-
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -6843,10 +6859,6 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
-    engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -7920,9 +7932,6 @@ packages:
   hono@4.12.16:
     resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
     engines: {node: '>=16.9.0'}
-
-  hookable@5.5.3:
-    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
@@ -10345,22 +10354,6 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown-plugin-dts@0.13.14:
-    resolution: {integrity: sha512-wjNhHZz9dlN6PTIXyizB6u/mAg1wEFMW9yw7imEVe3CxHSRnNHVyycIX0yDEOVJfDNISLPbkCIPEpFpizy5+PQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
-      rolldown: ^1.0.0-beta.9
-      typescript: ^5.0.0
-      vue-tsc: ^2.2.0 || ^3.0.0
-    peerDependenciesMeta:
-      '@typescript/native-preview':
-        optional: true
-      typescript:
-        optional: true
-      vue-tsc:
-        optional: true
-
   rolldown-plugin-dts@0.23.2:
     resolution: {integrity: sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==}
     engines: {node: '>=20.19.0'}
@@ -10925,10 +10918,6 @@ packages:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.14:
-    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -11020,28 +11009,6 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
-
-  tsdown@0.12.9:
-    resolution: {integrity: sha512-MfrXm9PIlT3saovtWKf/gCJJ/NQCdE0SiREkdNC+9Qy6UHhdeDPxnkFaBD7xttVUmgp0yUHtGirpoLB+OVLuLA==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@arethetypeswrong/core': ^0.18.1
-      publint: ^0.3.0
-      typescript: ^5.0.0
-      unplugin-lightningcss: ^0.4.0
-      unplugin-unused: ^0.5.0
-    peerDependenciesMeta:
-      '@arethetypeswrong/core':
-        optional: true
-      publint:
-        optional: true
-      typescript:
-        optional: true
-      unplugin-lightningcss:
-        optional: true
-      unplugin-unused:
-        optional: true
 
   tsdown@0.21.10:
     resolution: {integrity: sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==}
@@ -11153,9 +11120,6 @@ packages:
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
-
-  unconfig@7.5.0:
-    resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -11301,14 +11265,6 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
-
-  valibot@1.0.0:
-    resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   valibot@1.3.1:
     resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
@@ -14816,7 +14772,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -14834,7 +14790,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -14883,7 +14839,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -16251,11 +16207,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/bun@1.2.17':
     dependencies:
@@ -16269,11 +16225,11 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.8
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/d3-array@3.2.2': {}
 
@@ -16307,13 +16263,13 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@3.3.47':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       '@types/ssh2': 1.15.5
 
   '@types/eslint-scope@3.7.7':
@@ -16336,7 +16292,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -16350,7 +16306,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/gtag.js@0.0.20': {}
 
@@ -16368,7 +16324,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -16439,16 +16395,16 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -16457,20 +16413,20 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       '@types/send': 0.17.6
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
@@ -16485,7 +16441,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -16495,7 +16451,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2)':
@@ -16701,7 +16657,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -17064,11 +17020,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-kit@2.2.0:
-    dependencies:
-      '@babel/parser': 7.29.3
-      pathe: 2.0.3
-
   ast-kit@3.0.0-beta.1:
     dependencies:
       '@babel/parser': 8.0.0-rc.3
@@ -17257,8 +17208,6 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
-  birpc@2.9.0: {}
-
   birpc@4.0.0: {}
 
   bl@4.1.0:
@@ -17392,7 +17341,7 @@ snapshots:
 
   bun-types@1.2.14:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
 
   bun-types@1.2.17:
     dependencies:
@@ -17424,8 +17373,6 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 2.3.1
       rc9: 2.1.2
-
-  cac@6.7.14: {}
 
   cac@7.0.0: {}
 
@@ -18198,8 +18145,6 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@8.0.4: {}
-
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -18827,7 +18772,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       require-like: 0.1.2
 
   event-target-shim@5.0.1: {}
@@ -19470,8 +19415,6 @@ snapshots:
 
   hono@4.12.16: {}
 
-  hookable@5.5.3: {}
-
   hookable@6.1.1: {}
 
   hpack.js@2.1.6:
@@ -19826,7 +19769,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -19860,7 +19803,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -19893,7 +19836,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -19901,13 +19844,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -22143,7 +22086,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 22.19.17
+      '@types/node': 24.12.4
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -22576,23 +22519,6 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
-
-  rolldown-plugin-dts@0.13.14(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.17)(typescript@5.9.3):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
-      ast-kit: 2.2.0
-      birpc: 2.9.0
-      debug: 4.4.3
-      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
-      get-tsconfig: 4.14.0
-      rolldown: 1.0.0-rc.17
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - oxc-resolver
-      - supports-color
 
   rolldown-plugin-dts@0.23.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.17)(typescript@6.0.2):
     dependencies:
@@ -23387,11 +23313,6 @@ snapshots:
 
   tinyexec@1.1.2: {}
 
-  tinyglobby@0.2.14:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -23472,29 +23393,6 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.12.9(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3):
-    dependencies:
-      ansis: 4.2.0
-      cac: 6.7.14
-      chokidar: 4.0.3
-      debug: 4.4.3
-      diff: 8.0.4
-      empathic: 2.0.0
-      hookable: 5.5.3
-      rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.13.14(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.17)(typescript@5.9.3)
-      semver: 7.7.4
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.14
-      unconfig: 7.5.0
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript/native-preview'
-      - oxc-resolver
-      - supports-color
-      - vue-tsc
-
   tsdown@0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2):
     dependencies:
       ansis: 4.2.0
@@ -23507,7 +23405,7 @@ snapshots:
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.17
       rolldown-plugin-dts: 0.23.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.17)(typescript@6.0.2)
-      semver: 7.7.4
+      semver: 7.8.0
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
@@ -23601,14 +23499,6 @@ snapshots:
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
-
-  unconfig@7.5.0:
-    dependencies:
-      '@quansync/fs': 1.0.0
-      defu: 6.1.7
-      jiti: 2.6.1
-      quansync: 1.0.0
-      unconfig-core: 7.5.0
 
   undici-types@5.26.5: {}
 
@@ -23783,10 +23673,6 @@ snapshots:
   uuid@10.0.0: {}
 
   uuid@8.3.2: {}
-
-  valibot@1.0.0(typescript@6.0.2):
-    optionalDependencies:
-      typescript: 6.0.2
 
   valibot@1.3.1(typescript@6.0.2):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,27 @@ packages:
   - 'packages/*'
   - 'examples/*'
   - 'website'
+
+# 共通依存のバージョンを一元管理し、パッケージ間でのバージョン不一致を防ぐ
+# (異なる版が解決されると hono/valibot の instanceof チェックが runtime で失敗するため)
+catalog:
+  hono: 4.12.16
+  valibot: 1.3.1
+  "@valibot/to-json-schema": 1.6.0
+  "@types/node": 22.19.17
+  typescript: 6.0.2
+  vitest: 4.1.5
+  tsdown: 0.21.10
+  tsx: 4.21.0
+
+catalogs:
+  # peerDependencies 用: consumer 側の柔軟性を保つため範囲指定を維持する
+  peer:
+    hono: ^4.0.0
+    valibot: ^1.0.0
+    "@valibot/to-json-schema": ^1.0.0
+    typescript: ">=5.0.0"
+
 ignoredBuiltDependencies:
   - unrs-resolver
 

--- a/website/package.json
+++ b/website/package.json
@@ -60,9 +60,9 @@
     "bullmq": "5.76.9",
     "drizzle-orm": "0.44.2",
     "twoslash": "0.3.8",
-    "typescript": "~6.0.2",
-    "valibot": "1.0.0",
-    "vitest": "4.1.5",
+    "typescript": "catalog:",
+    "valibot": "catalog:",
+    "vitest": "catalog:",
     "wrangler": "3.114.6"
   },
   "browserslist": {


### PR DESCRIPTION
## 背景

`hono` や `valibot` などの共通依存が各パッケージで個別にバージョン指定されており、ユーザー環境で異なる版が解決されると `instanceof` チェックが runtime で失敗する問題があった（例: valibot の `validated()` が 500 を返す問題）。

closes #6e6048af

## 変更内容

`pnpm-workspace.yaml` に catalog を導入し、共通依存を一元管理する。23ファイル・52箇所の依存指定を `catalog:` / `catalog:peer` に置換。

| カタログ | 用途 | エントリ |
|---|---|---|
| `catalog:` (default) | ランタイム/dev の版を exact 固定 | hono 4.12.16, valibot 1.3.1, @valibot/to-json-schema 1.6.0, @types/node 22.19.17, typescript 6.0.2, vitest 4.1.5, tsdown 0.21.10, tsx 4.21.0 |
| `catalog:peer` (named) | peerDependencies は consumer の柔軟性維持のため範囲指定 | hono ^4.0.0, valibot ^1.0.0, @valibot/to-json-schema ^1.0.0, typescript >=5.0.0 |

### 方針の補足
- hono-client / validator-valibot の peer は元々 exact `4.12.16` だったため `catalog:`（exact 維持）を割り当て
- インライン維持の例外: vitest peer（kv `>=4<5` と testing `>=2` で範囲が異なるため）、@types/node peer `>=20`（単一・instanceof 非依存）

### 副次的に解消されたバージョン不一致
hono `^4.0.0`、@types/node `^22.15.21`、typescript `^5.8.3`、tsdown `^0.12.6`、valibot `1.0.0` などが統一された。

## 検証

- ✅ `pnpm install` — catalog 解決OK
- ✅ `pnpm build` — 22 projects 成功
- ✅ `pnpm typecheck` — 成功
- ✅ `pnpm test` — 641 passed / 2 skipped
- ✅ `pnpm pack` で publish 展開を確認 — `catalog:` → 具体版、`catalog:peer` → `^1.0.0` に展開され、公開 package.json に `catalog:` 参照は残らない（consumer は壊れない）

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782603047&installation_id=133048706&pr_number=237&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F237&signature=52441613505253d83bfb8b05782b52efa106dd12c9eb587a7a65a96f1ed80196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 依存関係のバージョン管理をワークスペース共通のカタログ参照に移行しました。
  * 各パッケージの固定バージョン指定をカタログ参照へ置換し、一貫性を向上させました。
  * パッケージ生成・テスト系の処理をカタログから実バージョンを解決する仕組みに更新し、配布時の依存解決を安定化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->