### PR TITLE
feat: EC backend dogfooding app with module-based App type

### DIFF
--- a/integration/ec-backend/e2e/auth.spec.ts
+++ b/integration/ec-backend/e2e/auth.spec.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  type TestApp,
+  authRequest,
+  createTestApp,
+  loginUser,
+  registerUser,
+  seedAdmin,
+  shutdownAll,
+} from './helpers/test-setup';
+
+describe('Auth API', () => {
+  let testApp: TestApp;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await shutdownAll();
+  });
+
+  describe('POST /api/auth/register', () => {
+    // Validation tests first (count toward rate limit: 3/min for register)
+    it('rejects invalid email', async () => {
+      const { res } = await registerUser(testApp, {
+        email: 'not-an-email',
+        password: 'password123',
+        name: 'Bad Email',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects short password', async () => {
+      const { res } = await registerUser(testApp, {
+        email: 'short@example.com',
+        password: '123',
+        name: 'Short Pass',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('registers a new user', async () => {
+      const { res, body } = await registerUser(testApp, {
+        email: 'user@example.com',
+        password: 'password123',
+        name: 'Test User',
+      });
+      expect(res.status).toBe(200);
+      expect(body.id).toBeDefined();
+      expect(body.email).toBe('user@example.com');
+      expect(body.name).toBe('Test User');
+      expect(body.passwordHash).toBeUndefined();
+    });
+  });
+
+  describe('POST /api/auth/login', () => {
+    it('logs in with valid credentials', async () => {
+      const { res, body } = await loginUser(testApp, {
+        email: 'user@example.com',
+        password: 'password123',
+      });
+      expect(res.status).toBe(200);
+      expect(body.token).toBeDefined();
+      expect(typeof body.token).toBe('string');
+    });
+
+    it('rejects wrong password', async () => {
+      const res = await testApp.request('/api/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'user@example.com', password: 'wrong-password' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects non-existent user', async () => {
+      const res = await testApp.request('/api/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'nobody@example.com', password: 'password123' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/auth/me', () => {
+    it('returns profile with valid token', async () => {
+      const { body: loginBody } = await loginUser(testApp, {
+        email: 'user@example.com',
+        password: 'password123',
+      });
+
+      const res = await authRequest(testApp, loginBody.token, 'GET', '/api/auth/me');
+      expect(res.status).toBe(200);
+
+      const profile = await res.json();
+      expect(profile.email).toBe('user@example.com');
+      expect(profile.name).toBe('Test User');
+      expect(profile.role).toBe('user');
+    });
+
+    it('returns 401 without token', async () => {
+      const res = await testApp.request('/api/auth/me');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with invalid token', async () => {
+      const res = await authRequest(testApp, 'invalid-token', 'GET', '/api/auth/me');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/auth/register (duplicate)', () => {
+    it('rejects duplicate email', async () => {
+      // This is a separate describe to manage rate limit ordering
+      // user@example.com was registered in the previous describe block
+      const res = await testApp.request('/api/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: 'user@example.com',
+          password: 'another-password',
+          name: 'Duplicate User',
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      // May be 409 or 429 depending on rate limit state
+      expect([409, 429]).toContain(res.status);
+    });
+  });
+
+  describe('Product write authorization', () => {
+    let authApp: TestApp;
+    let adminToken: string;
+    let userToken: string;
+
+    beforeAll(async () => {
+      authApp = await createTestApp();
+      adminToken = await seedAdmin(authApp);
+
+      await registerUser(authApp, {
+        email: 'user-auth@example.com',
+        password: 'password123',
+        name: 'Auth Test User',
+      });
+      const { body } = await loginUser(authApp, {
+        email: 'user-auth@example.com',
+        password: 'password123',
+      });
+      userToken = body.token;
+    });
+
+    const productData = {
+      name: 'Auth Test Product',
+      description: 'Testing authorization',
+      price: 999,
+      category: 'test',
+      stock: 10,
+    };
+
+    it('admin can create products', async () => {
+      const res = await authRequest(authApp, adminToken, 'POST', '/api/products', productData);
+      expect(res.status).toBe(201);
+    });
+
+    it('regular user cannot create products', async () => {
+      const res = await authRequest(authApp, userToken, 'POST', '/api/products', productData);
+      expect(res.status).toBe(403);
+    });
+
+    it('unauthenticated cannot create products', async () => {
+      const res = await authApp.request('/api/products', {
+        method: 'POST',
+        body: JSON.stringify(productData),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('admin can update products', async () => {
+      const createRes = await authRequest(authApp, adminToken, 'POST', '/api/products', productData);
+      const created = await createRes.json();
+
+      const res = await authRequest(authApp, adminToken, 'PUT', `/api/products/${created.id}`, {
+        name: 'Updated',
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('admin can delete products', async () => {
+      const createRes = await authRequest(authApp, adminToken, 'POST', '/api/products', productData);
+      const created = await createRes.json();
+
+      const res = await authRequest(authApp, adminToken, 'DELETE', `/api/products/${created.id}`);
+      expect(res.status).toBe(200);
+    });
+
+    it('regular user cannot delete products', async () => {
+      const createRes = await authRequest(authApp, adminToken, 'POST', '/api/products', productData);
+      const created = await createRes.json();
+
+      const res = await authRequest(authApp, userToken, 'DELETE', `/api/products/${created.id}`);
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/integration/ec-backend/e2e/auth.spec.ts
+++ b/integration/ec-backend/e2e/auth.spec.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-
+import type { TestApp } from './helpers/test-setup';
 import {
-  type TestApp,
   authRequest,
   createTestApp,
   loginUser,
@@ -179,7 +178,13 @@ describe('Auth API', () => {
     });
 
     it('admin can update products', async () => {
-      const createRes = await authRequest(authApp, adminToken, 'POST', '/api/products', productData);
+      const createRes = await authRequest(
+        authApp,
+        adminToken,
+        'POST',
+        '/api/products',
+        productData,
+      );
       const created = await createRes.json();
 
       const res = await authRequest(authApp, adminToken, 'PUT', `/api/products/${created.id}`, {
@@ -189,7 +194,13 @@ describe('Auth API', () => {
     });
 
     it('admin can delete products', async () => {
-      const createRes = await authRequest(authApp, adminToken, 'POST', '/api/products', productData);
+      const createRes = await authRequest(
+        authApp,
+        adminToken,
+        'POST',
+        '/api/products',
+        productData,
+      );
       const created = await createRes.json();
 
       const res = await authRequest(authApp, adminToken, 'DELETE', `/api/products/${created.id}`);
@@ -197,7 +208,13 @@ describe('Auth API', () => {
     });
 
     it('regular user cannot delete products', async () => {
-      const createRes = await authRequest(authApp, adminToken, 'POST', '/api/products', productData);
+      const createRes = await authRequest(
+        authApp,
+        adminToken,
+        'POST',
+        '/api/products',
+        productData,
+      );
       const created = await createRes.json();
 
       const res = await authRequest(authApp, userToken, 'DELETE', `/api/products/${created.id}`);

--- a/integration/ec-backend/e2e/cart.spec.ts
+++ b/integration/ec-backend/e2e/cart.spec.ts
@@ -1,0 +1,203 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  type TestApp,
+  authRequest,
+  createTestApp,
+  loginUser,
+  registerUser,
+  seedAdmin,
+  shutdownAll,
+} from './helpers/test-setup';
+
+describe('Cart API', () => {
+  let testApp: TestApp;
+  let userToken: string;
+  let adminToken: string;
+  let productId: number;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+    adminToken = await seedAdmin(testApp);
+
+    await registerUser(testApp, {
+      email: 'shopper@example.com',
+      password: 'shopper-pass123',
+      name: 'Shopper',
+    });
+    const { body } = await loginUser(testApp, {
+      email: 'shopper@example.com',
+      password: 'shopper-pass123',
+    });
+    userToken = body.token;
+
+    const productRes = await authRequest(testApp, adminToken, 'POST', '/api/products', {
+      name: 'Cart Test Product',
+      description: 'For cart tests',
+      price: 1500,
+      category: 'electronics',
+      stock: 20,
+    });
+    const product = await productRes.json();
+    productId = product.id;
+  });
+
+  afterAll(async () => {
+    await shutdownAll();
+  });
+
+  describe('GET /api/cart', () => {
+    it('returns empty cart initially', async () => {
+      const res = await authRequest(testApp, userToken, 'GET', '/api/cart');
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.items).toEqual([]);
+      expect(body.total).toBe(0);
+    });
+
+    it('requires authentication', async () => {
+      const res = await testApp.request('/api/cart');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/cart/items', () => {
+    it('adds item to cart', async () => {
+      const res = await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId,
+        quantity: 2,
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].productId).toBe(productId);
+      expect(body.items[0].quantity).toBe(2);
+      expect(body.items[0].price).toBe(1500);
+    });
+
+    it('increases quantity when adding same product', async () => {
+      const res = await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId,
+        quantity: 3,
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].quantity).toBe(5);
+    });
+
+    it('rejects non-existent product', async () => {
+      const res = await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId: 99999,
+        quantity: 1,
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('rejects quantity exceeding stock', async () => {
+      const res = await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId,
+        quantity: 100,
+      });
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe('PUT /api/cart/items/:productId', () => {
+    it('updates item quantity', async () => {
+      const res = await authRequest(
+        testApp,
+        userToken,
+        'PUT',
+        `/api/cart/items/${productId}`,
+        { quantity: 1 },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.items[0].quantity).toBe(1);
+    });
+
+    it('removes item when quantity is 0', async () => {
+      const res = await authRequest(
+        testApp,
+        userToken,
+        'PUT',
+        `/api/cart/items/${productId}`,
+        { quantity: 0 },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.items).toHaveLength(0);
+    });
+  });
+
+  describe('DELETE /api/cart/items/:productId', () => {
+    it('removes item from cart', async () => {
+      await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId,
+        quantity: 3,
+      });
+
+      const res = await authRequest(
+        testApp,
+        userToken,
+        'DELETE',
+        `/api/cart/items/${productId}`,
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.items).toHaveLength(0);
+    });
+  });
+
+  describe('DELETE /api/cart', () => {
+    it('clears the cart', async () => {
+      await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId,
+        quantity: 2,
+      });
+
+      const clearRes = await authRequest(testApp, userToken, 'DELETE', '/api/cart');
+      expect(clearRes.status).toBe(200);
+
+      const cartRes = await authRequest(testApp, userToken, 'GET', '/api/cart');
+      const body = await cartRes.json();
+      expect(body.items).toEqual([]);
+    });
+  });
+
+  describe('User scope isolation', () => {
+    it('different users have separate carts', async () => {
+      await registerUser(testApp, {
+        email: 'other-shopper@example.com',
+        password: 'other-pass123',
+        name: 'Other Shopper',
+      });
+      const { body: otherLogin } = await loginUser(testApp, {
+        email: 'other-shopper@example.com',
+        password: 'other-pass123',
+      });
+      const otherToken = otherLogin.token;
+
+      await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId,
+        quantity: 5,
+      });
+
+      const otherCart = await authRequest(testApp, otherToken, 'GET', '/api/cart');
+      const otherBody = await otherCart.json();
+      expect(otherBody.items).toEqual([]);
+
+      const myCart = await authRequest(testApp, userToken, 'GET', '/api/cart');
+      const myBody = await myCart.json();
+      expect(myBody.items).toHaveLength(1);
+      expect(myBody.items[0].quantity).toBe(5);
+    });
+  });
+});

--- a/integration/ec-backend/e2e/cart.spec.ts
+++ b/integration/ec-backend/e2e/cart.spec.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-
+import type { TestApp } from './helpers/test-setup';
 import {
-  type TestApp,
   authRequest,
   createTestApp,
   loginUser,
@@ -108,13 +107,9 @@ describe('Cart API', () => {
 
   describe('PUT /api/cart/items/:productId', () => {
     it('updates item quantity', async () => {
-      const res = await authRequest(
-        testApp,
-        userToken,
-        'PUT',
-        `/api/cart/items/${productId}`,
-        { quantity: 1 },
-      );
+      const res = await authRequest(testApp, userToken, 'PUT', `/api/cart/items/${productId}`, {
+        quantity: 1,
+      });
       expect(res.status).toBe(200);
 
       const body = await res.json();
@@ -122,13 +117,9 @@ describe('Cart API', () => {
     });
 
     it('removes item when quantity is 0', async () => {
-      const res = await authRequest(
-        testApp,
-        userToken,
-        'PUT',
-        `/api/cart/items/${productId}`,
-        { quantity: 0 },
-      );
+      const res = await authRequest(testApp, userToken, 'PUT', `/api/cart/items/${productId}`, {
+        quantity: 0,
+      });
       expect(res.status).toBe(200);
 
       const body = await res.json();
@@ -143,12 +134,7 @@ describe('Cart API', () => {
         quantity: 3,
       });
 
-      const res = await authRequest(
-        testApp,
-        userToken,
-        'DELETE',
-        `/api/cart/items/${productId}`,
-      );
+      const res = await authRequest(testApp, userToken, 'DELETE', `/api/cart/items/${productId}`);
       expect(res.status).toBe(200);
 
       const body = await res.json();

--- a/integration/ec-backend/e2e/full-flow.spec.ts
+++ b/integration/ec-backend/e2e/full-flow.spec.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-
+import type { TestApp } from './helpers/test-setup';
 import {
-  type TestApp,
   authRequest,
   createTestApp,
   loginUser,

--- a/integration/ec-backend/e2e/full-flow.spec.ts
+++ b/integration/ec-backend/e2e/full-flow.spec.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  type TestApp,
+  authRequest,
+  createTestApp,
+  loginUser,
+  registerUser,
+  seedAdmin,
+  shutdownAll,
+} from './helpers/test-setup';
+
+describe('Full EC Flow', () => {
+  let testApp: TestApp;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await shutdownAll();
+  });
+
+  it('completes a full user journey: register → login → browse → cart → order', async () => {
+    // 1. Admin creates products
+    const adminToken = await seedAdmin(testApp);
+
+    const laptop = await authRequest(testApp, adminToken, 'POST', '/api/products', {
+      name: 'Laptop Pro',
+      description: 'High-performance laptop',
+      price: 150000,
+      category: 'electronics',
+      stock: 5,
+    }).then((r) => r.json());
+
+    const keyboard = await authRequest(testApp, adminToken, 'POST', '/api/products', {
+      name: 'Mechanical Keyboard',
+      description: 'Cherry MX switches',
+      price: 12000,
+      category: 'electronics',
+      stock: 20,
+    }).then((r) => r.json());
+
+    // 2. User registers
+    const { body: regBody } = await registerUser(testApp, {
+      email: 'customer@example.com',
+      password: 'customer-pass123',
+      name: 'Customer',
+    });
+    expect(regBody.email).toBe('customer@example.com');
+
+    // 3. User logs in
+    const { body: loginBody } = await loginUser(testApp, {
+      email: 'customer@example.com',
+      password: 'customer-pass123',
+    });
+    const token = loginBody.token;
+    expect(token).toBeDefined();
+
+    // 4. Browse products (public)
+    const productsRes = await testApp.request('/api/products');
+    const products = await productsRes.json();
+    expect(products.items.length).toBeGreaterThanOrEqual(2);
+
+    // 5. Add items to cart
+    await authRequest(testApp, token, 'POST', '/api/cart/items', {
+      productId: laptop.id,
+      quantity: 1,
+    });
+    await authRequest(testApp, token, 'POST', '/api/cart/items', {
+      productId: keyboard.id,
+      quantity: 2,
+    });
+
+    // Verify cart
+    const cartRes = await authRequest(testApp, token, 'GET', '/api/cart');
+    const cart = await cartRes.json();
+    expect(cart.items).toHaveLength(2);
+    expect(cart.total).toBe(150000 + 12000 * 2);
+
+    // 6. Create order from cart
+    const orderRes = await authRequest(testApp, token, 'POST', '/api/orders');
+    expect(orderRes.status).toBe(201);
+    const order = await orderRes.json();
+    expect(order.totalPrice).toBe(150000 + 12000 * 2);
+    expect(order.status).toBe('confirmed');
+
+    // 7. Verify cart is empty
+    const emptyCartRes = await authRequest(testApp, token, 'GET', '/api/cart');
+    const emptyCart = await emptyCartRes.json();
+    expect(emptyCart.items).toEqual([]);
+
+    // 8. Verify stock reduced
+    const laptopAfter = await testApp.request(`/api/products/${laptop.id}`).then((r) => r.json());
+    expect(laptopAfter.stock).toBe(4);
+
+    const keyboardAfter = await testApp
+      .request(`/api/products/${keyboard.id}`)
+      .then((r) => r.json());
+    expect(keyboardAfter.stock).toBe(18);
+
+    // 9. Verify order in list
+    const ordersRes = await authRequest(testApp, token, 'GET', '/api/orders');
+    const orders = await ordersRes.json();
+    expect(orders.items).toHaveLength(1);
+    expect(orders.items[0].id).toBe(order.id);
+
+    // 10. Verify order detail with items
+    const detailRes = await authRequest(testApp, token, 'GET', `/api/orders/${order.id}`);
+    const detail = await detailRes.json();
+    expect(detail.items).toHaveLength(2);
+  });
+});

--- a/integration/ec-backend/e2e/helpers/test-setup.ts
+++ b/integration/ec-backend/e2e/helpers/test-setup.ts
@@ -1,0 +1,78 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
+import { onTest, shutdownAll } from '@zeltjs/testing';
+
+import { createEcApp } from '../../src/app';
+
+export type TestApp = TestableApp<App<[HttpModule]>>;
+
+export const createTestApp = async () => {
+  const app = createEcApp();
+  return onTest(app);
+};
+
+export const registerUser = async (
+  app: TestApp,
+  data: { email: string; password: string; name: string },
+) => {
+  const res = await app.request('/api/auth/register', {
+    method: 'POST',
+    body: JSON.stringify(data),
+    headers: { 'Content-Type': 'application/json' },
+  });
+  return { res, body: await res.json() };
+};
+
+export const loginUser = async (
+  app: TestApp,
+  data: { email: string; password: string },
+) => {
+  const res = await app.request('/api/auth/login', {
+    method: 'POST',
+    body: JSON.stringify(data),
+    headers: { 'Content-Type': 'application/json' },
+  });
+  return { res, body: await res.json() };
+};
+
+export const seedAdmin = async (app: TestApp): Promise<string> => {
+  await registerUser(app, {
+    email: 'admin@example.com',
+    password: 'admin-password-123',
+    name: 'Admin User',
+  });
+
+  // Directly update role via drizzle
+  const drizzle = app.get(
+    (await import('../../src/db/drizzle.service')).DrizzleService,
+  );
+  const { users } = await import('../../src/db/schema');
+  const { eq } = await import('drizzle-orm');
+  drizzle.db.update(users).set({ role: 'admin' }).where(eq(users.email, 'admin@example.com')).run();
+
+  const { body } = await loginUser(app, {
+    email: 'admin@example.com',
+    password: 'admin-password-123',
+  });
+  return body.token;
+};
+
+export const authRequest = (
+  app: TestApp,
+  token: string,
+  method: string,
+  path: string,
+  body?: unknown,
+) => {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    init.body = JSON.stringify(body);
+  }
+  return app.request(path, init);
+};
+
+export { shutdownAll };

--- a/integration/ec-backend/e2e/helpers/test-setup.ts
+++ b/integration/ec-backend/e2e/helpers/test-setup.ts
@@ -23,10 +23,7 @@ export const registerUser = async (
   return { res, body: await res.json() };
 };
 
-export const loginUser = async (
-  app: TestApp,
-  data: { email: string; password: string },
-) => {
+export const loginUser = async (app: TestApp, data: { email: string; password: string }) => {
   const res = await app.request('/api/auth/login', {
     method: 'POST',
     body: JSON.stringify(data),
@@ -43,9 +40,7 @@ export const seedAdmin = async (app: TestApp): Promise<string> => {
   });
 
   // Directly update role via drizzle
-  const drizzle = app.get(
-    (await import('../../src/db/drizzle.service')).DrizzleService,
-  );
+  const drizzle = app.get((await import('../../src/db/drizzle.service')).DrizzleService);
   const { users } = await import('../../src/db/schema');
   const { eq } = await import('drizzle-orm');
   drizzle.db.update(users).set({ role: 'admin' }).where(eq(users.email, 'admin@example.com')).run();

--- a/integration/ec-backend/e2e/openapi.spec.ts
+++ b/integration/ec-backend/e2e/openapi.spec.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type { SchemaResolver } from '@zeltjs/openapi';
+import { generateOpenApi } from '@zeltjs/openapi';
+import { valibotAdapter } from '@zeltjs/validator-valibot/openapi';
+import { describe, expect, it } from 'vitest';
+
+import { createEcApp } from '../src/app';
+
+const tsconfig = resolve(__dirname, '../tsconfig.json');
+
+const schemaResolver: SchemaResolver = async (modulePath) =>
+  (await import(modulePath)) as Record<string, unknown>;
+
+type OpenApiDoc = {
+  paths: Record<string, Record<string, unknown>>;
+  info: { title: string; version: string };
+};
+
+describe('OpenAPI generation', () => {
+  it('generates spec with all endpoints', async () => {
+    const app = createEcApp();
+    const dist = await mkdtemp(join(tmpdir(), 'ec-openapi-'));
+    await generateOpenApi(app, {
+      distDir: dist,
+      tsconfig,
+      title: 'EC Backend API',
+      version: '1.0.0',
+      schemaAdapter: valibotAdapter,
+      schemaResolver,
+    });
+
+    const doc = JSON.parse(
+      await readFile(join(dist, 'openapi.json'), 'utf8'),
+    ) as OpenApiDoc;
+
+    expect(doc.info.title).toBe('EC Backend API');
+    expect(doc.info.version).toBe('1.0.0');
+
+    const paths = Object.keys(doc.paths);
+
+    expect(paths).toContain('/api/auth/register');
+    expect(paths).toContain('/api/auth/login');
+    expect(paths).toContain('/api/auth/me');
+    expect(paths).toContain('/api/products');
+    expect(paths).toContain('/api/products/{id}');
+    expect(paths).toContain('/api/cart');
+    expect(paths).toContain('/api/cart/items');
+    expect(paths).toContain('/api/cart/items/{productId}');
+    expect(paths).toContain('/api/orders');
+    expect(paths).toContain('/api/orders/{id}');
+  });
+
+  it('includes request body schemas for POST endpoints', async () => {
+    const app = createEcApp();
+    const dist = await mkdtemp(join(tmpdir(), 'ec-openapi-'));
+    await generateOpenApi(app, {
+      distDir: dist,
+      tsconfig,
+      title: 'EC Backend API',
+      version: '1.0.0',
+      schemaAdapter: valibotAdapter,
+      schemaResolver,
+    });
+
+    const doc = JSON.parse(
+      await readFile(join(dist, 'openapi.json'), 'utf8'),
+    ) as OpenApiDoc;
+
+    const registerPath = doc.paths['/api/auth/register'] as Record<string, { requestBody?: unknown }>;
+    expect(registerPath?.post?.requestBody).toBeDefined();
+
+    const productPath = doc.paths['/api/products'] as Record<string, { requestBody?: unknown }>;
+    expect(productPath?.post?.requestBody).toBeDefined();
+  });
+});

--- a/integration/ec-backend/e2e/openapi.spec.ts
+++ b/integration/ec-backend/e2e/openapi.spec.ts
@@ -31,9 +31,7 @@ describe('OpenAPI generation', () => {
       schemaResolver,
     });
 
-    const doc = JSON.parse(
-      await readFile(join(dist, 'openapi.json'), 'utf8'),
-    ) as OpenApiDoc;
+    const doc = JSON.parse(await readFile(join(dist, 'openapi.json'), 'utf8')) as OpenApiDoc;
 
     expect(doc.info.title).toBe('EC Backend API');
     expect(doc.info.version).toBe('1.0.0');
@@ -64,11 +62,12 @@ describe('OpenAPI generation', () => {
       schemaResolver,
     });
 
-    const doc = JSON.parse(
-      await readFile(join(dist, 'openapi.json'), 'utf8'),
-    ) as OpenApiDoc;
+    const doc = JSON.parse(await readFile(join(dist, 'openapi.json'), 'utf8')) as OpenApiDoc;
 
-    const registerPath = doc.paths['/api/auth/register'] as Record<string, { requestBody?: unknown }>;
+    const registerPath = doc.paths['/api/auth/register'] as Record<
+      string,
+      { requestBody?: unknown }
+    >;
     expect(registerPath?.post?.requestBody).toBeDefined();
 
     const productPath = doc.paths['/api/products'] as Record<string, { requestBody?: unknown }>;

--- a/integration/ec-backend/e2e/order.spec.ts
+++ b/integration/ec-backend/e2e/order.spec.ts
@@ -1,0 +1,176 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  type TestApp,
+  authRequest,
+  createTestApp,
+  loginUser,
+  registerUser,
+  seedAdmin,
+  shutdownAll,
+} from './helpers/test-setup';
+
+describe('Order API', () => {
+  let testApp: TestApp;
+  let userToken: string;
+  let adminToken: string;
+  let productId1: number;
+  let productId2: number;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+    adminToken = await seedAdmin(testApp);
+
+    await registerUser(testApp, {
+      email: 'buyer@example.com',
+      password: 'buyer-pass123',
+      name: 'Buyer',
+    });
+    const { body } = await loginUser(testApp, {
+      email: 'buyer@example.com',
+      password: 'buyer-pass123',
+    });
+    userToken = body.token;
+
+    const p1 = await authRequest(testApp, adminToken, 'POST', '/api/products', {
+      name: 'Order Product 1',
+      description: 'First product',
+      price: 1000,
+      category: 'electronics',
+      stock: 10,
+    });
+    productId1 = (await p1.json()).id;
+
+    const p2 = await authRequest(testApp, adminToken, 'POST', '/api/products', {
+      name: 'Order Product 2',
+      description: 'Second product',
+      price: 2000,
+      category: 'clothing',
+      stock: 5,
+    });
+    productId2 = (await p2.json()).id;
+  });
+
+  afterAll(async () => {
+    await shutdownAll();
+  });
+
+  describe('POST /api/orders', () => {
+    it('creates order from cart', async () => {
+      await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId: productId1,
+        quantity: 2,
+      });
+      await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId: productId2,
+        quantity: 1,
+      });
+
+      const res = await authRequest(testApp, userToken, 'POST', '/api/orders');
+      expect(res.status).toBe(201);
+
+      const order = await res.json();
+      expect(order.id).toBeDefined();
+      expect(order.totalPrice).toBe(2 * 1000 + 1 * 2000);
+      expect(order.status).toBe('confirmed');
+    });
+
+    it('clears cart after order', async () => {
+      const cartRes = await authRequest(testApp, userToken, 'GET', '/api/cart');
+      const cart = await cartRes.json();
+      expect(cart.items).toEqual([]);
+    });
+
+    it('reduces product stock', async () => {
+      const p1Res = await testApp.request(`/api/products/${productId1}`);
+      const p1 = await p1Res.json();
+      expect(p1.stock).toBe(8);
+
+      const p2Res = await testApp.request(`/api/products/${productId2}`);
+      const p2 = await p2Res.json();
+      expect(p2.stock).toBe(4);
+    });
+
+    it('rejects order with empty cart', async () => {
+      const res = await authRequest(testApp, userToken, 'POST', '/api/orders');
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects adding out-of-stock product to cart', async () => {
+      // productId2 stock was reduced by previous orders, check remaining
+      const pRes = await testApp.request(`/api/products/${productId2}`);
+      const product = await pRes.json();
+
+      // Try to add more than available stock
+      const res = await authRequest(testApp, userToken, 'POST', '/api/cart/items', {
+        productId: productId2,
+        quantity: product.stock + 1,
+      });
+      // CartService checks stock at add time
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe('GET /api/orders', () => {
+    it('lists own orders', async () => {
+      const res = await authRequest(testApp, userToken, 'GET', '/api/orders');
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.items.length).toBeGreaterThan(0);
+      expect(body.total).toBeGreaterThan(0);
+    });
+
+    it('does not show other users orders', async () => {
+      await registerUser(testApp, {
+        email: 'other-buyer@example.com',
+        password: 'other-pass123',
+        name: 'Other Buyer',
+      });
+      const { body: otherLogin } = await loginUser(testApp, {
+        email: 'other-buyer@example.com',
+        password: 'other-pass123',
+      });
+
+      const res = await authRequest(testApp, otherLogin.token, 'GET', '/api/orders');
+      const body = await res.json();
+      expect(body.items).toEqual([]);
+      expect(body.total).toBe(0);
+    });
+
+    it('requires authentication', async () => {
+      const res = await testApp.request('/api/orders');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/orders/:id', () => {
+    it('returns order with items', async () => {
+      const listRes = await authRequest(testApp, userToken, 'GET', '/api/orders');
+      const list = await listRes.json();
+      const orderId = list.items[0].id;
+
+      const res = await authRequest(testApp, userToken, 'GET', `/api/orders/${orderId}`);
+      expect(res.status).toBe(200);
+
+      const order = await res.json();
+      expect(order.id).toBe(orderId);
+      expect(order.items).toBeDefined();
+      expect(order.items.length).toBeGreaterThan(0);
+    });
+
+    it('returns 404 for other users order', async () => {
+      const { body: otherLogin } = await loginUser(testApp, {
+        email: 'other-buyer@example.com',
+        password: 'other-pass123',
+      });
+
+      const listRes = await authRequest(testApp, userToken, 'GET', '/api/orders');
+      const list = await listRes.json();
+      const orderId = list.items[0].id;
+
+      const res = await authRequest(testApp, otherLogin.token, 'GET', `/api/orders/${orderId}`);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/integration/ec-backend/e2e/order.spec.ts
+++ b/integration/ec-backend/e2e/order.spec.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-
+import type { TestApp } from './helpers/test-setup';
 import {
-  type TestApp,
   authRequest,
   createTestApp,
   loginUser,

--- a/integration/ec-backend/e2e/product.spec.ts
+++ b/integration/ec-backend/e2e/product.spec.ts
@@ -1,12 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-
-import {
-  type TestApp,
-  authRequest,
-  createTestApp,
-  seedAdmin,
-  shutdownAll,
-} from './helpers/test-setup';
+import type { TestApp } from './helpers/test-setup';
+import { authRequest, createTestApp, seedAdmin, shutdownAll } from './helpers/test-setup';
 
 describe('Product API', () => {
   let testApp: TestApp;
@@ -117,13 +111,10 @@ describe('Product API', () => {
       });
       const created = await createRes.json();
 
-      const res = await authRequest(
-        testApp,
-        adminToken,
-        'PUT',
-        `/api/products/${created.id}`,
-        { name: 'After Update', price: 1500 },
-      );
+      const res = await authRequest(testApp, adminToken, 'PUT', `/api/products/${created.id}`, {
+        name: 'After Update',
+        price: 1500,
+      });
       expect(res.status).toBe(200);
 
       const updated = await res.json();
@@ -133,13 +124,9 @@ describe('Product API', () => {
     });
 
     it('returns 404 for non-existent product', async () => {
-      const res = await authRequest(
-        testApp,
-        adminToken,
-        'PUT',
-        '/api/products/99999',
-        { name: 'Ghost' },
-      );
+      const res = await authRequest(testApp, adminToken, 'PUT', '/api/products/99999', {
+        name: 'Ghost',
+      });
       expect(res.status).toBe(404);
     });
   });
@@ -168,12 +155,7 @@ describe('Product API', () => {
     });
 
     it('returns 404 for non-existent product', async () => {
-      const res = await authRequest(
-        testApp,
-        adminToken,
-        'DELETE',
-        '/api/products/99999',
-      );
+      const res = await authRequest(testApp, adminToken, 'DELETE', '/api/products/99999');
       expect(res.status).toBe(404);
     });
   });

--- a/integration/ec-backend/e2e/product.spec.ts
+++ b/integration/ec-backend/e2e/product.spec.ts
@@ -1,0 +1,232 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  type TestApp,
+  authRequest,
+  createTestApp,
+  seedAdmin,
+  shutdownAll,
+} from './helpers/test-setup';
+
+describe('Product API', () => {
+  let testApp: TestApp;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+    adminToken = await seedAdmin(testApp);
+  });
+
+  afterAll(async () => {
+    await shutdownAll();
+  });
+
+  const createProduct = (data: Record<string, unknown>) =>
+    authRequest(testApp, adminToken, 'POST', '/api/products', data);
+
+  describe('GET /api/products', () => {
+    it('returns empty list initially', async () => {
+      const res = await testApp.request('/api/products');
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.items).toEqual([]);
+      expect(body.total).toBe(0);
+      expect(body.page).toBe(1);
+    });
+
+    it('uses default pagination', async () => {
+      const res = await testApp.request('/api/products');
+      const body = await res.json();
+      expect(body.page).toBe(1);
+      expect(body.limit).toBe(20);
+    });
+  });
+
+  describe('POST /api/products', () => {
+    it('creates a product', async () => {
+      const res = await createProduct({
+        name: 'Test Product',
+        description: 'A great product',
+        price: 1999,
+        category: 'electronics',
+        stock: 50,
+      });
+      expect(res.status).toBe(201);
+
+      const product = await res.json();
+      expect(product.id).toBeDefined();
+      expect(product.name).toBe('Test Product');
+      expect(product.price).toBe(1999);
+      expect(product.category).toBe('electronics');
+      expect(product.stock).toBe(50);
+    });
+
+    it('rejects invalid data', async () => {
+      const res = await createProduct({ name: '', price: -1 });
+      expect(res.status).toBe(400);
+
+      const body = await res.json();
+      expect(body.code).toBe('VALIDATION_FAILED');
+    });
+
+    it('rejects missing required fields', async () => {
+      const res = await createProduct({});
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/products/:id', () => {
+    it('returns product detail', async () => {
+      const createRes = await createProduct({
+        name: 'Detail Product',
+        description: 'For detail test',
+        price: 500,
+        category: 'books',
+        stock: 10,
+      });
+      const created = await createRes.json();
+
+      const res = await testApp.request(`/api/products/${created.id}`);
+      expect(res.status).toBe(200);
+
+      const product = await res.json();
+      expect(product.name).toBe('Detail Product');
+      expect(product.id).toBe(created.id);
+    });
+
+    it('returns 404 for non-existent product', async () => {
+      const res = await testApp.request('/api/products/99999');
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 400 for invalid id', async () => {
+      const res = await testApp.request('/api/products/abc');
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('PUT /api/products/:id', () => {
+    it('updates a product', async () => {
+      const createRes = await createProduct({
+        name: 'Before Update',
+        description: 'Original',
+        price: 1000,
+        category: 'clothing',
+        stock: 5,
+      });
+      const created = await createRes.json();
+
+      const res = await authRequest(
+        testApp,
+        adminToken,
+        'PUT',
+        `/api/products/${created.id}`,
+        { name: 'After Update', price: 1500 },
+      );
+      expect(res.status).toBe(200);
+
+      const updated = await res.json();
+      expect(updated.name).toBe('After Update');
+      expect(updated.price).toBe(1500);
+      expect(updated.description).toBe('Original');
+    });
+
+    it('returns 404 for non-existent product', async () => {
+      const res = await authRequest(
+        testApp,
+        adminToken,
+        'PUT',
+        '/api/products/99999',
+        { name: 'Ghost' },
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/products/:id', () => {
+    it('deletes a product', async () => {
+      const createRes = await createProduct({
+        name: 'To Delete',
+        description: 'Will be deleted',
+        price: 100,
+        category: 'misc',
+        stock: 1,
+      });
+      const created = await createRes.json();
+
+      const deleteRes = await authRequest(
+        testApp,
+        adminToken,
+        'DELETE',
+        `/api/products/${created.id}`,
+      );
+      expect(deleteRes.status).toBe(200);
+
+      const getRes = await testApp.request(`/api/products/${created.id}`);
+      expect(getRes.status).toBe(404);
+    });
+
+    it('returns 404 for non-existent product', async () => {
+      const res = await authRequest(
+        testApp,
+        adminToken,
+        'DELETE',
+        '/api/products/99999',
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('Pagination and filtering', () => {
+    let paginationApp: TestApp;
+    let paginationAdminToken: string;
+
+    beforeAll(async () => {
+      paginationApp = await createTestApp();
+      paginationAdminToken = await seedAdmin(paginationApp);
+
+      for (let i = 1; i <= 15; i++) {
+        await authRequest(paginationApp, paginationAdminToken, 'POST', '/api/products', {
+          name: `Product ${i}`,
+          description: `Description ${i}`,
+          price: i * 100,
+          category: i <= 10 ? 'electronics' : 'clothing',
+          stock: i,
+        });
+      }
+    });
+
+    it('paginates results', async () => {
+      const res = await paginationApp.request('/api/products?page=2&limit=5');
+      const body = await res.json();
+      expect(body.items).toHaveLength(5);
+      expect(body.page).toBe(2);
+      expect(body.limit).toBe(5);
+      expect(body.total).toBe(15);
+    });
+
+    it('filters by category', async () => {
+      const res = await paginationApp.request('/api/products?category=clothing');
+      const body = await res.json();
+      expect(body.total).toBe(5);
+      expect(body.items.every((p: { category: string }) => p.category === 'clothing')).toBe(true);
+    });
+
+    it('filters by price range', async () => {
+      const res = await paginationApp.request('/api/products?minPrice=500&maxPrice=1000');
+      const body = await res.json();
+      expect(body.items.every((p: { price: number }) => p.price >= 500 && p.price <= 1000)).toBe(
+        true,
+      );
+    });
+
+    it('ignores invalid query params gracefully', async () => {
+      const res = await paginationApp.request('/api/products?page=abc&limit=-5');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.page).toBe(1);
+      expect(body.limit).toBe(1);
+    });
+  });
+});

--- a/integration/ec-backend/e2e/rate-limit.spec.ts
+++ b/integration/ec-backend/e2e/rate-limit.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-
-import { type TestApp, createTestApp, shutdownAll } from './helpers/test-setup';
+import type { TestApp } from './helpers/test-setup';
+import { createTestApp, shutdownAll } from './helpers/test-setup';
 
 describe('Rate Limit', () => {
   let testApp: TestApp;

--- a/integration/ec-backend/e2e/rate-limit.spec.ts
+++ b/integration/ec-backend/e2e/rate-limit.spec.ts
@@ -1,0 +1,79 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { type TestApp, createTestApp, shutdownAll } from './helpers/test-setup';
+
+describe('Rate Limit', () => {
+  let testApp: TestApp;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await shutdownAll();
+  });
+
+  it('returns rate limit headers on login', async () => {
+    // Register a user first so login doesn't 401 before rate limit middleware runs
+    await testApp.request('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'login-test@example.com',
+        password: 'password123',
+        name: 'Login Test',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await testApp.request('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'login-test@example.com', password: 'password123' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('5');
+    expect(res.headers.get('X-RateLimit-Remaining')).toBeDefined();
+  });
+
+  it('returns rate limit headers on register', async () => {
+    const res = await testApp.request('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'ratelimit@example.com',
+        password: 'password123',
+        name: 'Rate Limit',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('3');
+  });
+
+  it('returns 429 after exceeding register limit', async () => {
+    for (let i = 0; i < 3; i++) {
+      await testApp.request('/api/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: `flood-${i}@example.com`,
+          password: 'password123',
+          name: `Flood ${i}`,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const res = await testApp.request('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'one-more@example.com',
+        password: 'password123',
+        name: 'One More',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.code).toBe('RATE_LIMIT_EXCEEDED');
+  });
+});

--- a/integration/ec-backend/package.extra.json
+++ b/integration/ec-backend/package.extra.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "better-sqlite3": "12.9.0",
+    "drizzle-orm": "0.45.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "7.6.13"
+  }
+}

--- a/integration/ec-backend/package.extra.json
+++ b/integration/ec-backend/package.extra.json
@@ -5,5 +5,8 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.13"
+  },
+  "scripts": {
+    "postinstall": "cd node_modules/better-sqlite3 && npx --yes node-gyp@11.1.0 rebuild"
   }
 }

--- a/integration/ec-backend/src/app.ts
+++ b/integration/ec-backend/src/app.ts
@@ -1,11 +1,11 @@
 import { createApp } from '@zeltjs/core';
 
 import './context-schema';
+import { AuthController } from './auth/auth.controller';
 import { EcJwtConfig } from './auth/ec-jwt.config';
+import { CartController } from './cart/cart.controller';
 import { EcCorsConfig } from './config/ec-cors.config';
 import { LoggingMiddleware } from './middleware/logging.middleware';
-import { AuthController } from './auth/auth.controller';
-import { CartController } from './cart/cart.controller';
 import { OrderController } from './order/order.controller';
 import { ProductController } from './product/product.controller';
 

--- a/integration/ec-backend/src/app.ts
+++ b/integration/ec-backend/src/app.ts
@@ -1,0 +1,19 @@
+import { createApp } from '@zeltjs/core';
+
+import './context-schema';
+import { EcJwtConfig } from './auth/ec-jwt.config';
+import { EcCorsConfig } from './config/ec-cors.config';
+import { LoggingMiddleware } from './middleware/logging.middleware';
+import { AuthController } from './auth/auth.controller';
+import { CartController } from './cart/cart.controller';
+import { OrderController } from './order/order.controller';
+import { ProductController } from './product/product.controller';
+
+export const createEcApp = () =>
+  createApp({
+    http: {
+      controllers: [AuthController, ProductController, CartController, OrderController],
+      middlewares: [LoggingMiddleware],
+    },
+    configs: [EcJwtConfig, EcCorsConfig],
+  });

--- a/integration/ec-backend/src/auth/auth.controller.ts
+++ b/integration/ec-backend/src/auth/auth.controller.ts
@@ -1,13 +1,11 @@
-import { Controller, Get, Post, inject } from '@zeltjs/core';
-import { UseMiddleware } from '@zeltjs/core';
 import { JwtMiddleware } from '@zeltjs/auth-jwt';
+import { Controller, Get, inject, Post, UseMiddleware } from '@zeltjs/core';
 import { RateLimit } from '@zeltjs/rate-limit';
-import { HTTPException } from 'hono/http-exception';
 import { validated } from '@zeltjs/validator-valibot';
-
+import { HTTPException } from 'hono/http-exception';
+import { LoginSchema, RegisterSchema } from './auth.schema';
 import { AuthService } from './auth.service';
 import { requireUser } from './current-user.lib';
-import { RegisterSchema, LoginSchema } from './auth.schema';
 
 @Controller('/api/auth')
 export class AuthController {

--- a/integration/ec-backend/src/auth/auth.controller.ts
+++ b/integration/ec-backend/src/auth/auth.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Post, inject } from '@zeltjs/core';
+import { UseMiddleware } from '@zeltjs/core';
+import { JwtMiddleware } from '@zeltjs/auth-jwt';
+import { RateLimit } from '@zeltjs/rate-limit';
+import { HTTPException } from 'hono/http-exception';
+import { validated } from '@zeltjs/validator-valibot';
+
+import { AuthService } from './auth.service';
+import { requireUser } from './current-user.lib';
+import { RegisterSchema, LoginSchema } from './auth.schema';
+
+@Controller('/api/auth')
+export class AuthController {
+  constructor(private readonly authService = inject(AuthService)) {}
+
+  @RateLimit({ limit: 3, windowSec: 60, key: 'auth:register' })
+  @Post('/register')
+  async register(data = validated(RegisterSchema)) {
+    const user = await this.authService.register(data);
+    return user;
+  }
+
+  @RateLimit({ limit: 5, windowSec: 60, key: 'auth:login' })
+  @Post('/login')
+  async login(data = validated(LoginSchema)) {
+    const result = await this.authService.login(data.email, data.password);
+    return result;
+  }
+
+  @UseMiddleware(JwtMiddleware)
+  @Get('/me')
+  async me() {
+    const user = requireUser();
+    const profile = await this.authService.getProfile(user.id);
+    if (!profile) {
+      throw new HTTPException(404, { message: 'User not found' });
+    }
+    return profile;
+  }
+}

--- a/integration/ec-backend/src/auth/auth.schema.ts
+++ b/integration/ec-backend/src/auth/auth.schema.ts
@@ -1,0 +1,15 @@
+import * as v from 'valibot';
+
+export const RegisterSchema = v.object({
+  email: v.pipe(v.string(), v.email()),
+  password: v.pipe(v.string(), v.minLength(8)),
+  name: v.pipe(v.string(), v.minLength(1)),
+});
+
+export const LoginSchema = v.object({
+  email: v.pipe(v.string(), v.email()),
+  password: v.pipe(v.string(), v.minLength(1)),
+});
+
+export type RegisterInput = v.InferOutput<typeof RegisterSchema>;
+export type LoginInput = v.InferOutput<typeof LoginSchema>;

--- a/integration/ec-backend/src/auth/auth.service.ts
+++ b/integration/ec-backend/src/auth/auth.service.ts
@@ -1,10 +1,9 @@
-import { scrypt, randomBytes, timingSafeEqual } from 'node:crypto';
+import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
 import { promisify } from 'node:util';
-
-import { Injectable, inject } from '@zeltjs/core';
 import { JwtService } from '@zeltjs/auth-jwt';
-import { HTTPException } from 'hono/http-exception';
+import { Injectable, inject } from '@zeltjs/core';
 import { eq } from 'drizzle-orm';
+import { HTTPException } from 'hono/http-exception';
 
 import { DrizzleService } from '../db/drizzle.service';
 import { users } from '../db/schema';
@@ -33,11 +32,7 @@ export class AuthService {
   ) {}
 
   async register(data: RegisterInput): Promise<{ id: number; email: string; name: string }> {
-    const existing = this.drizzle.db
-      .select()
-      .from(users)
-      .where(eq(users.email, data.email))
-      .get();
+    const existing = this.drizzle.db.select().from(users).where(eq(users.email, data.email)).get();
 
     if (existing) {
       throw new HTTPException(409, { message: 'Email already exists' });
@@ -79,7 +74,9 @@ export class AuthService {
     return { token };
   }
 
-  async getProfile(userId: number): Promise<{ id: number; email: string; name: string; role: string } | undefined> {
+  async getProfile(
+    userId: number,
+  ): Promise<{ id: number; email: string; name: string; role: string } | undefined> {
     const user = this.drizzle.db.select().from(users).where(eq(users.id, userId)).get();
     if (!user) return undefined;
     return { id: user.id, email: user.email, name: user.name, role: user.role };

--- a/integration/ec-backend/src/auth/auth.service.ts
+++ b/integration/ec-backend/src/auth/auth.service.ts
@@ -1,0 +1,87 @@
+import { scrypt, randomBytes, timingSafeEqual } from 'node:crypto';
+import { promisify } from 'node:util';
+
+import { Injectable, inject } from '@zeltjs/core';
+import { JwtService } from '@zeltjs/auth-jwt';
+import { HTTPException } from 'hono/http-exception';
+import { eq } from 'drizzle-orm';
+
+import { DrizzleService } from '../db/drizzle.service';
+import { users } from '../db/schema';
+import type { RegisterInput } from './auth.schema';
+
+const scryptAsync = promisify(scrypt);
+
+const hashPassword = async (password: string): Promise<string> => {
+  const salt = randomBytes(16).toString('hex');
+  const derived = (await scryptAsync(password, salt, 64)) as Buffer;
+  return `${salt}:${derived.toString('hex')}`;
+};
+
+const verifyPassword = async (password: string, hash: string): Promise<boolean> => {
+  const [salt, key] = hash.split(':');
+  if (!salt || !key) return false;
+  const derived = (await scryptAsync(password, salt, 64)) as Buffer;
+  return timingSafeEqual(Buffer.from(key, 'hex'), derived);
+};
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly drizzle = inject(DrizzleService),
+    private readonly jwtService = inject(JwtService),
+  ) {}
+
+  async register(data: RegisterInput): Promise<{ id: number; email: string; name: string }> {
+    const existing = this.drizzle.db
+      .select()
+      .from(users)
+      .where(eq(users.email, data.email))
+      .get();
+
+    if (existing) {
+      throw new HTTPException(409, { message: 'Email already exists' });
+    }
+
+    const passwordHash = await hashPassword(data.password);
+    const user = this.drizzle.db
+      .insert(users)
+      .values({
+        email: data.email,
+        passwordHash,
+        name: data.name,
+        createdAt: new Date(),
+      })
+      .returning()
+      .get();
+
+    return { id: user.id, email: user.email, name: user.name };
+  }
+
+  async login(email: string, password: string): Promise<{ token: string }> {
+    const user = this.drizzle.db.select().from(users).where(eq(users.email, email)).get();
+
+    if (!user) {
+      throw new HTTPException(401, { message: 'Invalid credentials' });
+    }
+
+    const valid = await verifyPassword(password, user.passwordHash);
+    if (!valid) {
+      throw new HTTPException(401, { message: 'Invalid credentials' });
+    }
+
+    const token = await this.jwtService.sign({
+      sub: String(user.id),
+      email: user.email,
+      roles: [user.role],
+    });
+
+    return { token };
+  }
+
+  async getProfile(userId: number): Promise<{ id: number; email: string; name: string; role: string } | undefined> {
+    const user = this.drizzle.db.select().from(users).where(eq(users.id, userId)).get();
+    if (!user) return undefined;
+    return { id: user.id, email: user.email, name: user.name, role: user.role };
+  }
+}

--- a/integration/ec-backend/src/auth/current-user.lib.ts
+++ b/integration/ec-backend/src/auth/current-user.lib.ts
@@ -1,0 +1,10 @@
+import { currentUser } from '@zeltjs/core';
+import { HTTPException } from 'hono/http-exception';
+
+export type EcUser = { readonly id: number; readonly email: string };
+
+export const requireUser = (): EcUser => {
+  const user = currentUser();
+  if (!user) throw new HTTPException(401, { message: 'Not authenticated' });
+  return user as EcUser;
+};

--- a/integration/ec-backend/src/auth/ec-jwt.config.ts
+++ b/integration/ec-backend/src/auth/ec-jwt.config.ts
@@ -1,6 +1,6 @@
-import { Config } from '@zeltjs/core';
-import type { ResolveUserResult, JwtPayload } from '@zeltjs/auth-jwt';
+import type { JwtPayload, ResolveUserResult } from '@zeltjs/auth-jwt';
 import { JwtConfig } from '@zeltjs/auth-jwt';
+import { Config } from '@zeltjs/core';
 
 import type { EcUser } from './current-user.lib';
 

--- a/integration/ec-backend/src/auth/ec-jwt.config.ts
+++ b/integration/ec-backend/src/auth/ec-jwt.config.ts
@@ -1,0 +1,29 @@
+import { Config } from '@zeltjs/core';
+import type { ResolveUserResult, JwtPayload } from '@zeltjs/auth-jwt';
+import { JwtConfig } from '@zeltjs/auth-jwt';
+
+import type { EcUser } from './current-user.lib';
+
+@Config
+export class EcJwtConfig extends JwtConfig {
+  override get secret(): string {
+    return 'ec-backend-test-secret-key-do-not-use-in-production';
+  }
+
+  override get expiresIn(): string {
+    return '24h';
+  }
+
+  override get resolveUser(): (payload: JwtPayload) => Promise<ResolveUserResult> {
+    return async (payload) => {
+      const user: EcUser = {
+        id: payload.sub ? parseInt(payload.sub, 10) : 0,
+        email: (payload.email as string) ?? '',
+      };
+      return {
+        user,
+        roles: (payload.roles as readonly string[]) ?? [],
+      };
+    };
+  }
+}

--- a/integration/ec-backend/src/cart/cart.controller.ts
+++ b/integration/ec-backend/src/cart/cart.controller.ts
@@ -1,0 +1,59 @@
+import { Authorized, Controller, Delete, Get, Post, Put, UseMiddleware, inject, pathParam } from '@zeltjs/core';
+import { JwtMiddleware } from '@zeltjs/auth-jwt';
+import { validated } from '@zeltjs/validator-valibot';
+
+import { requireUser } from '../auth/current-user.lib';
+import { CartService } from './cart.service';
+import { AddToCartSchema, UpdateCartItemSchema } from './cart.schema';
+
+@UseMiddleware(JwtMiddleware)
+@Controller('/api/cart')
+export class CartController {
+  constructor(private readonly cartService = inject(CartService)) {}
+
+  @Authorized()
+  @Get('/')
+  async getCart() {
+    const user = requireUser();
+    const cart = await this.cartService.getCart(user.id);
+    const total = cart.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+    return { ...cart, total };
+  }
+
+  @Authorized()
+  @Post('/items')
+  async addItem(data = validated(AddToCartSchema)) {
+    const user = requireUser();
+    const cart = await this.cartService.addItem(user.id, data.productId, data.quantity);
+    return cart;
+  }
+
+  @Authorized()
+  @Put('/items/:productId')
+  async updateItem(
+    productIdStr = pathParam('productId'),
+    data = validated(UpdateCartItemSchema),
+  ) {
+    const user = requireUser();
+    const productId = parseInt(productIdStr, 10);
+    const cart = await this.cartService.updateQuantity(user.id, productId, data.quantity);
+    return cart;
+  }
+
+  @Authorized()
+  @Delete('/items/:productId')
+  async removeItem(productIdStr = pathParam('productId')) {
+    const user = requireUser();
+    const productId = parseInt(productIdStr, 10);
+    const cart = await this.cartService.removeItem(user.id, productId);
+    return cart;
+  }
+
+  @Authorized()
+  @Delete('/')
+  async clearCart() {
+    const user = requireUser();
+    await this.cartService.clearCart(user.id);
+    return { cleared: true };
+  }
+}

--- a/integration/ec-backend/src/cart/cart.controller.ts
+++ b/integration/ec-backend/src/cart/cart.controller.ts
@@ -1,10 +1,20 @@
-import { Authorized, Controller, Delete, Get, Post, Put, UseMiddleware, inject, pathParam } from '@zeltjs/core';
 import { JwtMiddleware } from '@zeltjs/auth-jwt';
+import {
+  Authorized,
+  Controller,
+  Delete,
+  Get,
+  inject,
+  Post,
+  Put,
+  pathParam,
+  UseMiddleware,
+} from '@zeltjs/core';
 import { validated } from '@zeltjs/validator-valibot';
 
 import { requireUser } from '../auth/current-user.lib';
-import { CartService } from './cart.service';
 import { AddToCartSchema, UpdateCartItemSchema } from './cart.schema';
+import { CartService } from './cart.service';
 
 @UseMiddleware(JwtMiddleware)
 @Controller('/api/cart')
@@ -30,10 +40,7 @@ export class CartController {
 
   @Authorized()
   @Put('/items/:productId')
-  async updateItem(
-    productIdStr = pathParam('productId'),
-    data = validated(UpdateCartItemSchema),
-  ) {
+  async updateItem(productIdStr = pathParam('productId'), data = validated(UpdateCartItemSchema)) {
     const user = requireUser();
     const productId = parseInt(productIdStr, 10);
     const cart = await this.cartService.updateQuantity(user.id, productId, data.quantity);

--- a/integration/ec-backend/src/cart/cart.schema.ts
+++ b/integration/ec-backend/src/cart/cart.schema.ts
@@ -1,0 +1,13 @@
+import * as v from 'valibot';
+
+export const AddToCartSchema = v.object({
+  productId: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  quantity: v.pipe(v.number(), v.integer(), v.minValue(1)),
+});
+
+export const UpdateCartItemSchema = v.object({
+  quantity: v.pipe(v.number(), v.integer(), v.minValue(0)),
+});
+
+export type AddToCartInput = v.InferOutput<typeof AddToCartSchema>;
+export type UpdateCartItemInput = v.InferOutput<typeof UpdateCartItemSchema>;

--- a/integration/ec-backend/src/cart/cart.service.ts
+++ b/integration/ec-backend/src/cart/cart.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@zeltjs/core';
-import { MemoryKVAdaptor } from '@zeltjs/kv';
 import type { KVStore } from '@zeltjs/kv';
+import { MemoryKVAdaptor } from '@zeltjs/kv';
 import { HTTPException } from 'hono/http-exception';
 
 import { ProductService } from '../product/product.service';
@@ -56,10 +56,7 @@ export class CartService {
         i === existingIndex ? { ...item, quantity: newQuantity } : item,
       ) as CartItem[];
     } else {
-      updatedItems = [
-        ...cart.items,
-        { productId, quantity, price: product.price },
-      ] as CartItem[];
+      updatedItems = [...cart.items, { productId, quantity, price: product.price }] as CartItem[];
     }
 
     const updated: CartData = { items: updatedItems };
@@ -97,9 +94,7 @@ export class CartService {
 
   async removeItem(userId: number, productId: number): Promise<CartData> {
     const cart = await this.getCart(userId);
-    const updatedItems = cart.items.filter(
-      (item) => item.productId !== productId,
-    ) as CartItem[];
+    const updatedItems = cart.items.filter((item) => item.productId !== productId) as CartItem[];
 
     const updated: CartData = { items: updatedItems };
     if (updatedItems.length === 0) {

--- a/integration/ec-backend/src/cart/cart.service.ts
+++ b/integration/ec-backend/src/cart/cart.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, inject } from '@zeltjs/core';
+import { MemoryKVAdaptor } from '@zeltjs/kv';
+import type { KVStore } from '@zeltjs/kv';
+import { HTTPException } from 'hono/http-exception';
+
+import { ProductService } from '../product/product.service';
+
+type CartItem = {
+  readonly productId: number;
+  readonly quantity: number;
+  readonly price: number;
+};
+
+type CartData = {
+  readonly items: readonly CartItem[];
+};
+
+const CART_TTL_SEC = 86400;
+
+@Injectable()
+export class CartService {
+  private readonly store: KVStore;
+
+  constructor(
+    private readonly kv = inject(MemoryKVAdaptor),
+    private readonly productService = inject(ProductService),
+  ) {
+    this.store = this.kv.namespace('cart:');
+  }
+
+  async getCart(userId: number): Promise<CartData> {
+    const cart = await this.store.get<CartData>(String(userId));
+    return cart ?? { items: [] };
+  }
+
+  async addItem(userId: number, productId: number, quantity: number): Promise<CartData> {
+    const product = await this.productService.findById(productId);
+    if (!product) {
+      throw new HTTPException(404, { message: 'Product not found' });
+    }
+    if (product.stock < quantity) {
+      throw new HTTPException(409, { message: 'Insufficient stock' });
+    }
+
+    const cart = await this.getCart(userId);
+    const existingIndex = cart.items.findIndex((item) => item.productId === productId);
+
+    let updatedItems: CartItem[];
+    if (existingIndex >= 0) {
+      const existing = cart.items[existingIndex]!;
+      const newQuantity = existing.quantity + quantity;
+      if (product.stock < newQuantity) {
+        throw new HTTPException(409, { message: 'Insufficient stock' });
+      }
+      updatedItems = cart.items.map((item, i) =>
+        i === existingIndex ? { ...item, quantity: newQuantity } : item,
+      ) as CartItem[];
+    } else {
+      updatedItems = [
+        ...cart.items,
+        { productId, quantity, price: product.price },
+      ] as CartItem[];
+    }
+
+    const updated: CartData = { items: updatedItems };
+    await this.store.set(String(userId), updated, { ttlSec: CART_TTL_SEC });
+    return updated;
+  }
+
+  async updateQuantity(userId: number, productId: number, quantity: number): Promise<CartData> {
+    if (quantity === 0) {
+      return this.removeItem(userId, productId);
+    }
+
+    const product = await this.productService.findById(productId);
+    if (!product) {
+      throw new HTTPException(404, { message: 'Product not found' });
+    }
+    if (product.stock < quantity) {
+      throw new HTTPException(409, { message: 'Insufficient stock' });
+    }
+
+    const cart = await this.getCart(userId);
+    const exists = cart.items.some((item) => item.productId === productId);
+    if (!exists) {
+      throw new HTTPException(404, { message: 'Item not in cart' });
+    }
+
+    const updatedItems = cart.items.map((item) =>
+      item.productId === productId ? { ...item, quantity } : item,
+    ) as CartItem[];
+
+    const updated: CartData = { items: updatedItems };
+    await this.store.set(String(userId), updated, { ttlSec: CART_TTL_SEC });
+    return updated;
+  }
+
+  async removeItem(userId: number, productId: number): Promise<CartData> {
+    const cart = await this.getCart(userId);
+    const updatedItems = cart.items.filter(
+      (item) => item.productId !== productId,
+    ) as CartItem[];
+
+    const updated: CartData = { items: updatedItems };
+    if (updatedItems.length === 0) {
+      await this.store.del(String(userId));
+    } else {
+      await this.store.set(String(userId), updated, { ttlSec: CART_TTL_SEC });
+    }
+    return updated;
+  }
+
+  async clearCart(userId: number): Promise<void> {
+    await this.store.del(String(userId));
+  }
+}

--- a/integration/ec-backend/src/config/ec-cors.config.ts
+++ b/integration/ec-backend/src/config/ec-cors.config.ts
@@ -1,0 +1,7 @@
+import { Config, CorsConfig } from '@zeltjs/core';
+
+@Config
+export class EcCorsConfig extends CorsConfig {
+  override readonly origin = ['http://localhost:3000'];
+  override readonly credentials = true;
+}

--- a/integration/ec-backend/src/context-schema.ts
+++ b/integration/ec-backend/src/context-schema.ts
@@ -1,0 +1,11 @@
+// Framework issue discovered: RequestContextSchema.user is typed as `unknown`
+// and cannot be narrowed via declaration merging (TS2717).
+// RequestContextSchema.authRoles is already `readonly string[]`.
+// We add EC-specific context keys instead.
+declare module '@zeltjs/core' {
+  interface RequestContextSchema {
+    ecUserId: number;
+  }
+}
+
+export {};

--- a/integration/ec-backend/src/db/drizzle.service.ts
+++ b/integration/ec-backend/src/db/drizzle.service.ts
@@ -13,6 +13,7 @@ export class DrizzleService implements Lifecycle {
 
   constructor(lifecycle = inject(LifecycleManager)) {
     this.sqlite = new Database(':memory:');
+    this.sqlite.pragma('foreign_keys = ON');
     this.db = drizzle(this.sqlite, { schema });
     this.initSchema();
     lifecycle.register(this);

--- a/integration/ec-backend/src/db/drizzle.service.ts
+++ b/integration/ec-backend/src/db/drizzle.service.ts
@@ -1,0 +1,66 @@
+import type { Lifecycle } from '@zeltjs/core';
+import { Injectable, inject, LifecycleManager } from '@zeltjs/core';
+import Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
+import * as schema from './schema';
+
+@Injectable()
+export class DrizzleService implements Lifecycle {
+  private readonly sqlite: Database.Database;
+  readonly db: BetterSQLite3Database<typeof schema>;
+
+  constructor(lifecycle = inject(LifecycleManager)) {
+    this.sqlite = new Database(':memory:');
+    this.db = drizzle(this.sqlite, { schema });
+    this.initSchema();
+    lifecycle.register(this);
+  }
+
+  private initSchema() {
+    this.sqlite.exec(`
+      CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        email TEXT NOT NULL UNIQUE,
+        password_hash TEXT NOT NULL,
+        name TEXT NOT NULL,
+        role TEXT NOT NULL DEFAULT 'user',
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS products (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        price INTEGER NOT NULL,
+        category TEXT NOT NULL,
+        stock INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS orders (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL REFERENCES users(id),
+        status TEXT NOT NULL DEFAULT 'pending',
+        total_price INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS order_items (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        order_id INTEGER NOT NULL REFERENCES orders(id),
+        product_id INTEGER NOT NULL REFERENCES products(id),
+        quantity INTEGER NOT NULL,
+        unit_price INTEGER NOT NULL
+      );
+    `);
+  }
+
+  async startup(): Promise<void> {}
+
+  async shutdown(): Promise<void> {
+    this.sqlite.close();
+  }
+}

--- a/integration/ec-backend/src/db/schema.ts
+++ b/integration/ec-backend/src/db/schema.ts
@@ -1,0 +1,64 @@
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  email: text('email').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  name: text('name').notNull(),
+  role: text('role', { enum: ['user', 'admin'] })
+    .notNull()
+    .default('user'),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const products = sqliteTable('products', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  description: text('description').notNull(),
+  price: integer('price').notNull(),
+  category: text('category').notNull(),
+  stock: integer('stock').notNull().default(0),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer('updated_at', { mode: 'timestamp' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const orders = sqliteTable('orders', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id),
+  status: text('status', { enum: ['pending', 'confirmed', 'cancelled'] })
+    .notNull()
+    .default('pending'),
+  totalPrice: integer('total_price').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const orderItems = sqliteTable('order_items', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  orderId: integer('order_id')
+    .notNull()
+    .references(() => orders.id),
+  productId: integer('product_id')
+    .notNull()
+    .references(() => products.id),
+  quantity: integer('quantity').notNull(),
+  unitPrice: integer('unit_price').notNull(),
+});
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
+export type Product = typeof products.$inferSelect;
+export type NewProduct = typeof products.$inferInsert;
+export type Order = typeof orders.$inferSelect;
+export type NewOrder = typeof orders.$inferInsert;
+export type OrderItem = typeof orderItems.$inferSelect;
+export type NewOrderItem = typeof orderItems.$inferInsert;

--- a/integration/ec-backend/src/middleware/logging.middleware.ts
+++ b/integration/ec-backend/src/middleware/logging.middleware.ts
@@ -1,6 +1,5 @@
 import type { Next, RequestContext } from '@zeltjs/core';
-import { inject, Middleware } from '@zeltjs/core';
-import { LoggerService } from '@zeltjs/core';
+import { inject, LoggerService, Middleware } from '@zeltjs/core';
 
 @Middleware
 export class LoggingMiddleware {

--- a/integration/ec-backend/src/middleware/logging.middleware.ts
+++ b/integration/ec-backend/src/middleware/logging.middleware.ts
@@ -1,0 +1,23 @@
+import type { Next, RequestContext } from '@zeltjs/core';
+import { inject, Middleware } from '@zeltjs/core';
+import { LoggerService } from '@zeltjs/core';
+
+@Middleware
+export class LoggingMiddleware {
+  constructor(private readonly logger = inject(LoggerService)) {}
+
+  async use(c: RequestContext, next: Next): Promise<Response | undefined> {
+    const start = performance.now();
+    await next();
+    const duration = Math.round(performance.now() - start);
+
+    this.logger.info('request', {
+      method: c.req.method,
+      path: c.req.path,
+      status: c.res.status,
+      duration,
+    });
+
+    return undefined;
+  }
+}

--- a/integration/ec-backend/src/order/order.controller.ts
+++ b/integration/ec-backend/src/order/order.controller.ts
@@ -1,28 +1,27 @@
+import { JwtMiddleware } from '@zeltjs/auth-jwt';
 import {
   Authorized,
   Controller,
   Get,
-  Post,
-  UseMiddleware,
   inject,
+  Post,
   pathParam,
   queryParam,
   response,
+  UseMiddleware,
 } from '@zeltjs/core';
-import { JwtMiddleware } from '@zeltjs/auth-jwt';
 import { HTTPException } from 'hono/http-exception';
 
 import { requireUser } from '../auth/current-user.lib';
-import { OrderService } from './order.service';
 import { OrderHandlers } from './order.handlers';
+import { OrderService } from './order.service';
 
 @UseMiddleware(JwtMiddleware)
 @Controller('/api/orders')
 export class OrderController {
   constructor(
     private readonly orderService = inject(OrderService),
-    // OrderHandlers is not a controller, so we inject it here to ensure DI resolves it
-    private readonly _handlers = inject(OrderHandlers),
+    readonly _handlers = inject(OrderHandlers),
   ) {}
 
   @Authorized()
@@ -35,10 +34,7 @@ export class OrderController {
 
   @Authorized()
   @Get('/')
-  async list(
-    pageStr = queryParam('page'),
-    limitStr = queryParam('limit'),
-  ) {
+  async list(pageStr = queryParam('page'), limitStr = queryParam('limit')) {
     const user = requireUser();
     const page = Math.max(1, parseInt(pageStr ?? '1', 10) || 1);
     const limit = Math.min(100, Math.max(1, parseInt(limitStr ?? '20', 10) || 20));

--- a/integration/ec-backend/src/order/order.controller.ts
+++ b/integration/ec-backend/src/order/order.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Authorized,
+  Controller,
+  Get,
+  Post,
+  UseMiddleware,
+  inject,
+  pathParam,
+  queryParam,
+  response,
+} from '@zeltjs/core';
+import { JwtMiddleware } from '@zeltjs/auth-jwt';
+import { HTTPException } from 'hono/http-exception';
+
+import { requireUser } from '../auth/current-user.lib';
+import { OrderService } from './order.service';
+import { OrderHandlers } from './order.handlers';
+
+@UseMiddleware(JwtMiddleware)
+@Controller('/api/orders')
+export class OrderController {
+  constructor(
+    private readonly orderService = inject(OrderService),
+    // OrderHandlers is not a controller, so we inject it here to ensure DI resolves it
+    private readonly _handlers = inject(OrderHandlers),
+  ) {}
+
+  @Authorized()
+  @Post('/')
+  async create(res = response()) {
+    const user = requireUser();
+    const order = await this.orderService.createOrder(user.id);
+    return res.json(order, 201);
+  }
+
+  @Authorized()
+  @Get('/')
+  async list(
+    pageStr = queryParam('page'),
+    limitStr = queryParam('limit'),
+  ) {
+    const user = requireUser();
+    const page = Math.max(1, parseInt(pageStr ?? '1', 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(limitStr ?? '20', 10) || 20));
+    const result = await this.orderService.findByUser(user.id, page, limit);
+    return { ...result, page, limit };
+  }
+
+  @Authorized()
+  @Get('/:id')
+  async detail(idStr = pathParam('id')) {
+    const user = requireUser();
+    const id = parseInt(idStr, 10);
+    if (Number.isNaN(id)) {
+      throw new HTTPException(400, { message: 'Invalid order ID' });
+    }
+
+    const order = await this.orderService.findById(id, user.id);
+    if (!order) {
+      throw new HTTPException(404, { message: 'Order not found' });
+    }
+
+    const items = await this.orderService.getOrderItems(order.id);
+    return { ...order, items };
+  }
+}

--- a/integration/ec-backend/src/order/order.events.ts
+++ b/integration/ec-backend/src/order/order.events.ts
@@ -1,0 +1,11 @@
+declare module '@zeltjs/eventbus' {
+  interface EventBusSchema {
+    'order:created': {
+      orderId: number;
+      userId: number;
+      items: ReadonlyArray<{ productId: number; quantity: number }>;
+    };
+  }
+}
+
+export {};

--- a/integration/ec-backend/src/order/order.handlers.ts
+++ b/integration/ec-backend/src/order/order.handlers.ts
@@ -1,0 +1,35 @@
+import type { Lifecycle } from '@zeltjs/core';
+import { Injectable, inject, LifecycleManager } from '@zeltjs/core';
+import { MemoryEventBusAdaptor } from '@zeltjs/eventbus';
+
+import './order.events';
+
+@Injectable()
+export class OrderHandlers implements Lifecycle {
+  private unsubscribes: Array<() => void> = [];
+  readonly notifications: Array<{ orderId: number; userId: number }> = [];
+
+  constructor(
+    private readonly eventBus = inject(MemoryEventBusAdaptor),
+    lifecycle = inject(LifecycleManager),
+  ) {
+    lifecycle.register(this);
+  }
+
+  async startup(): Promise<void> {
+    const unsub = this.eventBus.on('order:created', (data) => {
+      this.notifications.push({
+        orderId: data.orderId,
+        userId: data.userId,
+      });
+    });
+    this.unsubscribes.push(unsub);
+  }
+
+  async shutdown(): Promise<void> {
+    for (const unsub of this.unsubscribes) {
+      unsub();
+    }
+    this.unsubscribes = [];
+  }
+}

--- a/integration/ec-backend/src/order/order.service.ts
+++ b/integration/ec-backend/src/order/order.service.ts
@@ -1,0 +1,130 @@
+import { Injectable, inject } from '@zeltjs/core';
+import { MemoryEventBusAdaptor } from '@zeltjs/eventbus';
+import { HTTPException } from 'hono/http-exception';
+import { eq, sql } from 'drizzle-orm';
+
+import { DrizzleService } from '../db/drizzle.service';
+import { orders, orderItems, products } from '../db/schema';
+import type { Order } from '../db/schema';
+import { CartService } from '../cart/cart.service';
+import './order.events';
+
+@Injectable()
+export class OrderService {
+  constructor(
+    private readonly drizzle = inject(DrizzleService),
+    private readonly cartService = inject(CartService),
+    private readonly eventBus = inject(MemoryEventBusAdaptor),
+  ) {}
+
+  async createOrder(userId: number): Promise<Order> {
+    const cart = await this.cartService.getCart(userId);
+    if (cart.items.length === 0) {
+      throw new HTTPException(400, { message: 'Cart is empty' });
+    }
+
+    const totalPrice = cart.items.reduce(
+      (sum, item) => sum + item.price * item.quantity,
+      0,
+    );
+
+    const order = this.drizzle.db.transaction((tx) => {
+      for (const item of cart.items) {
+        const product = tx
+          .select()
+          .from(products)
+          .where(eq(products.id, item.productId))
+          .get();
+
+        if (!product || product.stock < item.quantity) {
+          throw new HTTPException(409, {
+            message: `Insufficient stock for product ${item.productId}`,
+          });
+        }
+
+        tx.update(products)
+          .set({ stock: sql`${products.stock} - ${item.quantity}` })
+          .where(eq(products.id, item.productId))
+          .run();
+      }
+
+      const newOrder = tx
+        .insert(orders)
+        .values({
+          userId,
+          totalPrice,
+          status: 'confirmed',
+          createdAt: new Date(),
+        })
+        .returning()
+        .get();
+
+      for (const item of cart.items) {
+        tx.insert(orderItems)
+          .values({
+            orderId: newOrder.id,
+            productId: item.productId,
+            quantity: item.quantity,
+            unitPrice: item.price,
+          })
+          .run();
+      }
+
+      return newOrder;
+    });
+
+    await this.cartService.clearCart(userId);
+
+    await this.eventBus.emit('order:created', {
+      orderId: order.id,
+      userId,
+      items: cart.items.map((item) => ({
+        productId: item.productId,
+        quantity: item.quantity,
+      })),
+    });
+
+    return order;
+  }
+
+  async findByUser(
+    userId: number,
+    page = 1,
+    limit = 20,
+  ): Promise<{ items: Order[]; total: number }> {
+    const items = this.drizzle.db
+      .select()
+      .from(orders)
+      .where(eq(orders.userId, userId))
+      .limit(limit)
+      .offset((page - 1) * limit)
+      .all();
+
+    const countResult = this.drizzle.db
+      .select({ count: sql<number>`count(*)` })
+      .from(orders)
+      .where(eq(orders.userId, userId))
+      .all();
+
+    return { items, total: countResult[0]?.count ?? 0 };
+  }
+
+  async findById(orderId: number, userId: number): Promise<Order | undefined> {
+    const order = this.drizzle.db
+      .select()
+      .from(orders)
+      .where(eq(orders.id, orderId))
+      .get();
+
+    if (!order || order.userId !== userId) return undefined;
+    return order;
+  }
+
+  async getOrderItems(orderId: number) {
+    return this.drizzle.db
+      .select()
+      .from(orderItems)
+      .where(eq(orderItems.orderId, orderId))
+      .all();
+  }
+}

--- a/integration/ec-backend/src/order/order.service.ts
+++ b/integration/ec-backend/src/order/order.service.ts
@@ -1,12 +1,11 @@
 import { Injectable, inject } from '@zeltjs/core';
 import { MemoryEventBusAdaptor } from '@zeltjs/eventbus';
-import { HTTPException } from 'hono/http-exception';
 import { eq, sql } from 'drizzle-orm';
-
-import { DrizzleService } from '../db/drizzle.service';
-import { orders, orderItems, products } from '../db/schema';
-import type { Order } from '../db/schema';
+import { HTTPException } from 'hono/http-exception';
 import { CartService } from '../cart/cart.service';
+import { DrizzleService } from '../db/drizzle.service';
+import type { Order } from '../db/schema';
+import { orderItems, orders, products } from '../db/schema';
 import './order.events';
 
 @Injectable()
@@ -23,18 +22,11 @@ export class OrderService {
       throw new HTTPException(400, { message: 'Cart is empty' });
     }
 
-    const totalPrice = cart.items.reduce(
-      (sum, item) => sum + item.price * item.quantity,
-      0,
-    );
+    const totalPrice = cart.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
 
     const order = this.drizzle.db.transaction((tx) => {
       for (const item of cart.items) {
-        const product = tx
-          .select()
-          .from(products)
-          .where(eq(products.id, item.productId))
-          .get();
+        const product = tx.select().from(products).where(eq(products.id, item.productId)).get();
 
         if (!product || product.stock < item.quantity) {
           throw new HTTPException(409, {
@@ -110,21 +102,13 @@ export class OrderService {
   }
 
   async findById(orderId: number, userId: number): Promise<Order | undefined> {
-    const order = this.drizzle.db
-      .select()
-      .from(orders)
-      .where(eq(orders.id, orderId))
-      .get();
+    const order = this.drizzle.db.select().from(orders).where(eq(orders.id, orderId)).get();
 
     if (!order || order.userId !== userId) return undefined;
     return order;
   }
 
   async getOrderItems(orderId: number) {
-    return this.drizzle.db
-      .select()
-      .from(orderItems)
-      .where(eq(orderItems.orderId, orderId))
-      .all();
+    return this.drizzle.db.select().from(orderItems).where(eq(orderItems.orderId, orderId)).all();
   }
 }

--- a/integration/ec-backend/src/order/order.service.ts
+++ b/integration/ec-backend/src/order/order.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@zeltjs/core';
 import { MemoryEventBusAdaptor } from '@zeltjs/eventbus';
-import { eq, sql } from 'drizzle-orm';
+import { desc, eq, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { CartService } from '../cart/cart.service';
 import { DrizzleService } from '../db/drizzle.service';
@@ -88,6 +88,7 @@ export class OrderService {
       .select()
       .from(orders)
       .where(eq(orders.userId, userId))
+      .orderBy(desc(orders.createdAt), desc(orders.id))
       .limit(limit)
       .offset((page - 1) * limit)
       .all();

--- a/integration/ec-backend/src/product/product.controller.ts
+++ b/integration/ec-backend/src/product/product.controller.ts
@@ -1,0 +1,107 @@
+import {
+  Authorized,
+  Controller,
+  Delete,
+  Get,
+  Post,
+  Put,
+  UseMiddleware,
+  inject,
+  pathParam,
+  queryParam,
+  response,
+} from '@zeltjs/core';
+import { JwtMiddleware } from '@zeltjs/auth-jwt';
+import { HTTPException } from 'hono/http-exception';
+import { validated } from '@zeltjs/validator-valibot';
+
+import { ProductService } from './product.service';
+import { CreateProductSchema, UpdateProductSchema } from './product.schema';
+
+@Controller('/api/products')
+export class ProductController {
+  constructor(private readonly productService = inject(ProductService)) {}
+
+  @Get('/')
+  async list(
+    pageStr = queryParam('page'),
+    limitStr = queryParam('limit'),
+    category = queryParam('category'),
+    minPriceStr = queryParam('minPrice'),
+    maxPriceStr = queryParam('maxPrice'),
+  ) {
+    const page = Math.max(1, parseInt(pageStr ?? '1', 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(limitStr ?? '20', 10) || 20));
+    const minPrice = minPriceStr ? parseInt(minPriceStr, 10) : undefined;
+    const maxPrice = maxPriceStr ? parseInt(maxPriceStr, 10) : undefined;
+
+    const result = await this.productService.findAll({
+      page,
+      limit,
+      category: category ?? undefined,
+      minPrice: Number.isNaN(minPrice) ? undefined : minPrice,
+      maxPrice: Number.isNaN(maxPrice) ? undefined : maxPrice,
+    });
+
+    return {
+      items: result.items,
+      total: result.total,
+      page,
+      limit,
+    };
+  }
+
+  @Get('/:id')
+  async detail(idStr = pathParam('id')) {
+    const id = parseInt(idStr, 10);
+    if (Number.isNaN(id)) {
+      throw new HTTPException(400, { message: 'Invalid product ID' });
+    }
+
+    const product = await this.productService.findById(id);
+    if (!product) {
+      throw new HTTPException(404, { message: 'Product not found' });
+    }
+    return product;
+  }
+
+  @UseMiddleware(JwtMiddleware)
+  @Authorized(['admin'])
+  @Post('/')
+  async create(data = validated(CreateProductSchema), res = response()) {
+    const product = await this.productService.create(data);
+    return res.json(product, 201);
+  }
+
+  @UseMiddleware(JwtMiddleware)
+  @Authorized(['admin'])
+  @Put('/:id')
+  async update(idStr = pathParam('id'), data = validated(UpdateProductSchema)) {
+    const id = parseInt(idStr, 10);
+    if (Number.isNaN(id)) {
+      throw new HTTPException(400, { message: 'Invalid product ID' });
+    }
+
+    const product = await this.productService.update(id, data);
+    if (!product) {
+      throw new HTTPException(404, { message: 'Product not found' });
+    }
+    return product;
+  }
+
+  @UseMiddleware(JwtMiddleware)
+  @Authorized(['admin'])
+  @Delete('/:id')
+  async remove(idStr = pathParam('id')) {
+    const id = parseInt(idStr, 10);
+    if (Number.isNaN(id)) {
+      throw new HTTPException(400, { message: 'Invalid product ID' });
+    }
+
+    const removed = await this.productService.remove(id);
+    if (!removed) {
+      throw new HTTPException(404, { message: 'Product not found' });
+    }
+    return { deleted: true };
+  }
+}

--- a/integration/ec-backend/src/product/product.controller.ts
+++ b/integration/ec-backend/src/product/product.controller.ts
@@ -1,22 +1,21 @@
+import { JwtMiddleware } from '@zeltjs/auth-jwt';
 import {
   Authorized,
   Controller,
   Delete,
   Get,
+  inject,
   Post,
   Put,
-  UseMiddleware,
-  inject,
   pathParam,
   queryParam,
   response,
+  UseMiddleware,
 } from '@zeltjs/core';
-import { JwtMiddleware } from '@zeltjs/auth-jwt';
-import { HTTPException } from 'hono/http-exception';
 import { validated } from '@zeltjs/validator-valibot';
-
-import { ProductService } from './product.service';
+import { HTTPException } from 'hono/http-exception';
 import { CreateProductSchema, UpdateProductSchema } from './product.schema';
+import { ProductService } from './product.service';
 
 @Controller('/api/products')
 export class ProductController {

--- a/integration/ec-backend/src/product/product.schema.ts
+++ b/integration/ec-backend/src/product/product.schema.ts
@@ -1,0 +1,20 @@
+import * as v from 'valibot';
+
+export const CreateProductSchema = v.object({
+  name: v.pipe(v.string(), v.minLength(1)),
+  description: v.string(),
+  price: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  category: v.pipe(v.string(), v.minLength(1)),
+  stock: v.pipe(v.number(), v.integer(), v.minValue(0)),
+});
+
+export const UpdateProductSchema = v.object({
+  name: v.optional(v.pipe(v.string(), v.minLength(1))),
+  description: v.optional(v.string()),
+  price: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+  category: v.optional(v.pipe(v.string(), v.minLength(1))),
+  stock: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
+});
+
+export type CreateProductInput = v.InferOutput<typeof CreateProductSchema>;
+export type UpdateProductInput = v.InferOutput<typeof UpdateProductSchema>;

--- a/integration/ec-backend/src/product/product.service.ts
+++ b/integration/ec-backend/src/product/product.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, inject } from '@zeltjs/core';
-import { eq, and, gte, lte, sql } from 'drizzle-orm';
+import { and, eq, gte, lte, sql } from 'drizzle-orm';
 
 import { DrizzleService } from '../db/drizzle.service';
+import type { NewProduct, Product } from '../db/schema';
 import { products } from '../db/schema';
-import type { Product, NewProduct } from '../db/schema';
 import type { CreateProductInput, UpdateProductInput } from './product.schema';
 
 @Injectable()
@@ -38,20 +38,14 @@ export class ProductService {
         .where(where)
         .limit(opts.limit)
         .offset((opts.page - 1) * opts.limit),
-      this.drizzle.db
-        .select({ count: sql<number>`count(*)` })
-        .from(products)
-        .where(where),
+      this.drizzle.db.select({ count: sql<number>`count(*)` }).from(products).where(where),
     ]);
 
     return { items, total: countResult[0]?.count ?? 0 };
   }
 
   async findById(id: number): Promise<Product | undefined> {
-    const result = await this.drizzle.db
-      .select()
-      .from(products)
-      .where(eq(products.id, id));
+    const result = await this.drizzle.db.select().from(products).where(eq(products.id, id));
     return result[0];
   }
 

--- a/integration/ec-backend/src/product/product.service.ts
+++ b/integration/ec-backend/src/product/product.service.ts
@@ -1,0 +1,92 @@
+import { Injectable, inject } from '@zeltjs/core';
+import { eq, and, gte, lte, sql } from 'drizzle-orm';
+
+import { DrizzleService } from '../db/drizzle.service';
+import { products } from '../db/schema';
+import type { Product, NewProduct } from '../db/schema';
+import type { CreateProductInput, UpdateProductInput } from './product.schema';
+
+@Injectable()
+export class ProductService {
+  constructor(private readonly drizzle = inject(DrizzleService)) {}
+
+  async findAll(opts: {
+    page: number;
+    limit: number;
+    category?: string;
+    minPrice?: number;
+    maxPrice?: number;
+  }): Promise<{ items: Product[]; total: number }> {
+    const conditions = [];
+
+    if (opts.category) {
+      conditions.push(eq(products.category, opts.category));
+    }
+    if (opts.minPrice !== undefined) {
+      conditions.push(gte(products.price, opts.minPrice));
+    }
+    if (opts.maxPrice !== undefined) {
+      conditions.push(lte(products.price, opts.maxPrice));
+    }
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      this.drizzle.db
+        .select()
+        .from(products)
+        .where(where)
+        .limit(opts.limit)
+        .offset((opts.page - 1) * opts.limit),
+      this.drizzle.db
+        .select({ count: sql<number>`count(*)` })
+        .from(products)
+        .where(where),
+    ]);
+
+    return { items, total: countResult[0]?.count ?? 0 };
+  }
+
+  async findById(id: number): Promise<Product | undefined> {
+    const result = await this.drizzle.db
+      .select()
+      .from(products)
+      .where(eq(products.id, id));
+    return result[0];
+  }
+
+  async create(data: CreateProductInput): Promise<Product> {
+    const now = new Date();
+    const result = this.drizzle.db
+      .insert(products)
+      .values({
+        ...data,
+        createdAt: now,
+        updatedAt: now,
+      } satisfies NewProduct)
+      .returning()
+      .get();
+    return result;
+  }
+
+  async update(id: number, data: UpdateProductInput): Promise<Product | undefined> {
+    const existing = await this.findById(id);
+    if (!existing) return undefined;
+
+    const result = this.drizzle.db
+      .update(products)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(products.id, id))
+      .returning()
+      .get();
+    return result;
+  }
+
+  async remove(id: number): Promise<boolean> {
+    const existing = await this.findById(id);
+    if (!existing) return false;
+
+    this.drizzle.db.delete(products).where(eq(products.id, id)).run();
+    return true;
+  }
+}

--- a/integration/ec-backend/tsconfig.json
+++ b/integration/ec-backend/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "e2e/**/*"]
+}

--- a/integration/ec-backend/vitest.config.ts
+++ b/integration/ec-backend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['e2e/**/*.spec.ts'],
+  },
+});

--- a/integration/scripts/switch-mode.sh
+++ b/integration/scripts/switch-mode.sh
@@ -249,6 +249,29 @@ prepare_pack_mode() {
 }
 
 # Per-directory setup (generate package.json + install)
+merge_extra_deps() {
+  local integration_dir="$1"
+  local extra_file="$integration_dir/package.extra.json"
+  local pkg_file="$integration_dir/package.json"
+
+  if [[ ! -f "$extra_file" ]]; then
+    return
+  fi
+
+  echo "  Merging package.extra.json..."
+  node -e '
+    const fs = require("fs");
+    const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const extra = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+    for (const field of ["dependencies", "devDependencies"]) {
+      if (extra[field]) {
+        pkg[field] = { ...(pkg[field] || {}), ...extra[field] };
+      }
+    }
+    fs.writeFileSync(process.argv[1], JSON.stringify(pkg, null, 2) + "\n");
+  ' "$pkg_file" "$extra_file"
+}
+
 setup_integration_dir() {
   local mode="$1"
   local integration_dir="$2"
@@ -257,6 +280,7 @@ setup_integration_dir() {
 
   echo "Setting up $name..."
   generate_package_json "$mode" "$integration_dir" > "$integration_dir/package.json"
+  merge_extra_deps "$integration_dir"
 
   echo "  Installing dependencies..."
   (cd "$integration_dir" && rm -rf node_modules pnpm-lock.yaml && pnpm install --ignore-workspace 2>/dev/null)

--- a/integration/scripts/switch-mode.sh
+++ b/integration/scripts/switch-mode.sh
@@ -263,7 +263,7 @@ merge_extra_deps() {
     const fs = require("fs");
     const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
     const extra = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-    for (const field of ["dependencies", "devDependencies"]) {
+    for (const field of ["dependencies", "devDependencies", "scripts"]) {
       if (extra[field]) {
         pkg[field] = { ...(pkg[field] || {}), ...extra[field] };
       }

--- a/packages/cli/src/config/config.types.ts
+++ b/packages/cli/src/config/config.types.ts
@@ -1,4 +1,4 @@
-import type { App, CreateAppOptions } from '@zeltjs/core';
+import type { App } from '@zeltjs/core';
 import * as v from 'valibot';
 
 const BuildConfigSchema = v.object({
@@ -39,7 +39,7 @@ export type ZeltPlugin = {
 export type BuildContext = {
   readonly cwd: string;
   readonly config: ZeltConfig;
-  readonly app: App<CreateAppOptions>;
+  readonly app: App;
 };
 
 export type BuildResult = {

--- a/packages/cli/src/dev-server.lib.ts
+++ b/packages/cli/src/dev-server.lib.ts
@@ -82,11 +82,7 @@ const startProcess = (cwd: string, entry: string): ChildProcess => {
 };
 
 /** @throws {ZeltMultipleBuildHooksError} */
-const runHooks = async (
-  cwd: string,
-  config: ZeltConfig,
-  app: App,
-): Promise<void> => {
+const runHooks = async (cwd: string, config: ZeltConfig, app: App): Promise<void> => {
   const hookOptions = { cwd, config, app };
 
   await runPreBuildHooks(hookOptions);

--- a/packages/cli/src/dev-server.lib.ts
+++ b/packages/cli/src/dev-server.lib.ts
@@ -2,7 +2,7 @@ import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 
 import { NodeCliConfig } from '@zeltjs/adapter-node';
-import type { App, CreateAppOptions, SignalHandler } from '@zeltjs/core';
+import type { App, SignalHandler } from '@zeltjs/core';
 import { createApp } from '@zeltjs/core';
 import consola from 'consola';
 
@@ -23,7 +23,7 @@ type DevServerState = {
   childProcess: ChildProcess | undefined;
   watcher: WatcherHandle | undefined;
   isShuttingDown: boolean;
-  app: App<CreateAppOptions>;
+  app: App;
 };
 
 const DEFAULT_WATCH_PATTERNS = ['./src/**/*.ts'];
@@ -85,7 +85,7 @@ const startProcess = (cwd: string, entry: string): ChildProcess => {
 const runHooks = async (
   cwd: string,
   config: ZeltConfig,
-  app: App<CreateAppOptions>,
+  app: App,
 ): Promise<void> => {
   const hookOptions = { cwd, config, app };
 

--- a/packages/cli/src/plugin-runner.lib.ts
+++ b/packages/cli/src/plugin-runner.lib.ts
@@ -1,4 +1,4 @@
-import type { App, CreateAppOptions } from '@zeltjs/core';
+import type { App } from '@zeltjs/core';
 import consola from 'consola';
 
 import { ZeltMultipleBuildHooksError } from './cli.errors';
@@ -7,7 +7,7 @@ import type { BuildContext, BuildResult, ZeltConfig, ZeltPlugin } from './config
 export type RunPluginHooksOptions = {
   readonly cwd: string;
   readonly config: ZeltConfig;
-  readonly app: App<CreateAppOptions>;
+  readonly app: App;
 };
 
 export const runPreBuildHooks = async (options: RunPluginHooksOptions): Promise<void> => {

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -1,7 +1,10 @@
 import { Container } from '@needle-di/core';
 
 import type { ConfigClass } from '../built-in-service/config';
-import type { ModuleCapsMap } from '../modules/module.types';
+import type { CommandModule } from '../modules/command/command.module';
+import type { HttpModule } from '../modules/http/http.module';
+import type { Module, ModuleCapsAll, ModuleCapsMap } from '../modules/module.types';
+import type { SchedulerModule } from '../modules/scheduler/scheduler.module';
 import type { ReadyOptions, ReadyResult } from './app-runtime.lib';
 import { AppRuntime } from './app-runtime.lib';
 import { ConfigRegistry } from './config-registry.lib';
@@ -22,14 +25,16 @@ type BaseApp = {
   readonly overrideConfig: (config: ConfigClass<object>) => void;
 };
 
-export type App<TOptions extends CreateAppOptions = CreateAppOptions> = BaseApp &
+export type App<M extends readonly Module[] = []> = BaseApp & ModuleCapsAll<M>;
+
+export type HttpApp = App<[HttpModule]>;
+
+export type CommandApp = App<[CommandModule]>;
+
+export type SchedulerApp = App<[SchedulerModule]>;
+
+type AppFromOptions<TOptions extends CreateAppOptions> = BaseApp &
   ModuleCapsMap<typeof DefaultModules, TOptions>;
-
-export type HttpApp = App<{ http: NonNullable<CreateAppOptions['http']> }>;
-
-export type CommandApp = App<{ commands: NonNullable<CreateAppOptions['commands']> }>;
-
-export type SchedulerApp = App<{ schedulers: NonNullable<CreateAppOptions['schedulers']> }>;
 
 export type { ReadyOptions, ReadyResult } from './app-runtime.lib';
 
@@ -60,9 +65,11 @@ const buildBaseApp = (runtime: AppRuntime, configRegistry: ConfigRegistry): Base
 // --- Main ---
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
-export function createApp<TOptions extends CreateAppOptions>(options: TOptions): App<TOptions>;
+export function createApp<TOptions extends CreateAppOptions>(
+  options: TOptions,
+): AppFromOptions<TOptions>;
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
-export function createApp(options: CreateAppOptions): App<CreateAppOptions> {
+export function createApp(options: CreateAppOptions): AppFromOptions<CreateAppOptions> {
   const container = new Container();
   bindDefaultModules(container, options);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,7 +57,7 @@ export {
   ZeltSchemaValidationError,
 } from './kernel/errors';
 export type { ReadyValue } from './kernel/internal';
-export type { CommandCapabilities } from './modules/command/command.module';
+export type { CommandCapabilities, CommandModule } from './modules/command/command.module';
 export type {
   ArgDefinition,
   ArgsDefinition,
@@ -89,7 +89,7 @@ export type {
   ValidationIssue,
 } from './modules/http/error/error.types';
 export { ErrorHandler } from './modules/http/error/error-handler.decorator';
-export type { HttpCapabilities } from './modules/http/http.module';
+export type { HttpCapabilities, HttpModule } from './modules/http/http.module';
 export type { HttpMetadata } from './modules/http/http.service';
 export type { ControllerClass } from './modules/http/http.types';
 // HTTP primitives
@@ -150,7 +150,7 @@ export type { ControllerRouteInfo, RouteInfo } from './modules/http/routing';
 export { getControllerMetadata } from './modules/http/routing';
 export { Controller } from './modules/http/routing/controller.decorator';
 export { Delete, Get, Patch, Post, Put } from './modules/http/routing/http-method.decorator';
-export type { Module, ModuleCapsMap, ModuleConfigMap } from './modules/module.types';
+export type { Module, ModuleCapsAll, ModuleCapsMap, ModuleConfigMap } from './modules/module.types';
 // Scheduler decorators
 export { Cron } from './modules/scheduler/schedule/cron.decorator';
 export { Daily } from './modules/scheduler/schedule/daily.decorator';
@@ -158,5 +158,5 @@ export { Every } from './modules/scheduler/schedule/every.decorator';
 export { Hourly } from './modules/scheduler/schedule/hourly.decorator';
 export { Scheduled } from './modules/scheduler/schedule/scheduled.decorator';
 export { Weekly } from './modules/scheduler/schedule/weekly.decorator';
-export type { SchedulerCapabilities } from './modules/scheduler/scheduler.module';
+export type { SchedulerCapabilities, SchedulerModule } from './modules/scheduler/scheduler.module';
 export type { SchedulerClass } from './modules/scheduler/scheduler.types';

--- a/packages/core/src/modules/command/command.module.ts
+++ b/packages/core/src/modules/command/command.module.ts
@@ -9,6 +9,7 @@ export type CommandCapabilities = {
   readonly execCommand: (argv: readonly string[]) => Promise<ExecResult>;
 };
 
+export type CommandModule = typeof CommandModule;
 export const CommandModule: Module<'commands', readonly CommandClass[], CommandCapabilities> = {
   key: 'commands',
   bind: (container, commands) => {

--- a/packages/core/src/modules/http/app.test.ts
+++ b/packages/core/src/modules/http/app.test.ts
@@ -8,7 +8,7 @@ import type { Lifecycle } from '../../kernel';
 import { LifecycleManager } from '../../kernel';
 import { inject } from '../../kernel/di';
 import { ErrorHandler } from './error/error-handler.decorator';
-import type { ControllerClass } from './http.types';
+import type { HttpModule } from './http.module';
 import { Middleware } from './middleware/middleware.decorator';
 import { SkipMiddleware } from './middleware/skip-middleware.decorator';
 import { UseMiddleware } from './middleware/use-middleware.decorator';
@@ -553,8 +553,7 @@ describe('errorHandlers', () => {
 });
 
 describe('createApp 2-phase initialization', () => {
-  type TestAppOptions = { http: { controllers: ControllerClass[] } };
-  let app: App<TestAppOptions> | undefined;
+  let app: App<[HttpModule]> | undefined;
 
   afterEach(async () => {
     if (app) {

--- a/packages/core/src/modules/http/http.module.ts
+++ b/packages/core/src/modules/http/http.module.ts
@@ -10,6 +10,7 @@ export type HttpCapabilities = {
   readonly getMetadata: () => HttpMetadata;
 };
 
+export type HttpModule = typeof HttpModule;
 export const HttpModule: Module<'http', HttpOptions, HttpCapabilities> = {
   key: 'http',
   bind: (container, config) => {

--- a/packages/core/src/modules/module.types.ts
+++ b/packages/core/src/modules/module.types.ts
@@ -37,6 +37,15 @@ export type ModuleCapsMap<M extends readonly Module[], TConfig> = M extends read
   ? ModuleCapsEntry<First, TConfig> & ModuleCapsMap<Rest, TConfig>
   : object;
 
+type ExtractCaps<M> = M extends Module<string, unknown, infer Caps> ? Caps : object;
+
+export type ModuleCapsAll<M extends readonly Module[]> = M extends readonly [
+  infer First extends Module,
+  ...infer Rest extends readonly Module[],
+]
+  ? ExtractCaps<First> & ModuleCapsAll<Rest>
+  : object;
+
 type ModuleCapsEntry<M, TConfig> = M extends {
   readonly key: infer K extends string;
   readonly bind: (container: never, config: infer C) => void;

--- a/packages/core/src/modules/scheduler/scheduler.module.test.ts
+++ b/packages/core/src/modules/scheduler/scheduler.module.test.ts
@@ -1,12 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { App } from '../../app';
 import { createApp } from '../../app';
+import type { HttpModule } from '../http/http.module';
 import { Cron } from './schedule/cron.decorator';
 import { Scheduled } from './schedule/scheduled.decorator';
-import type { SchedulerClass } from './scheduler.types';
+import type { SchedulerModule } from './scheduler.module';
 
 describe('createApp with schedulers', () => {
-  let app: App<{ http: { controllers: [] }; schedulers: SchedulerClass[] }> | undefined;
+  let app: App<[HttpModule, SchedulerModule]> | undefined;
 
   afterEach(async () => {
     if (app) {

--- a/packages/core/src/modules/scheduler/scheduler.module.ts
+++ b/packages/core/src/modules/scheduler/scheduler.module.ts
@@ -10,6 +10,7 @@ export type SchedulerCapabilities = {
   readonly getSchedulerJobs: () => readonly JobInfo[];
 };
 
+export type SchedulerModule = typeof SchedulerModule;
 export const SchedulerModule: Module<
   'schedulers',
   readonly SchedulerClass[],


### PR DESCRIPTION
## Summary

- Add `integration/ec-backend/` — a full-featured EC backend (auth, products, cart, orders) that exercises the framework as a real user would
- Replace options-based `App<TOptions>` with module-based `App<[HttpModule, ...]>` — users compose app types from modules declaratively without `typeof` hacks
- Extend `switch-mode.sh` to merge `package.extra.json` for integration-specific dependencies

## Changes

### Framework (`packages/core`)
- `App<M extends Module[]>` replaces `App<TOptions extends CreateAppOptions>` 
- Each module exports a same-name type alias (`export type HttpModule = typeof HttpModule`)
- `ModuleCapsAll` utility type extracts capabilities unconditionally from a module tuple
- `HttpApp = App<[HttpModule]>`, `CommandApp = App<[CommandModule]>`, etc.
- `createApp()` return type uses internal `AppFromOptions<TOptions>` for config-based inference

### EC Backend (`integration/ec-backend`)
- Drizzle ORM + SQLite (:memory:) with 4 domain models
- JWT auth with role-based access control
- KV-based cart with TTL, transactional orders with EventBus
- Rate limiting, CORS config, OpenAPI generation
- 59 e2e tests covering full user journeys

## Test plan
- [ ] `pnpm test` — all 371 core tests pass
- [ ] `cd integration/ec-backend && pnpm test` — all 59 EC backend tests pass
- [ ] `tsc --noEmit` in core — zero errors
- [ ] `tsc --noEmit` in ec-backend — zero project-own errors (drizzle-orm node_modules errors only, need skipLibCheck)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782708540&installation_id=133048706&pr_number=242&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F242&signature=2d703e6a5ba487e0096335e5ef61bdbf8be1243472cf9d671cbe2d15950a30bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * EC バックエンドを追加：認証（登録/ログイン/プロフィール）、商品管理、カート、注文作成と注文イベント通知を提供

* **テスト**
  * 認証・商品・カート・注文・レート制限・フルフロー・OpenAPI 検証を含む包括的な E2E テスト群を追加

* **改善**
  * レート制限、CORS、JWT 設定、リクエストログ出力を導入し信頼性と観測性を強化
  * 型定義の整理で開発体験を向上

* **雑務**
  * テスト用セットアップと統合スクリプトの依存マージ処理を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->