### PR TITLE
docs: align website docs with impl & verify example excerpts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+      - uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/examples/drizzle-todo/package.json
+++ b/examples/drizzle-todo/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "tsx src/entry/node.ts",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"
   },

--- a/examples/drizzle-todo/src/db/drizzle.service.ts
+++ b/examples/drizzle-todo/src/db/drizzle.service.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync } from 'node:fs';
-import type { Disposable } from '@zeltjs/core';
-import { Injectable } from '@zeltjs/core';
+import type { Lifecycle } from '@zeltjs/core';
+import { Injectable, inject, LifecycleManager } from '@zeltjs/core';
 import Database from 'better-sqlite3';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
@@ -8,17 +8,18 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from './schema';
 
 @Injectable()
-export class DrizzleService implements Disposable {
+export class DrizzleService implements Lifecycle {
   private sqlite: Database.Database;
   readonly db: BetterSQLite3Database<typeof schema>;
 
-  constructor() {
+  constructor(lifecycle = inject(LifecycleManager)) {
     if (!existsSync('./data')) {
       mkdirSync('./data', { recursive: true });
     }
     this.sqlite = new Database('./data/todo.db');
     this.db = drizzle(this.sqlite, { schema });
     this.initSchema();
+    lifecycle.register(this);
   }
 
   private initSchema() {
@@ -32,7 +33,9 @@ export class DrizzleService implements Disposable {
     `);
   }
 
-  dispose() {
+  async startup(): Promise<void> {}
+
+  async shutdown(): Promise<void> {
     this.sqlite.close();
   }
 }

--- a/examples/drizzle-todo/src/todo/todo.controller.ts
+++ b/examples/drizzle-todo/src/todo/todo.controller.ts
@@ -59,11 +59,11 @@ export class TodoController {
   }
 
   @Delete('/:id')
-  delete(id = pathParam('id'), res = response()) {
+  delete(id = pathParam('id')) {
     const deleted = this.todoService.delete(Number(id));
     if (!deleted) {
       throw new HTTPException(404, { message: 'Todo not found' });
     }
-    return res.body(null, 204);
+    return new Response(null, { status: 204 });
   }
 }

--- a/examples/drizzle-todo/src/todo/todo.service.ts
+++ b/examples/drizzle-todo/src/todo/todo.service.ts
@@ -26,7 +26,10 @@ export class TodoService {
     return result;
   }
 
-  update(id: number, data: Partial<Pick<Todo, 'title' | 'completed'>>): Todo | undefined {
+  update(
+    id: number,
+    data: { title?: string | undefined; completed?: boolean | undefined },
+  ): Todo | undefined {
     const result = this.drizzle.db
       .update(todos)
       .set(data)

--- a/examples/hello/package.json
+++ b/examples/hello/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx src/main.ts",
     "dev:node": "tsx src/entry/node.ts",
+    "typecheck": "tsc --noEmit",
     "contract:build": "tsx ../../packages/contract/src/cli.ts build",
     "contract:watch": "tsx ../../packages/contract/src/cli.ts watch"
   },

--- a/examples/hello/src/test/hello.e2e.test.ts
+++ b/examples/hello/src/test/hello.e2e.test.ts
@@ -37,7 +37,7 @@ describe('/hello', () => {
     });
     expect(res.status).toBe(400);
     if (res.status === 400) {
-      const body: { code: string; issues: unknown[] } = await res.json();
+      const body: { code: string; issues: readonly unknown[] } = await res.json();
       expect(body.code).toBe('VALIDATION_FAILED');
       expect(Array.isArray(body.issues)).toBe(true);
     }

--- a/examples/workers-url-shortener/package.json
+++ b/examples/workers-url-shortener/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@zeltjs/core": "workspace:*",

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -85,8 +85,11 @@ const config: KnipConfig = {
         'docusaurus.config.ts',
         'src/prism-theme-kanagawa.ts',
         'src/remark/*.ts',
+        'src/twoslash/*.ts',
         'scripts/check-doc-slugs.ts',
         'scripts/extract-doc-tests.ts',
+        'scripts/typecheck-docs.ts',
+        'scripts/check-example-excerpts.ts',
       ],
       // prism-react-renderer is used internally by Docusaurus for code block syntax highlighting
       // wrangler is used by Cloudflare Workers build system for deployment

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run",
     "test:integration": "./integration/scripts/run-tests.sh dist",
     "typecheck": "tsc -b",
-    "precommit": "pnpx lint-staged && pnpm typecheck && pnpm lint:cycle && pnpm build && pnpm verify-dist && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
+    "precommit": "pnpx lint-staged && pnpm typecheck && pnpm lint:cycle && pnpm build && pnpm --filter '@examples/*' typecheck && pnpm --filter website verify:docs && pnpm verify-dist && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
     "prepare": "pnpx lefthook install",
     "codepolicy:diff": "time codepolicy --filter=diff 2>&1 | tee codepolicy.diff.log",
     "throw-trace": "throw-trace check --exclude '**/*.test.ts' packages",

--- a/website/docs/authentication/jwt.md
+++ b/website/docs/authentication/jwt.md
@@ -202,14 +202,14 @@ class UserRepository {
 @Config
 class CustomJwtConfig extends JwtConfig {
   constructor(
-    private env = inject(EnvConfig),
+    private envConfig = inject(EnvConfig),
     private userRepo = inject(UserRepository)
   ) {
     super();
   }
 
   override get secret(): string {
-    return this.env.get('JWT_SECRET')!;
+    return this.envConfig.get('JWT_SECRET')!;
   }
 
   override get expiresIn(): string {
@@ -248,10 +248,10 @@ class UserRepository {
 @Config
 class CustomJwtConfig extends JwtConfig {
   constructor(
-    private env = inject(EnvConfig),
+    private envConfig = inject(EnvConfig),
     private userRepo = inject(UserRepository)
   ) { super(); }
-  override get secret(): string { return this.env.get('JWT_SECRET')!; }
+  override get secret(): string { return this.envConfig.get('JWT_SECRET')!; }
   override get expiresIn(): string { return '7d'; }
   override get resolveUser(): (payload: JwtPayload) => Promise<ResolveUserResult> {
     return async (payload) => {

--- a/website/docs/authentication/sessions.md
+++ b/website/docs/authentication/sessions.md
@@ -25,20 +25,15 @@ SESSION_SECRET=your-secret-key-at-least-32-characters
 
 ### 2. Configure Session Store
 
-Create a custom config that provides a KV store for session data:
+Sessions are stored in a KV store. By default `SessionConfig` uses the in-memory adaptor under the `session:` namespace. To customize the namespace (or other options), extend `SessionConfig`:
 
 ```typescript
-import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
+import { Config } from '@zeltjs/core';
 import { SessionConfig } from '@zeltjs/auth-session';
 // ---cut---
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-
-  override get store() {
-    return this.kv.namespace('sessions');
-  }
+  override readonly kvStoreNamespace = 'sessions:';
 }
 ```
 
@@ -52,8 +47,7 @@ import { HTTPException } from 'hono/http-exception';
 
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-  override get store() { return this.kv.namespace('sessions'); }
+  override readonly kvStoreNamespace = 'sessions:';
 }
 
 @Controller('/auth')
@@ -211,17 +205,12 @@ setSession({ userId: '123', name: 'Alice' });
 Extend `SessionConfig` to customize behavior:
 
 ```typescript
-import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
+import { Config } from '@zeltjs/core';
 import { SessionConfig } from '@zeltjs/auth-session';
 // ---cut---
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-
-  override get store() {
-    return this.kv.namespace('sessions');
-  }
+  override readonly kvStoreNamespace = 'sessions:';
 
   override get cookieName(): string {
     return 'my_session';  // default: 'session'
@@ -246,7 +235,8 @@ class MySessionConfig extends SessionConfig {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `store` | `KVNamespace` | Required | KV namespace for session storage |
+| `kv` | `KVAdaptor` | `MemoryKV` | KV adaptor (constructor arg 2) backing session storage |
+| `kvStoreNamespace` | `string` | `'session:'` | Namespace prefix for session keys |
 | `secret` | `string` | `env.get('SESSION_SECRET')` | Secret for signing session IDs |
 | `cookieName` | `string` | `'session'` | Cookie name |
 | `ttlSec` | `number` | `86400` (1 day) | Session TTL in seconds |
@@ -260,12 +250,12 @@ import { SessionConfig } from '@zeltjs/auth-session';
 
 @Config
 class MySessionConfig extends SessionConfig {
-  constructor(private env = inject(EnvService)) { super(); }
+  constructor(private envService = inject(EnvService)) { super(); }
 // ---cut---
   override get cookieOptions() {
     return {
       httpOnly: true,
-      secure: this.env.getString('NODE_ENV', '') === 'production',
+      secure: this.envService.getString('NODE_ENV', '') === 'production',
       sameSite: 'Lax' as const,
       path: '/',
     };
@@ -279,51 +269,37 @@ class MySessionConfig extends SessionConfig {
 
 ```typescript
 import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
+import { MemoryKV } from '@zeltjs/kv';
 import { SessionConfig } from '@zeltjs/auth-session';
 // ---cut---
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-  override get store() {
-    return this.kv.namespace('sessions');
+  constructor(kv = inject(MemoryKV)) {
+    super(undefined, kv);
   }
 }
 ```
 
 ### Redis (Production)
 
-```typescript
-import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
-import { SessionConfig } from '@zeltjs/auth-session';
-declare class RedisKVService extends MemoryKVService {}
-// ---cut---
-@Config
-class MySessionConfig extends SessionConfig {
-  private kv = inject(RedisKVService);
-  override get store() {
-    return this.kv.namespace('sessions');
-  }
-}
-```
-
-### Cloudflare KV
+`SessionConfig` takes the KV adaptor as its second constructor argument. Pass a `RedisKVAdaptor` to `super()` to store sessions in Redis (leave the first argument as `undefined` to keep the default `Env` injection):
 
 ```typescript
 import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
 import { SessionConfig } from '@zeltjs/auth-session';
-declare class CloudflareKVService extends MemoryKVService {}
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
 // ---cut---
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(CloudflareKVService);
-  override get store() {
-    return this.kv.namespace('sessions');
+  constructor(kv = inject(RedisKVAdaptor)) {
+    super(undefined, kv);
   }
+
+  override readonly kvStoreNamespace = 'sessions:';
 }
 ```
+
+Using Redis requires registering `RedisConfig` (from `@zeltjs/redis`) so the adaptor can resolve its connection.
 
 ## Integration with User Context
 
@@ -381,8 +357,7 @@ class UserRepository {
 
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-  override get store() { return this.kv.namespace('sessions'); }
+  override readonly kvStoreNamespace = 'sessions:';
 }
 
 @Middleware

--- a/website/docs/authorization/access-control.md
+++ b/website/docs/authorization/access-control.md
@@ -308,7 +308,7 @@ Check for any role in a hierarchy:
 import { Controller, Authorized, Put, currentRoles } from '@zeltjs/core';
 import { HTTPException } from 'hono/http-exception';
 // ---cut---
-const isEditor = (roles: string[]) =>
+const isEditor = (roles: readonly string[]) =>
   roles.some(r => ['admin', 'editor'].includes(r));
 
 @Controller('/posts')

--- a/website/docs/dependency-injection.md
+++ b/website/docs/dependency-injection.md
@@ -42,11 +42,8 @@ Zelt provides utilities to combine multiple decorators into a single meta-decora
 Combines multiple class decorators into one.
 
 ```typescript
-import {
-  Controller,
-  createClassDecorator,
-  composeClassDecorators,
-} from '@zeltjs/core';
+import { Controller } from '@zeltjs/core';
+import { createClassDecorator, composeClassDecorators } from '@zeltjs/decorator-metadata';
 // ---cut---
 const GraphqlController = (path: string) =>
   composeClassDecorators(
@@ -67,7 +64,7 @@ import {
   createClassDecorator,
   createMethodDecorator,
   composeMethodDecorators,
-} from '@zeltjs/core';
+} from '@zeltjs/decorator-metadata';
 // ---cut---
 const Controller = () => createClassDecorator({});
 const Route = (method: string, path: string) =>
@@ -95,7 +92,7 @@ import {
   createClassDecorator,
   createPropertyDecorator,
   composePropertyDecorators,
-} from '@zeltjs/core';
+} from '@zeltjs/decorator-metadata';
 // ---cut---
 const Entity = () => createClassDecorator({});
 const Column = (opts?: { nullable?: boolean }) =>

--- a/website/docs/getting-started/node.mdx
+++ b/website/docs/getting-started/node.mdx
@@ -200,12 +200,11 @@ export const app = createApp({
 The `@zeltjs/adapter-node` package provides additional configuration options:
 
 ```typescript
-import { ProcessEnvConfig, DotEnvConfig } from '@zeltjs/adapter-node';
+import { ProcessEnvConfig } from '@zeltjs/adapter-node';
 // ---cut---
-// ProcessEnvConfig: Reads from process.env (default behavior)
-// DotEnvConfig: Reads from .env file
+// ProcessEnvConfig: Reads from process.env (default behavior).
+// For .env files, import 'dotenv/config' at your entry point.
 void ProcessEnvConfig;
-void DotEnvConfig;
 ```
 
 ## What's Next?

--- a/website/docs/kv-redis.md
+++ b/website/docs/kv-redis.md
@@ -3,58 +3,63 @@
 
 # Redis KV Driver
 
-`@zeltjs/kv-driver-redis` provides a Redis backend for the KV abstraction. It implements `AtomicKVDriver` using [ioredis](https://github.com/redis/ioredis), supporting atomic operations like `incr` and `setnx`.
+`@zeltjs/kv` ships a Redis backend through its `@zeltjs/kv/adaptor-redis` entry point. `RedisKVAdaptor` implements `AtomicKVAdaptor` on top of [ioredis](https://github.com/redis/ioredis), supporting atomic operations like `incr` and `setnx`.
 
 ## Installation
 
 ```bash
-pnpm add @zeltjs/kv-driver-redis
+pnpm add @zeltjs/kv @zeltjs/redis
 ```
 
-Peer dependencies:
+Peer dependency:
 
 ```bash
-pnpm add @zeltjs/core @zeltjs/kv
+pnpm add @zeltjs/core
 ```
 
 ## Basic Setup
 
-Register `RedisConfig` and inject `RedisKV` into your services:
+Inject `RedisKVAdaptor` and create a namespaced store. `namespace()` returns an `AtomicKVStore` directly, and `get()` resolves to the value (or `undefined` when the key is missing) — there is no result wrapper to unwrap:
 
-```typescript
-import { createApp, Injectable, inject, Controller, Get } from '@zeltjs/core';
-interface AtomicKVStore {
-  get<T>(key: string): Promise<{ unwrapOr<U>(fallback: U): T | U }>;
-  set<T>(key: string, value: T, opts?: { ttlSec?: number }): Promise<void>;
-}
-declare class RedisConfig {}
-declare class RedisKV {
-  namespace(prefix: string): { unwrapOr<T>(fallback: T): AtomicKVStore | T };
-}
-@Controller('/app')
-class AppController { @Get('/') get() { return {}; } }
+```typescript twoslash
+import { Injectable, inject } from '@zeltjs/core';
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
+import type { AtomicKVStore, Defined } from '@zeltjs/kv';
 // ---cut---
 @Injectable()
-class CacheService {
-  private store = inject(RedisKV).namespace('cache:').unwrapOr(null);
+export class CacheService {
+  private store: AtomicKVStore;
 
-  async get<T>(key: string): Promise<T | undefined> {
-    if (!this.store) return undefined;
-    const result = await this.store.get<T>(key);
-    return result.unwrapOr(undefined);
+  constructor(kv = inject(RedisKVAdaptor)) {
+    this.store = kv.namespace('cache:');
   }
 
-  async set<T>(key: string, value: T, ttlSec?: number): Promise<void> {
-    if (!this.store) return;
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.store.get<T>(key);
+  }
+
+  async set<T extends Defined>(key: string, value: T, ttlSec?: number): Promise<void> {
     await this.store.set(key, value, { ttlSec });
   }
 }
+```
 
+Register `RedisConfig` and `RedisKVAdaptor` when creating the app. `RedisConfig` provides the connection settings (consumed by `RedisService`, which `RedisKVAdaptor` depends on), so listing `RedisKVAdaptor` in `injectables` is enough — its dependencies resolve automatically:
+
+```typescript twoslash
+import { createApp, Controller, Get } from '@zeltjs/core';
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
+import { RedisConfig } from '@zeltjs/redis';
+
+@Controller('/app')
+class AppController { @Get('/') get() { return {}; } }
+// ---cut---
 const app = createApp({
   http: {
     controllers: [AppController],
   },
   configs: [RedisConfig],
+  injectables: [RedisKVAdaptor],
 });
 ```
 
@@ -62,31 +67,23 @@ By default, `RedisConfig` reads the connection URL from the `REDIS_URL` environm
 
 ## Custom Configuration
 
-Extend `RedisConfig` to customize connection settings:
+Extend `RedisConfig` to customize connection settings. The `options` getter returns ioredis `RedisOptions`:
 
-```typescript
+```typescript twoslash
 import { Config, EnvService, inject } from '@zeltjs/core';
-type RedisOptions = {
-  maxRetriesPerRequest?: number;
-  retryStrategy?: (times: number) => number | null;
-  enableReadyCheck?: boolean;
-};
-declare class RedisConfig {
-  get url(): string;
-  get options(): RedisOptions;
-}
+import { RedisConfig } from '@zeltjs/redis';
 // ---cut---
 @Config
 class CustomRedisConfig extends RedisConfig {
-  constructor(private env = inject(EnvService)) {
+  constructor(private envService = inject(EnvService)) {
     super();
   }
 
   override get url(): string {
-    return this.env.getString('REDIS_URL', 'redis://localhost:6379');
+    return this.envService.getString('REDIS_URL', 'redis://localhost:6379');
   }
 
-  override get options(): RedisOptions {
+  override get options() {
     return {
       maxRetriesPerRequest: 3,
       retryStrategy: (times: number) => Math.min(times * 100, 3000),
@@ -97,18 +94,16 @@ class CustomRedisConfig extends RedisConfig {
 
 Register your custom config instead of the default:
 
-```typescript
+```typescript twoslash
 import { createApp, Config, EnvService, inject, Controller, Get } from '@zeltjs/core';
-type RedisOptions = { maxRetriesPerRequest?: number };
-declare class RedisConfig {
-  get url(): string;
-  get options(): RedisOptions;
-}
+import { RedisConfig } from '@zeltjs/redis';
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
+
 @Config
 class CustomRedisConfig extends RedisConfig {
-  constructor(private env = inject(EnvService)) { super(); }
-  override get url(): string { return this.env.getString('REDIS_URL', 'redis://localhost:6379'); }
-  override get options(): RedisOptions { return { maxRetriesPerRequest: 3 }; }
+  constructor(private envService = inject(EnvService)) { super(); }
+  override get url(): string { return this.envService.getString('REDIS_URL', 'redis://localhost:6379'); }
+  override get options() { return { maxRetriesPerRequest: 3 }; }
 }
 @Controller('/app')
 class AppController { @Get('/') get() { return {}; } }
@@ -118,27 +113,29 @@ const app = createApp({
     controllers: [AppController],
   },
   configs: [CustomRedisConfig],
+  injectables: [RedisKVAdaptor],
 });
 ```
 
 ## API Reference
 
-### RedisKV
+### RedisKVAdaptor
 
 | Method | Description |
 |--------|-------------|
 | `namespace(prefix)` | Returns a namespaced `AtomicKVStore` |
-| `shutdown()` | Disconnects from Redis |
+
+`RedisKVAdaptor` participates in the application lifecycle. The underlying ioredis connection is owned by `RedisService` and is disconnected automatically on shutdown (see [Graceful Shutdown](#graceful-shutdown)).
 
 ### AtomicKVStore Methods
 
 | Method | Description |
 |--------|-------------|
-| `get<T>(key)` | Retrieve a value |
+| `get<T>(key)` | Retrieve a value, or `undefined` if missing |
 | `set<T>(key, value, opts?)` | Store a value with optional TTL |
 | `del(key)` | Delete a key |
 | `has(key)` | Check if key exists |
-| `expire(key, ttlSec)` | Update TTL for existing key |
+| `expire(key, ttlSec)` | Update TTL for an existing key |
 | `incr(key, by?, opts?)` | Atomic increment |
 | `setnx<T>(key, value, opts?)` | Set if not exists |
 | `namespace(prefix)` | Create nested namespace |
@@ -147,21 +144,13 @@ const app = createApp({
 
 For production deployments, configure connection pooling and retry behavior:
 
-```typescript
+```typescript twoslash
 import { Config } from '@zeltjs/core';
-type RedisOptions = {
-  maxRetriesPerRequest?: number;
-  enableReadyCheck?: boolean;
-  retryStrategy?: (times: number) => number | null;
-};
-declare class RedisConfig {
-  get url(): string;
-  get options(): RedisOptions;
-}
+import { RedisConfig } from '@zeltjs/redis';
 // ---cut---
 @Config
 class ProductionRedisConfig extends RedisConfig {
-  override get options(): RedisOptions {
+  override get options() {
     return {
       maxRetriesPerRequest: 3,
       enableReadyCheck: true,
@@ -176,38 +165,27 @@ class ProductionRedisConfig extends RedisConfig {
 
 ### Graceful Shutdown
 
-Call `shutdown()` when your application terminates:
+You do not need to disconnect Redis manually. `RedisService` registers itself with the lifecycle manager, so when the application shuts down it disconnects the ioredis client automatically.
 
-```typescript
-import { createApp, Controller, Get, Injectable, inject, Config, EnvService } from '@zeltjs/core';
+With `@zeltjs/adapter-node`, `onNode` installs `SIGINT`/`SIGTERM` handlers that trigger this shutdown, and `handle.shutdown()` does the same:
+
+```typescript twoslash
+import { createApp, Controller, Get } from '@zeltjs/core';
 import { onNode } from '@zeltjs/adapter-node';
-declare class RedisKV { shutdown(): Promise<void>; }
-declare class RedisConfig {}
-interface AtomicKVStore { get<T>(key: string): Promise<{ unwrapOr<U>(fallback: U): T | U }>; }
-
-@Injectable()
-class CacheService {
-  private store = inject(RedisKV) as unknown as { namespace(prefix: string): { unwrapOr<T>(fallback: T): AtomicKVStore | T } };
-  async get<T>(key: string): Promise<T | undefined> {
-    const ns = this.store.namespace('cache:').unwrapOr(null);
-    if (!ns) return undefined;
-    const result = await ns.get<T>(key);
-    return result.unwrapOr(undefined);
-  }
-}
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
+import { RedisConfig } from '@zeltjs/redis';
 
 @Controller('/app') class AppController { @Get('/') get() { return {}; } }
 
 const app = createApp({
   http: { controllers: [AppController] },
   configs: [RedisConfig],
+  injectables: [RedisKVAdaptor],
 });
 const nodeApp = await onNode(app);
 // ---cut---
 const handle = await nodeApp.listen({ port: 3000 });
 
-process.on('SIGTERM', async () => {
-  await nodeApp.get(RedisKV).shutdown();
-  await handle.shutdown();
-});
+// Disconnects the server and runs lifecycle shutdown (Redis included)
+await handle.shutdown();
 ```

--- a/website/docs/kv.md
+++ b/website/docs/kv.md
@@ -9,7 +9,7 @@ Zelt provides `@zeltjs/kv` for namespace-based key-value storage with TTL suppor
 
 The KV module provides:
 
-- **`KVDriver` / `AtomicKVDriver`** — Top-level drivers that create namespaced stores
+- **`KVAdaptor` / `AtomicKVAdaptor`** — Top-level adaptors that create namespaced stores
 - **`KVStore` / `AtomicKVStore`** — Interfaces for data operations (get, set, del, etc.)
 - **`MemoryKV`** — In-memory implementation with automatic garbage collection
 - **Promise-based API** — All operations return `Promise` and throw on errors

--- a/website/docs/rate-limiting.md
+++ b/website/docs/rate-limiting.md
@@ -108,29 +108,27 @@ export class AuthController {
 
 ## Custom Configuration
 
-Extend `RateLimitConfig` to customize behavior:
+Extend `RateLimitConfig` to customize behavior. To back the limiter with Redis instead of the default in-memory store, pass a `RedisKVAdaptor` to `super()`:
 
 ```typescript
-import { Config, EnvConfig, inject } from '@zeltjs/core';
+import { Config, inject } from '@zeltjs/core';
 import { RateLimitConfig } from '@zeltjs/rate-limit';
-import type { AtomicKVStore } from '@zeltjs/kv';
-
-declare function createRedisKVStore(opts: { url: string | undefined }): AtomicKVStore;
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
 // ---cut---
 @Config
 class CustomRateLimitConfig extends RateLimitConfig {
-  override readonly store: AtomicKVStore;
-
-  constructor(private env = inject(EnvConfig)) {
-    super();
-    this.store = createRedisKVStore({ url: this.env.get('REDIS_URL') });
+  constructor(kv = inject(RedisKVAdaptor)) {
+    super(kv);
   }
 
+  override readonly kvStoreNamespace = 'ratelimit:';
   override readonly defaultLimit = 200;
   override readonly defaultWindowSec = 120;
   override readonly failureMode = 'closed' as const;
 }
 ```
+
+Using Redis requires registering `RedisConfig` (from `@zeltjs/redis`) so the adaptor can resolve its connection.
 
 ## Response Headers and Errors
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,12 +1,10 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import type * as Preset from '@docusaurus/preset-classic';
 import type { Config } from '@docusaurus/types';
 import type { PluginOptions as SearchPluginOptions } from '@easyops-cn/docusaurus-search-local';
 import rehypeShiki from '@shikijs/rehype';
-import { createTwoslasher } from 'twoslash';
 import sidebars from './sidebars.js';
 import { remarkTwoslashBlock } from './src/remark/remark-twoslash-block';
+import { twoslasher } from './src/twoslash/twoslasher';
 
 type SidebarItem =
   | string
@@ -23,44 +21,6 @@ const extractDocPaths = (items: SidebarItem[]): string[] =>
   });
 
 const llmsIncludeOrder = extractDocPaths(sidebars.docsSidebar as SidebarItem[]);
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const rootDir = path.resolve(__dirname, '..');
-const tsLibDirectory = path.resolve(__dirname, '../node_modules/typescript/lib');
-
-const twoslasher = createTwoslasher({
-  vfsRoot: rootDir,
-  tsLibDirectory,
-  compilerOptions: {
-    module: 99, // ESNext
-    moduleResolution: 99, // NodeNext
-    target: 99, // ESNext
-    lib: ['lib.esnext.full.d.ts'],
-    strict: true,
-    esModuleInterop: true,
-    skipLibCheck: true,
-    baseUrl: rootDir,
-    // @zeltjs/* packages: resolved via explicit paths because pnpm's strict
-    // node_modules structure doesn't work with Twoslash VFS.
-    // Corresponding devDependencies in package.json ensure nx builds them first.
-    paths: {
-      '@zeltjs/validator-valibot': ['./packages/validator-valibot/dist/index.d.ts'],
-      '@zeltjs/redis/testing': ['./packages/redis/dist/testing/index.d.ts'],
-      '@zeltjs/testing/vitest': ['./packages/testing/dist/adapters/vitest.d.ts'],
-      '@zeltjs/testing/jest': ['./packages/testing/dist/adapters/jest.d.ts'],
-      '@zeltjs/testing/bun': ['./packages/testing/dist/adapters/bun.d.ts'],
-      '@zeltjs/testing/node': ['./packages/testing/dist/adapters/node.d.ts'],
-      '@zeltjs/*': ['./packages/*/dist/index.d.ts'],
-      valibot: [
-        './node_modules/.pnpm/valibot@1.0.0_typescript@6.0.2/node_modules/valibot/dist/index.d.ts',
-      ],
-      hono: ['./node_modules/.pnpm/hono@4.12.16/node_modules/hono/dist/types/index.d.ts'],
-      'hono/*': ['./node_modules/.pnpm/hono@4.12.16/node_modules/hono/dist/types/*.d.ts'],
-      ioredis: ['./node_modules/.pnpm/ioredis@5.10.1/node_modules/ioredis/built/index.d.ts'],
-      bullmq: ['./node_modules/.pnpm/bullmq@5.76.9/node_modules/bullmq/dist/esm/index.d.ts'],
-    },
-  },
-});
 
 const shikiBaseConfig = {
   themes: {

--- a/website/examples/drizzle-todo.md
+++ b/website/examples/drizzle-todo.md
@@ -12,7 +12,7 @@ A simple Todo API using Drizzle ORM with SQLite.
 - CRUD operations with Drizzle ORM
 - Request validation with Valibot
 - SQLite database with better-sqlite3
-- Disposable pattern for cleanup
+- Lifecycle hooks for connection cleanup
 
 ## Running
 
@@ -24,23 +24,52 @@ pnpm dev
 
 ## Key Code
 
-**Controller with validation:**
+**Controller with validation** (`src/todo/todo.controller.ts`):
 
-```typescript
-import { Controller, Get, Post, inject, pathParam, validated } from '@zeltjs/core';
+```typescript source=examples/drizzle-todo/src/todo/todo.controller.ts
+import {
+  Controller,
+  Delete,
+  Get,
+  HTTPException,
+  inject,
+  Patch,
+  Post,
+  pathParam,
+  response,
+} from '@zeltjs/core';
+import { validated } from '@zeltjs/validator-valibot';
 import * as v from 'valibot';
+
+import type { Todo } from '../db/schema';
+
+import { TodoService } from './todo.service';
 
 const CreateTodoBody = v.object({
   title: v.pipe(v.string(), v.minLength(1)),
 });
 
+const UpdateTodoBody = v.object({
+  title: v.optional(v.pipe(v.string(), v.minLength(1))),
+  completed: v.optional(v.boolean()),
+});
+
 @Controller('/todos')
-class TodoController {
+export class TodoController {
   constructor(private todoService = inject(TodoService)) {}
 
   @Get('/')
-  findAll() {
+  findAll(): Todo[] {
     return this.todoService.findAll();
+  }
+
+  @Get('/:id')
+  findById(id = pathParam('id')): Todo {
+    const todo = this.todoService.findById(Number(id));
+    if (!todo) {
+      throw new HTTPException(404, { message: 'Todo not found' });
+    }
+    return todo;
   }
 
   @Post('/')
@@ -48,28 +77,68 @@ class TodoController {
     const todo = this.todoService.create({ title: body.title });
     return res.json(todo, 201);
   }
+
+  @Patch('/:id')
+  update(id = pathParam('id'), body = validated(UpdateTodoBody)): Todo {
+    const todo = this.todoService.update(Number(id), body);
+    if (!todo) {
+      throw new HTTPException(404, { message: 'Todo not found' });
+    }
+    return todo;
+  }
+
+  @Delete('/:id')
+  delete(id = pathParam('id')) {
+    const deleted = this.todoService.delete(Number(id));
+    if (!deleted) {
+      throw new HTTPException(404, { message: 'Todo not found' });
+    }
+    return new Response(null, { status: 204 });
+  }
 }
 ```
 
-**Drizzle service with Disposable:**
+**Drizzle service with Lifecycle** (`src/db/drizzle.service.ts`):
 
-```typescript
-import { Injectable } from '@zeltjs/core';
-import type { Disposable } from '@zeltjs/core';
+```typescript source=examples/drizzle-todo/src/db/drizzle.service.ts
+import { existsSync, mkdirSync } from 'node:fs';
+import type { Lifecycle } from '@zeltjs/core';
+import { Injectable, inject, LifecycleManager } from '@zeltjs/core';
 import Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 
-@Injectable()
-class DrizzleService implements Disposable {
-  private sqlite: Database.Database;
-  readonly db;
+import * as schema from './schema';
 
-  constructor() {
+@Injectable()
+export class DrizzleService implements Lifecycle {
+  private sqlite: Database.Database;
+  readonly db: BetterSQLite3Database<typeof schema>;
+
+  constructor(lifecycle = inject(LifecycleManager)) {
+    if (!existsSync('./data')) {
+      mkdirSync('./data', { recursive: true });
+    }
     this.sqlite = new Database('./data/todo.db');
     this.db = drizzle(this.sqlite, { schema });
+    this.initSchema();
+    lifecycle.register(this);
   }
 
-  dispose() {
+  private initSchema() {
+    this.sqlite.exec(`
+      CREATE TABLE IF NOT EXISTS todos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        completed INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL
+      )
+    `);
+  }
+
+  async startup(): Promise<void> {}
+
+  async shutdown(): Promise<void> {
     this.sqlite.close();
   }
 }

--- a/website/examples/workers-url-shortener.md
+++ b/website/examples/workers-url-shortener.md
@@ -24,9 +24,9 @@ pnpm dev
 
 ## Key Code
 
-**Worker entry point:**
+**Worker entry point** (`src/worker.ts`):
 
-```typescript
+```typescript source=examples/workers-url-shortener/src/worker.ts
 import { app } from './app';
 
 export default {
@@ -34,50 +34,119 @@ export default {
 };
 ```
 
-**Controller with KV access:**
+**Controller with KV access** (`src/url/url.controller.ts`):
 
-```typescript
-import { Controller, Get, Post, inject, pathParam, requestContext, validated } from '@zeltjs/core';
+```typescript source=examples/workers-url-shortener/src/url/url.controller.ts
+import {
+  Controller,
+  Get,
+  HTTPException,
+  inject,
+  Post,
+  pathParam,
+  requestContext,
+  response,
+} from '@zeltjs/core';
+import { validated } from '@zeltjs/validator-valibot';
+import type { Context } from 'hono';
 import * as v from 'valibot';
+
+import type { Env } from '../env';
+
+import { KVService } from './kv.service';
+import type { UrlRecord } from './types';
+
+type RequestContext = Context<Env>;
 
 const ShortenBody = v.object({
   url: v.pipe(v.string(), v.url()),
 });
 
+const generateCode = (): string => {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789';
+  let code = '';
+  for (let i = 0; i < 6; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+};
+
 @Controller('/')
-class UrlController {
+export class UrlController {
   constructor(private kv = inject(KVService)) {}
 
   @Post('/shorten')
-  async shorten(body = validated(ShortenBody), res = response(), ctx = requestContext()) {
+  async shorten(
+    body = validated(ShortenBody),
+    res = response(),
+    ctx = requestContext() as RequestContext,
+  ) {
     const code = generateCode();
-    await this.kv.set(ctx, code, { url: body.url, createdAt: Date.now(), hits: 0 });
+    const record: UrlRecord = {
+      url: body.url,
+      createdAt: Date.now(),
+      hits: 0,
+    };
+    await this.kv.set(ctx, code, record);
     return res.json({ code, shortUrl: `/${code}` }, 201);
   }
 
-  @Get('/:code')
-  async redirect(code = pathParam('code'), res = response(), ctx = requestContext()) {
+  @Get('/stats/:code')
+  async stats(code = pathParam('code'), ctx = requestContext() as RequestContext) {
     const record = await this.kv.get(ctx, code);
-    if (!record) throw new HTTPException(404, { message: 'URL not found' });
+    if (!record) {
+      throw new HTTPException(404, { message: 'URL not found' });
+    }
+    return { code, url: record.url, hits: record.hits, createdAt: record.createdAt };
+  }
+
+  @Get('/:code')
+  async redirect(
+    code = pathParam('code'),
+    res = response(),
+    ctx = requestContext() as RequestContext,
+  ) {
+    const record = await this.kv.get(ctx, code);
+    if (!record) {
+      throw new HTTPException(404, { message: 'URL not found' });
+    }
     await this.kv.incrementHits(ctx, code);
     return res.redirect(record.url, 302);
   }
 }
 ```
 
-**KV service:**
+**KV service** (`src/url/kv.service.ts`):
 
-```typescript
+```typescript source=examples/workers-url-shortener/src/url/kv.service.ts
 import { Injectable } from '@zeltjs/core';
+import type { Context } from 'hono';
+
+import type { Env } from '../env';
+
+import type { UrlRecord } from './types';
+
+type RequestContext = Context<Env>;
+
+const getKV = (c: RequestContext): KVNamespace => c.env.URLS;
 
 @Injectable()
-class KVService {
-  async get(c: RequestContext, code: string) {
-    return c.env.URLS.get(`url:${code}`, 'json');
+export class KVService {
+  async get(c: RequestContext, code: string): Promise<UrlRecord | null> {
+    const data = await getKV(c).get(`url:${code}`, 'json');
+    return data as UrlRecord | null;
   }
 
-  async set(c: RequestContext, code: string, record: UrlRecord) {
-    await c.env.URLS.put(`url:${code}`, JSON.stringify(record));
+  async set(c: RequestContext, code: string, record: UrlRecord): Promise<void> {
+    await getKV(c).put(`url:${code}`, JSON.stringify(record));
+  }
+
+  async incrementHits(c: RequestContext, code: string): Promise<void> {
+    const record = await this.get(c, code);
+    if (record) {
+      record.hits += 1;
+      await this.set(c, code, record);
+    }
   }
 }
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/authentication/jwt.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/authentication/jwt.md
@@ -202,14 +202,14 @@ class UserRepository {
 @Config
 class CustomJwtConfig extends JwtConfig {
   constructor(
-    private env = inject(EnvConfig),
+    private envConfig = inject(EnvConfig),
     private userRepo = inject(UserRepository)
   ) {
     super();
   }
 
   override get secret(): string {
-    return this.env.get('JWT_SECRET')!;
+    return this.envConfig.get('JWT_SECRET')!;
   }
 
   override get expiresIn(): string {
@@ -248,10 +248,10 @@ class UserRepository {
 @Config
 class CustomJwtConfig extends JwtConfig {
   constructor(
-    private env = inject(EnvConfig),
+    private envConfig = inject(EnvConfig),
     private userRepo = inject(UserRepository)
   ) { super(); }
-  override get secret(): string { return this.env.get('JWT_SECRET')!; }
+  override get secret(): string { return this.envConfig.get('JWT_SECRET')!; }
   override get expiresIn(): string { return '7d'; }
   override get resolveUser(): (payload: JwtPayload) => Promise<ResolveUserResult> {
     return async (payload) => {

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/authentication/sessions.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/authentication/sessions.md
@@ -25,20 +25,15 @@ SESSION_SECRET=your-secret-key-at-least-32-characters
 
 ### 2. Configure Session Store
 
-Create a custom config that provides a KV store for session data:
+Sessions are stored in a KV store. By default `SessionConfig` uses the in-memory adaptor under the `session:` namespace. To customize the namespace (or other options), extend `SessionConfig`:
 
 ```typescript
-import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
+import { Config } from '@zeltjs/core';
 import { SessionConfig } from '@zeltjs/auth-session';
 // ---cut---
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-
-  override get store() {
-    return this.kv.namespace('sessions');
-  }
+  override readonly kvStoreNamespace = 'sessions:';
 }
 ```
 
@@ -52,8 +47,7 @@ import { HTTPException } from 'hono/http-exception';
 
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-  override get store() { return this.kv.namespace('sessions'); }
+  override readonly kvStoreNamespace = 'sessions:';
 }
 
 @Controller('/auth')
@@ -211,17 +205,12 @@ setSession({ userId: '123', name: 'Alice' });
 Extend `SessionConfig` to customize behavior:
 
 ```typescript
-import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
+import { Config } from '@zeltjs/core';
 import { SessionConfig } from '@zeltjs/auth-session';
 // ---cut---
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-
-  override get store() {
-    return this.kv.namespace('sessions');
-  }
+  override readonly kvStoreNamespace = 'sessions:';
 
   override get cookieName(): string {
     return 'my_session';  // default: 'session'
@@ -246,7 +235,8 @@ class MySessionConfig extends SessionConfig {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `store` | `KVNamespace` | Required | KV namespace for session storage |
+| `kv` | `KVAdaptor` | `MemoryKV` | KV adaptor (constructor arg 2) backing session storage |
+| `kvStoreNamespace` | `string` | `'session:'` | Namespace prefix for session keys |
 | `secret` | `string` | `env.get('SESSION_SECRET')` | Secret for signing session IDs |
 | `cookieName` | `string` | `'session'` | Cookie name |
 | `ttlSec` | `number` | `86400` (1 day) | Session TTL in seconds |
@@ -260,12 +250,12 @@ import { SessionConfig } from '@zeltjs/auth-session';
 
 @Config
 class MySessionConfig extends SessionConfig {
-  constructor(private env = inject(EnvService)) { super(); }
+  constructor(private envService = inject(EnvService)) { super(); }
 // ---cut---
   override get cookieOptions() {
     return {
       httpOnly: true,
-      secure: this.env.getString('NODE_ENV', '') === 'production',
+      secure: this.envService.getString('NODE_ENV', '') === 'production',
       sameSite: 'Lax' as const,
       path: '/',
     };
@@ -279,51 +269,37 @@ class MySessionConfig extends SessionConfig {
 
 ```typescript
 import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
+import { MemoryKV } from '@zeltjs/kv';
 import { SessionConfig } from '@zeltjs/auth-session';
 // ---cut---
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-  override get store() {
-    return this.kv.namespace('sessions');
+  constructor(kv = inject(MemoryKV)) {
+    super(undefined, kv);
   }
 }
 ```
 
 ### Redis (Production)
 
-```typescript
-import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
-import { SessionConfig } from '@zeltjs/auth-session';
-declare class RedisKVService extends MemoryKVService {}
-// ---cut---
-@Config
-class MySessionConfig extends SessionConfig {
-  private kv = inject(RedisKVService);
-  override get store() {
-    return this.kv.namespace('sessions');
-  }
-}
-```
-
-### Cloudflare KV
+`SessionConfig` takes the KV adaptor as its second constructor argument. Pass a `RedisKVAdaptor` to `super()` to store sessions in Redis (leave the first argument as `undefined` to keep the default `Env` injection):
 
 ```typescript
 import { Config, inject } from '@zeltjs/core';
-import { MemoryKVService } from '@zeltjs/kv';
 import { SessionConfig } from '@zeltjs/auth-session';
-declare class CloudflareKVService extends MemoryKVService {}
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
 // ---cut---
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(CloudflareKVService);
-  override get store() {
-    return this.kv.namespace('sessions');
+  constructor(kv = inject(RedisKVAdaptor)) {
+    super(undefined, kv);
   }
+
+  override readonly kvStoreNamespace = 'sessions:';
 }
 ```
+
+Using Redis requires registering `RedisConfig` (from `@zeltjs/redis`) so the adaptor can resolve its connection.
 
 ## Integration with User Context
 
@@ -381,8 +357,7 @@ class UserRepository {
 
 @Config
 class MySessionConfig extends SessionConfig {
-  private kv = inject(MemoryKVService);
-  override get store() { return this.kv.namespace('sessions'); }
+  override readonly kvStoreNamespace = 'sessions:';
 }
 
 @Middleware

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/authorization/access-control.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/authorization/access-control.md
@@ -308,7 +308,7 @@ Check for any role in a hierarchy:
 import { Controller, Authorized, Put, currentRoles } from '@zeltjs/core';
 import { HTTPException } from 'hono/http-exception';
 // ---cut---
-const isEditor = (roles: string[]) =>
+const isEditor = (roles: readonly string[]) =>
   roles.some(r => ['admin', 'editor'].includes(r));
 
 @Controller('/posts')

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration.md
@@ -5,25 +5,30 @@
 
 Zelt provides a type-safe configuration system using the `@Config` decorator and `inject()` helper.
 
+:::info Migration Note
+As of version X.X, use `inject(Env)` instead of `inject(EnvConfig)` or `inject(EnvService)`.
+The old classes are deprecated and will be removed in the next major version.
+:::
+
 ## Defining Configuration
 
 Use the `@Config` decorator to define a configuration class. Each config class must have a static `Token` property:
 
 ```typescript
-import { Config, EnvConfig, inject } from '@zeltjs/core';
+import { Config, Env, inject } from '@zeltjs/core';
 
 @Config
 export class DatabaseConfig {
   static readonly Token = DatabaseConfig;
 
-  constructor(private env = inject(EnvConfig)) {}
+  constructor(private env = inject(Env)) {}
 
   get host() {
-    return this.env.get('DATABASE_HOST') ?? 'localhost';
+    return this.env.getString('DATABASE_HOST', 'localhost');
   }
 
   get port() {
-    return Number(this.env.get('DATABASE_PORT') ?? 5432);
+    return this.env.getNumber('DATABASE_PORT', 5432);
   }
 
   get connectionString() {
@@ -37,14 +42,14 @@ export class DatabaseConfig {
 Inject configuration into services or controllers using `inject()`:
 
 ```typescript
-import { Injectable, inject, Config, EnvConfig } from '@zeltjs/core';
+import { Injectable, inject, Config, Env } from '@zeltjs/core';
 
 @Config
 class DatabaseConfig {
   static readonly Token = DatabaseConfig;
-  constructor(private env = inject(EnvConfig)) {}
-  get host() { return this.env.get('DATABASE_HOST') ?? 'localhost'; }
-  get port() { return Number(this.env.get('DATABASE_PORT') ?? 5432); }
+  constructor(private env = inject(Env)) {}
+  get host() { return this.env.getString('DATABASE_HOST', 'localhost'); }
+  get port() { return this.env.getNumber('DATABASE_PORT', 5432); }
   get connectionString() { return `postgres://${this.host}:${this.port}/mydb`; }
 }
 // ---cut---
@@ -63,14 +68,14 @@ export class DatabaseService {
 Register config classes when creating the app:
 
 ```typescript
-import { createApp, Config, EnvConfig, inject, Controller, Get } from '@zeltjs/core';
+import { createApp, Config, Env, inject, Controller, Get } from '@zeltjs/core';
 
 @Config
 class DatabaseConfig {
   static readonly Token = DatabaseConfig;
-  constructor(private env = inject(EnvConfig)) {}
-  get host() { return this.env.get('DATABASE_HOST') ?? 'localhost'; }
-  get port() { return Number(this.env.get('DATABASE_PORT') ?? 5432); }
+  constructor(private env = inject(Env)) {}
+  get host() { return this.env.getString('DATABASE_HOST', 'localhost'); }
+  get port() { return this.env.getNumber('DATABASE_PORT', 5432); }
   get connectionString() { return `postgres://${this.host}:${this.port}/mydb`; }
 }
 @Controller('/') class AppController { @Get('/') index() { return { ok: true }; } }
@@ -88,14 +93,14 @@ const app = createApp({
 Override configuration values for testing by extending the config class:
 
 ```typescript
-import { Config, createApp, EnvConfig, inject } from '@zeltjs/core';
+import { Config, createApp, Env, inject } from '@zeltjs/core';
 declare class AppController {}
 @Config
 class DatabaseConfig {
   static readonly Token = DatabaseConfig;
-  constructor(private env = inject(EnvConfig)) {}
-  get host() { return this.env.get('DATABASE_HOST') ?? 'localhost'; }
-  get port() { return Number(this.env.get('DATABASE_PORT') ?? 5432); }
+  constructor(private env = inject(Env)) {}
+  get host() { return this.env.getString('DATABASE_HOST', 'localhost'); }
+  get port() { return this.env.getNumber('DATABASE_PORT', 5432); }
   get connectionString() { return `postgres://${this.host}:${this.port}/mydb`; }
 }
 // ---cut---
@@ -123,19 +128,14 @@ The `Token` property is inherited from the parent class, so `inject(DatabaseConf
 
 ## Environment-Based Configuration
 
-Zelt provides environment configuration through platform-specific adapters.
+`inject(Env)` reads environment variables from the platform-specific source registered by the adapter. No additional setup is needed for the common case.
 
 ### Node.js Environment
 
-For Node.js applications, use the configs from `@zeltjs/adapter-node`:
-
-#### ProcessEnvConfig
-
-Reads from `process.env` directly:
+When using `onNode()`, `ProcessEnvAdaptor` is registered automatically, so `inject(Env)` reads from `process.env` without any extra config:
 
 ```typescript
-import { Config, inject, createApp, Controller, Get } from '@zeltjs/core';
-import { ProcessEnvConfig } from '@zeltjs/adapter-node';
+import { Config, Env, inject, createApp, Controller, Get } from '@zeltjs/core';
 
 @Controller('/') class AppController { @Get('/') index() { return { ok: true }; } }
 // ---cut---
@@ -143,14 +143,14 @@ import { ProcessEnvConfig } from '@zeltjs/adapter-node';
 export class DatabaseConfig {
   static readonly Token = DatabaseConfig;
 
-  constructor(private env = inject(ProcessEnvConfig)) {}
+  constructor(private env = inject(Env)) {}
 
   get host() {
-    return this.env.get('DATABASE_HOST') ?? 'localhost';
+    return this.env.getString('DATABASE_HOST', 'localhost');
   }
 
   get port() {
-    return Number(this.env.get('DATABASE_PORT') ?? 5432);
+    return this.env.getNumber('DATABASE_PORT', 5432);
   }
 
   get connectionString() {
@@ -158,58 +158,26 @@ export class DatabaseConfig {
   }
 }
 
-// Register both configs
 const app = createApp({
   http: {
     controllers: [AppController],
   },
-  configs: [ProcessEnvConfig, DatabaseConfig],
+  configs: [DatabaseConfig],
 });
 ```
 
-#### DotEnvConfig
+### Loading `.env` Files
 
-Loads `.env` files using [dotenv](https://github.com/motdotla/dotenv), then reads from `process.env`:
-
-```typescript
-import { Config, inject, createApp, Controller, Get } from '@zeltjs/core';
-import { DotEnvConfig } from '@zeltjs/adapter-node';
-
-@Controller('/') class AppController { @Get('/') index() { return { ok: true }; } }
-// ---cut---
-@Config
-export class DatabaseConfig {
-  static readonly Token = DatabaseConfig;
-
-  constructor(private env = inject(DotEnvConfig)) {}
-
-  get host() {
-    return this.env.get('DATABASE_HOST') ?? 'localhost';
-  }
-}
-
-// DotEnvConfig loads .env on construction
-const app = createApp({
-  http: {
-    controllers: [AppController],
-  },
-  configs: [DotEnvConfig, DatabaseConfig],
-});
-```
-
-#### Custom Env Paths
-
-Extend `DotEnvConfig` to load from custom paths:
+To load a `.env` file, import `dotenv/config` at the entry point of your application before anything else:
 
 ```typescript
-import { Config } from '@zeltjs/core';
-import { DotEnvConfig } from '@zeltjs/adapter-node';
-// ---cut---
-@Config
-export class MyEnvConfig extends DotEnvConfig {
-  protected override readonly paths = ['.env', '.env.local'];
-}
+// @errors: 2882
+import 'dotenv/config';
+import { onNode } from '@zeltjs/adapter-node';
+// ...rest of app setup
 ```
+
+`inject(Env)` will then read the variables populated by dotenv from `process.env`.
 
 ### Cloudflare Workers Environment
 
@@ -254,4 +222,3 @@ Zelt automatically detects the decorator mode based on the runtime context:
 - **Legacy mode**: Decorator receives `target`, `propertyKey`, and `descriptor` arguments
 
 Both modes work identically from an API perspective—you don't need to change your code when switching between them.
-

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/examples/drizzle-todo.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/examples/drizzle-todo.md
@@ -12,7 +12,7 @@ A simple Todo API using Drizzle ORM with SQLite.
 - CRUD operations with Drizzle ORM
 - Request validation with Valibot
 - SQLite database with better-sqlite3
-- Disposable pattern for cleanup
+- Lifecycle hooks for connection cleanup
 
 ## Running
 
@@ -24,23 +24,52 @@ pnpm dev
 
 ## Key Code
 
-**Controller with validation:**
+**Controller with validation** (`src/todo/todo.controller.ts`):
 
-```typescript
-import { Controller, Get, Post, inject, pathParam, validated } from '@zeltjs/core';
+```typescript source=examples/drizzle-todo/src/todo/todo.controller.ts
+import {
+  Controller,
+  Delete,
+  Get,
+  HTTPException,
+  inject,
+  Patch,
+  Post,
+  pathParam,
+  response,
+} from '@zeltjs/core';
+import { validated } from '@zeltjs/validator-valibot';
 import * as v from 'valibot';
+
+import type { Todo } from '../db/schema';
+
+import { TodoService } from './todo.service';
 
 const CreateTodoBody = v.object({
   title: v.pipe(v.string(), v.minLength(1)),
 });
 
+const UpdateTodoBody = v.object({
+  title: v.optional(v.pipe(v.string(), v.minLength(1))),
+  completed: v.optional(v.boolean()),
+});
+
 @Controller('/todos')
-class TodoController {
+export class TodoController {
   constructor(private todoService = inject(TodoService)) {}
 
   @Get('/')
-  findAll() {
+  findAll(): Todo[] {
     return this.todoService.findAll();
+  }
+
+  @Get('/:id')
+  findById(id = pathParam('id')): Todo {
+    const todo = this.todoService.findById(Number(id));
+    if (!todo) {
+      throw new HTTPException(404, { message: 'Todo not found' });
+    }
+    return todo;
   }
 
   @Post('/')
@@ -48,28 +77,68 @@ class TodoController {
     const todo = this.todoService.create({ title: body.title });
     return res.json(todo, 201);
   }
+
+  @Patch('/:id')
+  update(id = pathParam('id'), body = validated(UpdateTodoBody)): Todo {
+    const todo = this.todoService.update(Number(id), body);
+    if (!todo) {
+      throw new HTTPException(404, { message: 'Todo not found' });
+    }
+    return todo;
+  }
+
+  @Delete('/:id')
+  delete(id = pathParam('id')) {
+    const deleted = this.todoService.delete(Number(id));
+    if (!deleted) {
+      throw new HTTPException(404, { message: 'Todo not found' });
+    }
+    return new Response(null, { status: 204 });
+  }
 }
 ```
 
-**Drizzle service with Disposable:**
+**Drizzle service with Lifecycle** (`src/db/drizzle.service.ts`):
 
-```typescript
-import { Injectable } from '@zeltjs/core';
-import type { Disposable } from '@zeltjs/core';
+```typescript source=examples/drizzle-todo/src/db/drizzle.service.ts
+import { existsSync, mkdirSync } from 'node:fs';
+import type { Lifecycle } from '@zeltjs/core';
+import { Injectable, inject, LifecycleManager } from '@zeltjs/core';
 import Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 
-@Injectable()
-class DrizzleService implements Disposable {
-  private sqlite: Database.Database;
-  readonly db;
+import * as schema from './schema';
 
-  constructor() {
+@Injectable()
+export class DrizzleService implements Lifecycle {
+  private sqlite: Database.Database;
+  readonly db: BetterSQLite3Database<typeof schema>;
+
+  constructor(lifecycle = inject(LifecycleManager)) {
+    if (!existsSync('./data')) {
+      mkdirSync('./data', { recursive: true });
+    }
     this.sqlite = new Database('./data/todo.db');
     this.db = drizzle(this.sqlite, { schema });
+    this.initSchema();
+    lifecycle.register(this);
   }
 
-  dispose() {
+  private initSchema() {
+    this.sqlite.exec(`
+      CREATE TABLE IF NOT EXISTS todos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        completed INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL
+      )
+    `);
+  }
+
+  async startup(): Promise<void> {}
+
+  async shutdown(): Promise<void> {
     this.sqlite.close();
   }
 }

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/examples/workers-url-shortener.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/examples/workers-url-shortener.md
@@ -24,9 +24,9 @@ pnpm dev
 
 ## Key Code
 
-**Worker entry point:**
+**Worker entry point** (`src/worker.ts`):
 
-```typescript
+```typescript source=examples/workers-url-shortener/src/worker.ts
 import { app } from './app';
 
 export default {
@@ -34,50 +34,119 @@ export default {
 };
 ```
 
-**Controller with KV access:**
+**Controller with KV access** (`src/url/url.controller.ts`):
 
-```typescript
-import { Controller, Get, Post, inject, pathParam, requestContext, validated } from '@zeltjs/core';
+```typescript source=examples/workers-url-shortener/src/url/url.controller.ts
+import {
+  Controller,
+  Get,
+  HTTPException,
+  inject,
+  Post,
+  pathParam,
+  requestContext,
+  response,
+} from '@zeltjs/core';
+import { validated } from '@zeltjs/validator-valibot';
+import type { Context } from 'hono';
 import * as v from 'valibot';
+
+import type { Env } from '../env';
+
+import { KVService } from './kv.service';
+import type { UrlRecord } from './types';
+
+type RequestContext = Context<Env>;
 
 const ShortenBody = v.object({
   url: v.pipe(v.string(), v.url()),
 });
 
+const generateCode = (): string => {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789';
+  let code = '';
+  for (let i = 0; i < 6; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+};
+
 @Controller('/')
-class UrlController {
+export class UrlController {
   constructor(private kv = inject(KVService)) {}
 
   @Post('/shorten')
-  async shorten(body = validated(ShortenBody), res = response(), ctx = requestContext()) {
+  async shorten(
+    body = validated(ShortenBody),
+    res = response(),
+    ctx = requestContext() as RequestContext,
+  ) {
     const code = generateCode();
-    await this.kv.set(ctx, code, { url: body.url, createdAt: Date.now(), hits: 0 });
+    const record: UrlRecord = {
+      url: body.url,
+      createdAt: Date.now(),
+      hits: 0,
+    };
+    await this.kv.set(ctx, code, record);
     return res.json({ code, shortUrl: `/${code}` }, 201);
   }
 
-  @Get('/:code')
-  async redirect(code = pathParam('code'), res = response(), ctx = requestContext()) {
+  @Get('/stats/:code')
+  async stats(code = pathParam('code'), ctx = requestContext() as RequestContext) {
     const record = await this.kv.get(ctx, code);
-    if (!record) throw new HTTPException(404, { message: 'URL not found' });
+    if (!record) {
+      throw new HTTPException(404, { message: 'URL not found' });
+    }
+    return { code, url: record.url, hits: record.hits, createdAt: record.createdAt };
+  }
+
+  @Get('/:code')
+  async redirect(
+    code = pathParam('code'),
+    res = response(),
+    ctx = requestContext() as RequestContext,
+  ) {
+    const record = await this.kv.get(ctx, code);
+    if (!record) {
+      throw new HTTPException(404, { message: 'URL not found' });
+    }
     await this.kv.incrementHits(ctx, code);
     return res.redirect(record.url, 302);
   }
 }
 ```
 
-**KV service:**
+**KV service** (`src/url/kv.service.ts`):
 
-```typescript
+```typescript source=examples/workers-url-shortener/src/url/kv.service.ts
 import { Injectable } from '@zeltjs/core';
+import type { Context } from 'hono';
+
+import type { Env } from '../env';
+
+import type { UrlRecord } from './types';
+
+type RequestContext = Context<Env>;
+
+const getKV = (c: RequestContext): KVNamespace => c.env.URLS;
 
 @Injectable()
-class KVService {
-  async get(c: RequestContext, code: string) {
-    return c.env.URLS.get(`url:${code}`, 'json');
+export class KVService {
+  async get(c: RequestContext, code: string): Promise<UrlRecord | null> {
+    const data = await getKV(c).get(`url:${code}`, 'json');
+    return data as UrlRecord | null;
   }
 
-  async set(c: RequestContext, code: string, record: UrlRecord) {
-    await c.env.URLS.put(`url:${code}`, JSON.stringify(record));
+  async set(c: RequestContext, code: string, record: UrlRecord): Promise<void> {
+    await getKV(c).put(`url:${code}`, JSON.stringify(record));
+  }
+
+  async incrementHits(c: RequestContext, code: string): Promise<void> {
+    const record = await this.get(c, code);
+    if (record) {
+      record.hits += 1;
+      await this.set(c, code, record);
+    }
   }
 }
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/node.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/node.md
@@ -211,12 +211,11 @@ export const app = createApp({
 The `@zeltjs/adapter-node` package provides additional configuration options:
 
 ```typescript
-import { ProcessEnvConfig, DotEnvConfig } from '@zeltjs/adapter-node';
+import { ProcessEnvConfig } from '@zeltjs/adapter-node';
 // ---cut---
-// ProcessEnvConfig: Reads from process.env (default behavior)
-// DotEnvConfig: Reads from .env file
+// ProcessEnvConfig: Reads from process.env (default behavior).
+// For .env files, import 'dotenv/config' at your entry point.
 void ProcessEnvConfig;
-void DotEnvConfig;
 ```
 
 ## What's Next?

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/kv-redis.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/kv-redis.md
@@ -3,90 +3,87 @@
 
 # Redis KV Driver
 
-`@zeltjs/kv-driver-redis` provides a Redis backend for the KV abstraction. It implements `AtomicKVDriver` using [ioredis](https://github.com/redis/ioredis), supporting atomic operations like `incr` and `setnx`.
+`@zeltjs/kv` は `@zeltjs/kv/adaptor-redis` エントリポイント経由で Redis バックエンドを提供します。`RedisKVAdaptor` は [ioredis](https://github.com/redis/ioredis) を用いて `AtomicKVAdaptor` を実装し、`incr` や `setnx` などのアトミック操作をサポートします。
 
-## Installation
-
-```bash
-pnpm add @zeltjs/kv-driver-redis
-```
-
-Peer dependencies:
+## インストール
 
 ```bash
-pnpm add @zeltjs/core @zeltjs/kv
+pnpm add @zeltjs/kv @zeltjs/redis
 ```
 
-## Basic Setup
+peer dependency:
 
-Register `RedisConfig` and inject `RedisKV` into your services:
+```bash
+pnpm add @zeltjs/core
+```
 
-```typescript
-import { createApp, Injectable, inject, Controller, Get } from '@zeltjs/core';
-interface AtomicKVStore {
-  get<T>(key: string): Promise<{ unwrapOr<U>(fallback: U): T | U }>;
-  set<T>(key: string, value: T, opts?: { ttlSec?: number }): Promise<void>;
-}
-declare class RedisConfig {}
-declare class RedisKV {
-  namespace(prefix: string): { unwrapOr<T>(fallback: T): AtomicKVStore | T };
-}
-@Controller('/app')
-class AppController { @Get('/') get() { return {}; } }
+## 基本的なセットアップ
+
+`RedisKVAdaptor` を inject し、namespace 化したストアを作成します。`namespace()` は `AtomicKVStore` をそのまま返し、`get()` は値（キーが存在しない場合は `undefined`）に解決されます。unwrap が必要な result ラッパーはありません:
+
+```typescript twoslash
+import { Injectable, inject } from '@zeltjs/core';
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
+import type { AtomicKVStore, Defined } from '@zeltjs/kv';
 // ---cut---
 @Injectable()
-class CacheService {
-  private store = inject(RedisKV).namespace('cache:').unwrapOr(null);
+export class CacheService {
+  private store: AtomicKVStore;
 
-  async get<T>(key: string): Promise<T | undefined> {
-    if (!this.store) return undefined;
-    const result = await this.store.get<T>(key);
-    return result.unwrapOr(undefined);
+  constructor(kv = inject(RedisKVAdaptor)) {
+    this.store = kv.namespace('cache:');
   }
 
-  async set<T>(key: string, value: T, ttlSec?: number): Promise<void> {
-    if (!this.store) return;
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.store.get<T>(key);
+  }
+
+  async set<T extends Defined>(key: string, value: T, ttlSec?: number): Promise<void> {
     await this.store.set(key, value, { ttlSec });
   }
 }
+```
 
+アプリ生成時に `RedisConfig` と `RedisKVAdaptor` を登録します。`RedisConfig` が接続設定を提供し（`RedisKVAdaptor` が依存する `RedisService` が利用します）、依存は自動的に解決されるため、`injectables` には `RedisKVAdaptor` を挙げるだけで十分です:
+
+```typescript twoslash
+import { createApp, Controller, Get } from '@zeltjs/core';
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
+import { RedisConfig } from '@zeltjs/redis';
+
+@Controller('/app')
+class AppController { @Get('/') get() { return {}; } }
+// ---cut---
 const app = createApp({
   http: {
     controllers: [AppController],
   },
   configs: [RedisConfig],
+  injectables: [RedisKVAdaptor],
 });
 ```
 
-By default, `RedisConfig` reads the connection URL from the `REDIS_URL` environment variable, falling back to `redis://localhost:6379`.
+デフォルトでは、`RedisConfig` は接続 URL を環境変数 `REDIS_URL` から読み取り、未設定時は `redis://localhost:6379` にフォールバックします。
 
-## Custom Configuration
+## カスタム設定
 
-Extend `RedisConfig` to customize connection settings:
+`RedisConfig` を継承して接続設定をカスタマイズできます。`options` getter は ioredis の `RedisOptions` を返します:
 
-```typescript
+```typescript twoslash
 import { Config, EnvService, inject } from '@zeltjs/core';
-type RedisOptions = {
-  maxRetriesPerRequest?: number;
-  retryStrategy?: (times: number) => number | null;
-  enableReadyCheck?: boolean;
-};
-declare class RedisConfig {
-  get url(): string;
-  get options(): RedisOptions;
-}
+import { RedisConfig } from '@zeltjs/redis';
 // ---cut---
 @Config
 class CustomRedisConfig extends RedisConfig {
-  constructor(private env = inject(EnvService)) {
+  constructor(private envService = inject(EnvService)) {
     super();
   }
 
   override get url(): string {
-    return this.env.getString('REDIS_URL', 'redis://localhost:6379');
+    return this.envService.getString('REDIS_URL', 'redis://localhost:6379');
   }
 
-  override get options(): RedisOptions {
+  override get options() {
     return {
       maxRetriesPerRequest: 3,
       retryStrategy: (times: number) => Math.min(times * 100, 3000),
@@ -95,20 +92,18 @@ class CustomRedisConfig extends RedisConfig {
 }
 ```
 
-Register your custom config instead of the default:
+デフォルトの代わりにカスタム config を登録します:
 
-```typescript
+```typescript twoslash
 import { createApp, Config, EnvService, inject, Controller, Get } from '@zeltjs/core';
-type RedisOptions = { maxRetriesPerRequest?: number };
-declare class RedisConfig {
-  get url(): string;
-  get options(): RedisOptions;
-}
+import { RedisConfig } from '@zeltjs/redis';
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
+
 @Config
 class CustomRedisConfig extends RedisConfig {
-  constructor(private env = inject(EnvService)) { super(); }
-  override get url(): string { return this.env.getString('REDIS_URL', 'redis://localhost:6379'); }
-  override get options(): RedisOptions { return { maxRetriesPerRequest: 3 }; }
+  constructor(private envService = inject(EnvService)) { super(); }
+  override get url(): string { return this.envService.getString('REDIS_URL', 'redis://localhost:6379'); }
+  override get options() { return { maxRetriesPerRequest: 3 }; }
 }
 @Controller('/app')
 class AppController { @Get('/') get() { return {}; } }
@@ -118,50 +113,44 @@ const app = createApp({
     controllers: [AppController],
   },
   configs: [CustomRedisConfig],
+  injectables: [RedisKVAdaptor],
 });
 ```
 
-## API Reference
+## API リファレンス
 
-### RedisKV
+### RedisKVAdaptor
 
-| Method | Description |
+| メソッド | 説明 |
 |--------|-------------|
-| `namespace(prefix)` | Returns a namespaced `AtomicKVStore` |
-| `shutdown()` | Disconnects from Redis |
+| `namespace(prefix)` | namespace 化された `AtomicKVStore` を返す |
 
-### AtomicKVStore Methods
+`RedisKVAdaptor` はアプリケーションのライフサイクルに参加します。ioredis の接続は `RedisService` が保持し、シャットダウン時に自動的に切断されます（[グレースフルシャットダウン](#グレースフルシャットダウン)を参照）。
 
-| Method | Description |
+### AtomicKVStore のメソッド
+
+| メソッド | 説明 |
 |--------|-------------|
-| `get<T>(key)` | Retrieve a value |
-| `set<T>(key, value, opts?)` | Store a value with optional TTL |
-| `del(key)` | Delete a key |
-| `has(key)` | Check if key exists |
-| `expire(key, ttlSec)` | Update TTL for existing key |
-| `incr(key, by?, opts?)` | Atomic increment |
-| `setnx<T>(key, value, opts?)` | Set if not exists |
-| `namespace(prefix)` | Create nested namespace |
+| `get<T>(key)` | 値を取得（存在しない場合は `undefined`） |
+| `set<T>(key, value, opts?)` | TTL 任意指定で値を保存 |
+| `del(key)` | キーを削除 |
+| `has(key)` | キーの存在確認 |
+| `expire(key, ttlSec)` | 既存キーの TTL を更新 |
+| `incr(key, by?, opts?)` | アトミックなインクリメント |
+| `setnx<T>(key, value, opts?)` | 存在しない場合のみ set |
+| `namespace(prefix)` | ネストした namespace を作成 |
 
-## Production Setup
+## 本番環境のセットアップ
 
-For production deployments, configure connection pooling and retry behavior:
+本番デプロイでは、接続プールとリトライ動作を設定します:
 
-```typescript
+```typescript twoslash
 import { Config } from '@zeltjs/core';
-type RedisOptions = {
-  maxRetriesPerRequest?: number;
-  enableReadyCheck?: boolean;
-  retryStrategy?: (times: number) => number | null;
-};
-declare class RedisConfig {
-  get url(): string;
-  get options(): RedisOptions;
-}
+import { RedisConfig } from '@zeltjs/redis';
 // ---cut---
 @Config
 class ProductionRedisConfig extends RedisConfig {
-  override get options(): RedisOptions {
+  override get options() {
     return {
       maxRetriesPerRequest: 3,
       enableReadyCheck: true,
@@ -174,40 +163,29 @@ class ProductionRedisConfig extends RedisConfig {
 }
 ```
 
-### Graceful Shutdown
+### グレースフルシャットダウン
 
-Call `shutdown()` when your application terminates:
+Redis を手動で切断する必要はありません。`RedisService` がライフサイクルマネージャに自身を登録するため、アプリケーションのシャットダウン時に ioredis クライアントが自動的に切断されます。
 
-```typescript
-import { createApp, Controller, Get, Injectable, inject, Config, EnvService } from '@zeltjs/core';
+`@zeltjs/adapter-node` を使う場合、`onNode` が `SIGINT`/`SIGTERM` ハンドラを登録してこのシャットダウンをトリガーします。`handle.shutdown()` でも同様です:
+
+```typescript twoslash
+import { createApp, Controller, Get } from '@zeltjs/core';
 import { onNode } from '@zeltjs/adapter-node';
-declare class RedisKV { shutdown(): Promise<void>; }
-declare class RedisConfig {}
-interface AtomicKVStore { get<T>(key: string): Promise<{ unwrapOr<U>(fallback: U): T | U }>; }
-
-@Injectable()
-class CacheService {
-  private store = inject(RedisKV) as unknown as { namespace(prefix: string): { unwrapOr<T>(fallback: T): AtomicKVStore | T } };
-  async get<T>(key: string): Promise<T | undefined> {
-    const ns = this.store.namespace('cache:').unwrapOr(null);
-    if (!ns) return undefined;
-    const result = await ns.get<T>(key);
-    return result.unwrapOr(undefined);
-  }
-}
+import { RedisKVAdaptor } from '@zeltjs/kv/adaptor-redis';
+import { RedisConfig } from '@zeltjs/redis';
 
 @Controller('/app') class AppController { @Get('/') get() { return {}; } }
 
 const app = createApp({
   http: { controllers: [AppController] },
   configs: [RedisConfig],
+  injectables: [RedisKVAdaptor],
 });
 const nodeApp = await onNode(app);
 // ---cut---
 const handle = await nodeApp.listen({ port: 3000 });
 
-process.on('SIGTERM', async () => {
-  await nodeApp.get(RedisKV).shutdown();
-  await handle.shutdown();
-});
+// サーバを停止し、ライフサイクルのシャットダウン（Redis を含む）を実行
+await handle.shutdown();
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/primitives.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/primitives.md
@@ -111,33 +111,23 @@ import { Controller, Post, body, response } from '@zeltjs/core';
 
 @Controller('/upload')
 export class UploadController {
-  @Post('/text')
-  async uploadText(res = response()) {
-    const text = await body('text');
-    return res.json({ received: text });
-  }
-
   @Post('/json')
-  async uploadJson(res = response()) {
-    const data = await body('json');
+  uploadJson(data = body(), res = response()) {
     return res.json({ received: data });
   }
 
   @Post('/form')
-  async uploadForm(res = response()) {
-    const formData = await body('form');
-    return res.json({ fields: Object.fromEntries(formData) });
+  uploadForm(formData = body('form'), res = response()) {
+    return res.json({ fields: formData });
   }
 }
 ```
 
 | Type | Return Type | Description |
 |------|-------------|-------------|
-| `body('text')` | `Promise<string>` | Raw text body |
-| `body('json')` | `Promise<unknown>` | Parsed JSON body |
-| `body('form')` | `Promise<FormData>` | Form data (multipart or urlencoded) |
-| `body('arrayBuffer')` | `Promise<ArrayBuffer>` | Raw binary data |
-| `body('blob')` | `Promise<Blob>` | Blob data |
+| `body()` | `unknown` | Parsed JSON body |
+| `body('form')` | `FormBody` | Form data record (`Record<string, string \| File \| (string \| File)[]>`) |
+| `body('text')` | `string` | Plain text body |
 
 :::tip
 For validated request bodies with automatic type inference, use [`validated()`](./validation.md) instead.

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,9 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
+    "typecheck:docs": "bun scripts/typecheck-docs.ts",
+    "check:examples": "bun scripts/check-example-excerpts.ts",
+    "verify:docs": "bun scripts/typecheck-docs.ts && bun scripts/check-example-excerpts.ts",
     "lint:slugs": "bun scripts/check-doc-slugs.ts",
     "test:docs": "bun scripts/extract-doc-tests.ts && vitest run",
     "test:docs:watch": "bun scripts/extract-doc-tests.ts && vitest"
@@ -50,6 +53,7 @@
     "@zeltjs/auth-session": "workspace:*",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/db": "workspace:*",
+    "@zeltjs/decorator-metadata": "workspace:*",
     "@zeltjs/hono-client": "workspace:*",
     "@zeltjs/kv": "workspace:*",
     "@zeltjs/rate-limit": "workspace:*",

--- a/website/package.json
+++ b/website/package.json
@@ -53,7 +53,6 @@
     "@zeltjs/auth-session": "workspace:*",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/db": "workspace:*",
-    "@zeltjs/decorator-metadata": "workspace:*",
     "@zeltjs/hono-client": "workspace:*",
     "@zeltjs/kv": "workspace:*",
     "@zeltjs/rate-limit": "workspace:*",

--- a/website/scripts/check-example-excerpts.ts
+++ b/website/scripts/check-example-excerpts.ts
@@ -1,0 +1,137 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Example docs are NOT type-checked in isolation. Their code blocks must be
+// verbatim excerpts of the real, separately type-checked example apps under
+// `examples/`. Each TypeScript fence therefore declares its origin via a
+// `source=<repo-relative-path>` fence meta, and this script verifies the block
+// is a contiguous run of lines in that file — so a block cannot drift from (or
+// lie about) the real, compiling source.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const websiteDir = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(websiteDir, '..');
+
+// Both the English example docs and their Japanese translation carry the same
+// excerpts, so both trees are checked.
+const TARGET_DIRS = [
+  path.join(websiteDir, 'examples'),
+  path.join(websiteDir, 'i18n/ja/docusaurus-plugin-content-docs/current/examples'),
+];
+
+// Captures: 1=lang, 2=meta string (after the lang), 3=block body.
+const TS_FENCE = /```(ts|tsx|typescript|typescriptreact)([^\n]*)\n([\s\S]*?)```/g;
+
+const SOURCE_META = /\bsource=(\S+)/;
+
+const walk = (dir: string, acc: string[] = []): string[] => {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === 'node_modules' || entry === 'build' || entry === '.docusaurus') continue;
+      walk(full, acc);
+    } else if (/\.mdx?$/.test(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+};
+
+// rstrip every line so trailing-whitespace differences never cause a mismatch.
+const normalize = (text: string): string[] =>
+  text
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((l) => l.replace(/\s+$/, ''));
+
+const dropOuterBlankLines = (lines: string[]): string[] => {
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start] === '') start += 1;
+  while (end > start && lines[end - 1] === '') end -= 1;
+  return lines.slice(start, end);
+};
+
+// Is `needle` a contiguous run of lines inside `haystack`? Returns the 1-based
+// start line on success, or null on failure.
+const findContiguous = (haystack: string[], needle: string[]): number | null => {
+  if (needle.length === 0) return null;
+  for (let i = 0; i + needle.length <= haystack.length; i += 1) {
+    let matched = true;
+    for (let j = 0; j < needle.length; j += 1) {
+      if (haystack[i + j] !== needle[j]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return i + 1;
+  }
+  return null;
+};
+
+type Failure = { file: string; block: number; message: string };
+
+const failures: Failure[] = [];
+let blockCount = 0;
+
+for (const dir of TARGET_DIRS) {
+  for (const file of walk(dir)) {
+    const markdown = readFileSync(file, 'utf8');
+    let blockIndex = 0;
+    for (const match of markdown.matchAll(TS_FENCE)) {
+      blockIndex += 1;
+      blockCount += 1;
+      const meta = match[2] ?? '';
+      const body = match[3] ?? '';
+      const rel = path.relative(websiteDir, file);
+
+      const sourceMatch = meta.match(SOURCE_META);
+      if (!sourceMatch) {
+        failures.push({
+          file: rel,
+          block: blockIndex,
+          message:
+            'TypeScript fence has no `source=<path>` meta. Example code blocks must be verbatim excerpts of a file under examples/.',
+        });
+        continue;
+      }
+
+      const sourcePath = sourceMatch[1];
+      const absSource = path.join(repoRoot, sourcePath);
+      if (!existsSync(absSource)) {
+        failures.push({
+          file: rel,
+          block: blockIndex,
+          message: `source=${sourcePath} does not exist (resolved to ${path.relative(repoRoot, absSource)}).`,
+        });
+        continue;
+      }
+
+      const excerpt = dropOuterBlankLines(normalize(body));
+      const source = normalize(readFileSync(absSource, 'utf8'));
+      const at = findContiguous(source, excerpt);
+      if (at === null) {
+        const firstLine = excerpt[0] ?? '';
+        failures.push({
+          file: rel,
+          block: blockIndex,
+          message: `block is not a contiguous excerpt of ${sourcePath}. First block line not aligned: "${firstLine}"`,
+        });
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(
+    `\n✗ Example excerpt check failed: ${failures.length}/${blockCount} block(s) do not match their source\n`,
+  );
+  for (const failure of failures) {
+    console.error(`  ${failure.file} (block ${failure.block})`);
+    console.error(`      ${failure.message}\n`);
+  }
+  process.exit(1);
+}
+
+console.log(`✓ Example excerpt check passed: ${blockCount} block(s) match their source`);

--- a/website/scripts/typecheck-docs.ts
+++ b/website/scripts/typecheck-docs.ts
@@ -1,0 +1,89 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { twoslasher } from '../src/twoslash/twoslasher';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const websiteDir = path.resolve(__dirname, '..');
+
+// Both the English docs and the Japanese translation carry the same code
+// blocks, so a wrong API name has to be caught in both trees. The `examples/`
+// docs are deliberately excluded here: their blocks are verbatim excerpts of
+// the real example apps (which are type-checked on their own) and are verified
+// by check-example-excerpts.ts instead of being re-type-checked in isolation.
+const TARGET_DIRS = ['docs', 'i18n/ja/docusaurus-plugin-content-docs/current'];
+
+// Skip any markdown that lives under an `examples/` segment (the Japanese
+// example docs sit inside the i18n docs tree). Those are excerpt-checked.
+const isExampleDoc = (relPath: string): boolean => relPath.split(path.sep).includes('examples');
+
+// Matches the fences that the Docusaurus build runs through Twoslash
+// (remark-twoslash-block uses explicitTrigger: false, so the `twoslash`
+// keyword is optional — every TS fence is type-checked).
+const TS_FENCE = /```(ts|tsx|typescript|typescriptreact)(?: twoslash)?\n([\s\S]*?)```/g;
+
+const langFor = (fence: string): 'ts' | 'tsx' =>
+  fence === 'tsx' || fence === 'typescriptreact' ? 'tsx' : 'ts';
+
+const walkMarkdown = (dir: string, acc: string[] = []): string[] => {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === 'node_modules' || entry === 'build' || entry === '.docusaurus') continue;
+      walkMarkdown(full, acc);
+    } else if (/\.mdx?$/.test(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+};
+
+type Failure = { file: string; block: number; message: string };
+
+const compilerErrorLines = (message: string): string[] =>
+  message
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /^\[\d+]/.test(line));
+
+const failures: Failure[] = [];
+let blockCount = 0;
+
+for (const targetDir of TARGET_DIRS) {
+  const absDir = path.join(websiteDir, targetDir);
+  for (const file of walkMarkdown(absDir)) {
+    if (isExampleDoc(path.relative(websiteDir, file))) continue;
+    const markdown = readFileSync(file, 'utf8');
+    let blockIndex = 0;
+    for (const match of markdown.matchAll(TS_FENCE)) {
+      blockIndex += 1;
+      blockCount += 1;
+      const code = match[2];
+      try {
+        twoslasher(code, langFor(match[1]));
+      } catch (error) {
+        const message = (error as Error).message;
+        const errors = compilerErrorLines(message);
+        failures.push({
+          file: path.relative(websiteDir, file),
+          block: blockIndex,
+          message: errors.length > 0 ? errors.join('\n      ') : message.split('\n')[0],
+        });
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(
+    `\n✗ Doc type-check failed: ${failures.length}/${blockCount} block(s) have errors\n`,
+  );
+  for (const failure of failures) {
+    console.error(`  ${failure.file} (block ${failure.block})`);
+    console.error(`      ${failure.message}\n`);
+  }
+  process.exit(1);
+}
+
+console.log(`✓ Doc type-check passed: ${blockCount} block(s) OK`);

--- a/website/src/remark/remark-twoslash-block.ts
+++ b/website/src/remark/remark-twoslash-block.ts
@@ -100,10 +100,17 @@ export const remarkTwoslashBlock = (options: RemarkTwoslashBlockOptions) => {
     for (const { node, parent, index } of codeNodes) {
       const lang = node.lang as string;
       const code = node.value as string;
+      const meta = (node.meta as string | null) ?? '';
 
       if (!langs.includes(lang)) continue;
 
       if (!isTypeScriptLang(lang)) continue;
+
+      // Example excerpts (```ts source=...```) are verbatim slices of real
+      // example apps validated by check-example-excerpts.ts. They reference
+      // sibling modules that don't resolve in the isolated twoslash VFS, so
+      // render them as plain highlighted code instead of type-checking them.
+      if (/\bsource=/.test(meta)) continue;
 
       let twoslashHtml: string | null = null;
       let plainCodeHtml: string | null = null;

--- a/website/src/twoslash/twoslasher.ts
+++ b/website/src/twoslash/twoslasher.ts
@@ -1,0 +1,53 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createTwoslasher } from 'twoslash';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// src/twoslash -> website -> repo root
+const rootDir = path.resolve(__dirname, '../../..');
+const tsLibDirectory = path.resolve(rootDir, 'node_modules/typescript/lib');
+
+/**
+ * Shared Twoslash instance used both by the Docusaurus build (to render
+ * type-checked code blocks) and by `scripts/typecheck-docs.ts` (to fail CI
+ * when a doc snippet stops type-checking). Keeping a single instance prevents
+ * the compilerOptions/paths from drifting between rendering and verification.
+ */
+export const twoslasher = createTwoslasher({
+  vfsRoot: rootDir,
+  tsLibDirectory,
+  compilerOptions: {
+    // module: ESNext + moduleResolution: Bundler — matches how the docs are
+    // authored (bare specifiers, `paths` aliases, top-level await). The
+    // previous ESNext + NodeNext pairing is rejected by tsc (TS5110), which
+    // silently broke type-checking for every block.
+    module: 99, // ESNext
+    moduleResolution: 100, // Bundler
+    target: 99, // ESNext
+    lib: ['lib.esnext.full.d.ts'],
+    strict: true,
+    esModuleInterop: true,
+    skipLibCheck: true,
+    baseUrl: rootDir,
+    // @zeltjs/* packages: resolved via explicit paths because pnpm's strict
+    // node_modules structure doesn't work with Twoslash VFS.
+    // Corresponding devDependencies in package.json ensure nx builds them first.
+    paths: {
+      '@zeltjs/validator-valibot': ['./packages/validator-valibot/dist/index.d.ts'],
+      '@zeltjs/kv/adaptor-redis': ['./packages/kv/dist/adaptor-redis/index.d.ts'],
+      '@zeltjs/redis/testing': ['./packages/redis/dist/testing/index.d.ts'],
+      '@zeltjs/testing/vitest': ['./packages/testing/dist/adapters/vitest.d.ts'],
+      '@zeltjs/testing/jest': ['./packages/testing/dist/adapters/jest.d.ts'],
+      '@zeltjs/testing/bun': ['./packages/testing/dist/adapters/bun.d.ts'],
+      '@zeltjs/testing/node': ['./packages/testing/dist/adapters/node.d.ts'],
+      '@zeltjs/*': ['./packages/*/dist/index.d.ts'],
+      valibot: [
+        './node_modules/.pnpm/valibot@1.0.0_typescript@6.0.2/node_modules/valibot/dist/index.d.ts',
+      ],
+      hono: ['./node_modules/.pnpm/hono@4.12.16/node_modules/hono/dist/types/index.d.ts'],
+      'hono/*': ['./node_modules/.pnpm/hono@4.12.16/node_modules/hono/dist/types/*.d.ts'],
+      ioredis: ['./node_modules/.pnpm/ioredis@5.10.1/node_modules/ioredis/built/index.d.ts'],
+      bullmq: ['./node_modules/.pnpm/bullmq@5.76.9/node_modules/bullmq/dist/esm/index.d.ts'],
+    },
+  },
+});

--- a/website/src/twoslash/twoslasher.ts
+++ b/website/src/twoslash/twoslasher.ts
@@ -1,3 +1,4 @@
+import { existsSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createTwoslasher } from 'twoslash';
@@ -6,6 +7,21 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // src/twoslash -> website -> repo root
 const rootDir = path.resolve(__dirname, '../../..');
 const tsLibDirectory = path.resolve(rootDir, 'node_modules/typescript/lib');
+
+// Resolve a third-party package's types through pnpm's content-addressed store
+// by prefix instead of hard-coding the (peer-hashed) version directory. The
+// hard-coded path drifts on every dependency bump and only happens to resolve
+// in a non-clean node_modules, which silently breaks type-checking on a fresh
+// install (CI, new worktree).
+const pnpmModulesDir = path.join(rootDir, 'node_modules/.pnpm');
+const pnpmEntries = existsSync(pnpmModulesDir) ? readdirSync(pnpmModulesDir) : [];
+const pnpmTypes = (prefix: string, subpath: string): string[] => {
+  const match = pnpmEntries
+    .filter((dir) => dir.startsWith(prefix))
+    .sort()
+    .pop();
+  return match ? [`./node_modules/.pnpm/${match}/node_modules/${subpath}`] : [];
+};
 
 /**
  * Shared Twoslash instance used both by the Docusaurus build (to render
@@ -41,13 +57,11 @@ export const twoslasher = createTwoslasher({
       '@zeltjs/testing/bun': ['./packages/testing/dist/adapters/bun.d.ts'],
       '@zeltjs/testing/node': ['./packages/testing/dist/adapters/node.d.ts'],
       '@zeltjs/*': ['./packages/*/dist/index.d.ts'],
-      valibot: [
-        './node_modules/.pnpm/valibot@1.0.0_typescript@6.0.2/node_modules/valibot/dist/index.d.ts',
-      ],
-      hono: ['./node_modules/.pnpm/hono@4.12.16/node_modules/hono/dist/types/index.d.ts'],
-      'hono/*': ['./node_modules/.pnpm/hono@4.12.16/node_modules/hono/dist/types/*.d.ts'],
-      ioredis: ['./node_modules/.pnpm/ioredis@5.10.1/node_modules/ioredis/built/index.d.ts'],
-      bullmq: ['./node_modules/.pnpm/bullmq@5.76.9/node_modules/bullmq/dist/esm/index.d.ts'],
+      valibot: pnpmTypes('valibot@', 'valibot/dist/index.d.mts'),
+      hono: pnpmTypes('hono@', 'hono/dist/types/index.d.ts'),
+      'hono/*': pnpmTypes('hono@', 'hono/dist/types/*.d.ts'),
+      ioredis: pnpmTypes('ioredis@', 'ioredis/built/index.d.ts'),
+      bullmq: pnpmTypes('bullmq@', 'bullmq/dist/esm/index.d.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary

Documentation code had drifted from the real public API and from the example apps. This aligns the docs with the implementation and adds gates so they cannot silently drift again.

### Docs aligned to the public API
- KV / Redis / session / rate-limit / auth / DI pages rewritten to use the real exports (`RedisKVAdaptor`, `Lifecycle`, `kvStoreNamespace`, decorators from `decorator-metadata`, ...).
- Shared twoslash config (`website/src/twoslash/twoslasher.ts`) so every doc TS fence is type-checked against the built package types.

### Example apps: restored type safety
- `drizzle-todo`: migrate `DrizzleService` from the removed `Disposable` to the public `Lifecycle` (startup/shutdown + `LifecycleManager` registration); fix an `exactOptionalPropertyTypes` mismatch on `update()`; return a raw `204` `Response`.
- `hello`: mark the validation issues array as `readonly` to match the public type.
- Add a `typecheck` script to every example.

### Example docs are now verbatim excerpts
- Each example page's TS fence declares `source=<path>` and is verified to be a contiguous excerpt of the real, separately type-checked example source (`website/scripts/check-example-excerpts.ts`). Those fences render as plain code instead of being type-checked in isolation.

### Gates
- `@examples/* typecheck` and website `verify:docs` (twoslash doc type-check + excerpt match) now run in the `precommit` chain (local + CI); bun setup added to the CI job.

## Verification
- `pnpm run precommit` green (build, 647 tests, examples typecheck, verify:docs).
- `typecheck:docs`: 567 blocks OK · `check:examples`: 10 blocks match source.
- `docusaurus build` succeeds; `source=` meta does not leak into rendered HTML and example blocks render as plain highlighted code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782642013&installation_id=133048706&pr_number=239&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F239&signature=7be2ff06d28a879a47b9d261e41425c1f364d018fd408763db86b2687e887875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * サンプルアプリ（Drizzle Todo、URL短縮）にCRUD拡張とアクセス統計（ヒット数）APIを追加

* **改善**
  * リソース管理をライフサイクル方式へ移行し起動/終了の安定性を向上
  * 型シグネチャの微調整とレスポンス生成の扱いを整理

* **CI／開発環境**
  * CIワークフローに追加のランタイムセットアップとドキュメント・型チェックを統合

* **ドキュメント**
  * 多数のガイドやコード例を更新し、例の整合性チェックと型検証を導入

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->