### PR TITLE
fix(hono-client): fix type-system bugs in BuildSchema and WrapRaw

### DIFF
--- a/packages/hono-client/src/func2hono.types.test.ts
+++ b/packages/hono-client/src/func2hono.types.test.ts
@@ -1,0 +1,78 @@
+import type { hc } from 'hono/client';
+import { describe, expectTypeOf, it } from 'vitest';
+import type { BuildAppType, Route } from './func2hono.types.js';
+
+type DummyHandler = () => Promise<{ id: string }>;
+
+// 50 routes to verify no TS2589
+type ManyRoutes = BuildAppType<
+  [
+    Route<'GET', '/r01', DummyHandler>,
+    Route<'GET', '/r02', DummyHandler>,
+    Route<'GET', '/r03', DummyHandler>,
+    Route<'GET', '/r04', DummyHandler>,
+    Route<'GET', '/r05', DummyHandler>,
+    Route<'GET', '/r06', DummyHandler>,
+    Route<'GET', '/r07', DummyHandler>,
+    Route<'GET', '/r08', DummyHandler>,
+    Route<'GET', '/r09', DummyHandler>,
+    Route<'GET', '/r10', DummyHandler>,
+    Route<'GET', '/r11', DummyHandler>,
+    Route<'GET', '/r12', DummyHandler>,
+    Route<'GET', '/r13', DummyHandler>,
+    Route<'GET', '/r14', DummyHandler>,
+    Route<'GET', '/r15', DummyHandler>,
+    Route<'GET', '/r16', DummyHandler>,
+    Route<'GET', '/r17', DummyHandler>,
+    Route<'GET', '/r18', DummyHandler>,
+    Route<'GET', '/r19', DummyHandler>,
+    Route<'GET', '/r20', DummyHandler>,
+    Route<'GET', '/r21', DummyHandler>,
+    Route<'GET', '/r22', DummyHandler>,
+    Route<'GET', '/r23', DummyHandler>,
+    Route<'GET', '/r24', DummyHandler>,
+    Route<'GET', '/r25', DummyHandler>,
+    Route<'GET', '/r26', DummyHandler>,
+    Route<'GET', '/r27', DummyHandler>,
+    Route<'GET', '/r28', DummyHandler>,
+    Route<'GET', '/r29', DummyHandler>,
+    Route<'GET', '/r30', DummyHandler>,
+    Route<'GET', '/r31', DummyHandler>,
+    Route<'GET', '/r32', DummyHandler>,
+    Route<'GET', '/r33', DummyHandler>,
+    Route<'GET', '/r34', DummyHandler>,
+    Route<'GET', '/r35', DummyHandler>,
+    Route<'GET', '/r36', DummyHandler>,
+    Route<'GET', '/r37', DummyHandler>,
+    Route<'GET', '/r38', DummyHandler>,
+    Route<'GET', '/r39', DummyHandler>,
+    Route<'GET', '/r40', DummyHandler>,
+    Route<'GET', '/r41', DummyHandler>,
+    Route<'GET', '/r42', DummyHandler>,
+    Route<'GET', '/r43', DummyHandler>,
+    Route<'GET', '/r44', DummyHandler>,
+    Route<'GET', '/r45', DummyHandler>,
+    Route<'POST', '/r01', DummyHandler>,
+    Route<'PUT', '/r01', DummyHandler>,
+    Route<'DELETE', '/r01', DummyHandler>,
+    Route<'PATCH', '/r01', DummyHandler>,
+    Route<'POST', '/r45', DummyHandler>,
+  ]
+>;
+
+type Client = ReturnType<typeof hc<ManyRoutes>>;
+
+describe('BuildSchema recursion depth', () => {
+  it('handles 50 routes without TS2589', () => {
+    expectTypeOf<Client['r01']['$get']>().toBeFunction();
+    expectTypeOf<Client['r45']['$get']>().toBeFunction();
+  });
+
+  it('merges multiple methods on the same path', () => {
+    expectTypeOf<Client['r01']['$get']>().toBeFunction();
+    expectTypeOf<Client['r01']['$post']>().toBeFunction();
+    expectTypeOf<Client['r01']['$put']>().toBeFunction();
+    expectTypeOf<Client['r01']['$delete']>().toBeFunction();
+    expectTypeOf<Client['r01']['$patch']>().toBeFunction();
+  });
+});

--- a/packages/hono-client/src/func2hono.types.test.ts
+++ b/packages/hono-client/src/func2hono.types.test.ts
@@ -1,6 +1,7 @@
 import type { hc } from 'hono/client';
+import type { TypedResponse } from 'hono/types';
 import { describe, expectTypeOf, it } from 'vitest';
-import type { BuildAppType, Route } from './func2hono.types.js';
+import type { BuildAppType, ExtractResponse, Route } from './func2hono.types.js';
 
 type DummyHandler = () => Promise<{ id: string }>;
 
@@ -74,5 +75,16 @@ describe('BuildSchema recursion depth', () => {
     expectTypeOf<Client['r01']['$put']>().toBeFunction();
     expectTypeOf<Client['r01']['$delete']>().toBeFunction();
     expectTypeOf<Client['r01']['$patch']>().toBeFunction();
+  });
+});
+
+describe('WrapRaw distribution', () => {
+  it('does not distribute union return types', () => {
+    type UnionHandler = () => Promise<{ ok: true; data: string } | { ok: false; err: string }>;
+    type Result = ExtractResponse<UnionHandler>;
+
+    expectTypeOf<Result>().toEqualTypeOf<
+      TypedResponse<{ ok: true; data: string } | { ok: false; err: string }, 200, 'json'>
+    >();
   });
 });

--- a/packages/hono-client/src/func2hono.types.ts
+++ b/packages/hono-client/src/func2hono.types.ts
@@ -29,9 +29,9 @@ export type ExtractRequestBody<H extends (...args: never[]) => unknown> = H exte
   : never;
 
 type WrapRaw<T> =
-  T extends TypedResponse<infer _D, infer _S extends StatusCode, infer _F extends string>
+  [T] extends [TypedResponse<infer _D, infer _S extends StatusCode, infer _F extends string>]
     ? T
-    : T extends Response
+    : [T] extends [Response]
       ? never
       : TypedResponse<T, 200, 'json'>;
 

--- a/packages/hono-client/src/func2hono.types.ts
+++ b/packages/hono-client/src/func2hono.types.ts
@@ -28,12 +28,13 @@ export type ExtractRequestBody<H extends (...args: never[]) => unknown> = H exte
     : ExtractValidated<A0>
   : never;
 
-type WrapRaw<T> =
-  [T] extends [TypedResponse<infer _D, infer _S extends StatusCode, infer _F extends string>]
-    ? T
-    : [T] extends [Response]
-      ? never
-      : TypedResponse<T, 200, 'json'>;
+type WrapRaw<T> = [T] extends [
+  TypedResponse<infer _D, infer _S extends StatusCode, infer _F extends string>,
+]
+  ? T
+  : [T] extends [Response]
+    ? never
+    : TypedResponse<T, 200, 'json'>;
 
 export type ExtractResponse<H extends (...args: never[]) => unknown> = WrapRaw<
   Awaited<ReturnType<H>>

--- a/packages/hono-client/src/func2hono.types.ts
+++ b/packages/hono-client/src/func2hono.types.ts
@@ -101,31 +101,25 @@ type RouteMethodEntry<
   } & RouteResponseEndpoints<R['response']>;
 };
 
-type Merge<A, B> = {
-  [K in keyof A | keyof B]: K extends keyof A
-    ? K extends keyof B
-      ? A[K] & B[K]
-      : A[K]
-    : K extends keyof B
-      ? B[K]
-      : never;
-};
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends (
+  x: infer I,
+) => void
+  ? I
+  : never;
 
-type BuildSchema<Routes extends readonly unknown[]> = Routes extends readonly [
-  infer Head,
-  ...infer Tail,
-]
-  ? Head extends {
-      method: string;
-      path: infer P extends string;
-      params: unknown;
-      body: unknown;
-      response: unknown;
-    }
-    ? Merge<{ [K in P]: RouteMethodEntry<Head & { method: string }> }, BuildSchema<Tail>>
-    : BuildSchema<Tail>
-  : // biome-ignore lint/complexity/noBannedTypes: {} is required here
-    {};
+type RouteToSchema<R> = R extends {
+  method: string;
+  path: infer P extends string;
+  params: unknown;
+  body: unknown;
+  response: unknown;
+}
+  ? { [K in P]: RouteMethodEntry<R & { method: string }> }
+  : never;
+
+type BuildSchema<Routes extends readonly unknown[]> = UnionToIntersection<
+  RouteToSchema<Routes[number]>
+>;
 
 export type BuildAppType<
   Routes extends readonly { readonly method: string; readonly path: string }[],


### PR DESCRIPTION
## Summary

- **BuildSchema recursion (TS2589)**: Replaced `[Head, ...Tail]` recursive pattern with `UnionToIntersection<RouteToSchema<...>>` mapped type approach, reducing recursion depth from O(N) to O(1). This fixes TS2589 errors when `AppType` has 45+ routes.
- **WrapRaw union distribution**: Wrapped conditional checks in `[T]` tuple to suppress distributive behavior. Union return types like `{ok: true} | {ok: false}` now correctly resolve to a single `TypedResponse` instead of splitting into separate entries.

## Test plan

- [x] Type-level test: 50 routes with `hc<AppType>()` — no TS2589
- [x] Type-level test: multiple methods on same path merge correctly
- [x] Type-level test: union return type produces single `TypedResponse`
- [x] All existing hono-client tests pass
- [x] Full project `tsc --noEmit` passes
- [x] `pnpm precommit` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782696240&installation_id=133048706&pr_number=241&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F241&signature=99d57d94e12f34882453156662c3045234b60a73ba40ed730b23901fe664ab74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 大規模なルート／複数メソッド構成やユニオン応答を含む型レベルの検証テストを追加し、クライアント型が期待通り生成されることを確認

* **Bug Fixes**
  * 型推論の振る舞いを改善し、複雑な構成での型計算エラーを回避、複数メソッドの合成とユニオン応答の収束を安定化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->