### PR TITLE
feat(core): add nested HTTP modules (children)

### DIFF
--- a/packages/core/src/modules/http/app.test.ts
+++ b/packages/core/src/modules/http/app.test.ts
@@ -895,6 +895,107 @@ describe('nested children', () => {
     expect(await res.json()).toEqual({ scope: 'child', message: 'child error' });
   });
 
+  it('parent error handler applies when child has no handler', async () => {
+    @ErrorHandler
+    class ParentErrorHandler {
+      onError(error: Error, _c: Context) {
+        return Response.json({ handler: 'parent', message: error.message }, { status: 502 });
+      }
+    }
+
+    @Controller('/test')
+    class ChildController {
+      @Get('/')
+      get() {
+        throw new Error('child error');
+      }
+    }
+
+    const app = createApp({
+      http: {
+        controllers: [],
+        errorHandlers: [ParentErrorHandler],
+        children: [
+          {
+            path: '/api',
+            controllers: [ChildController],
+          },
+        ],
+      },
+    });
+    await app.ready();
+
+    const res = await app.request('/api/test/');
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ handler: 'parent', message: 'child error' });
+  });
+
+  it('error handlers bubble child -> parent -> default', async () => {
+    @ErrorHandler
+    class ParentHandler {
+      onError(error: Error, _c: Context) {
+        if (error.message === 'parent-handles') {
+          return Response.json({ handler: 'parent' }, { status: 400 });
+        }
+        return undefined;
+      }
+    }
+
+    @ErrorHandler
+    class ChildHandler {
+      onError(error: Error, _c: Context) {
+        if (error.message === 'child-handles') {
+          return Response.json({ handler: 'child' }, { status: 422 });
+        }
+        return undefined;
+      }
+    }
+
+    @Controller('/test')
+    class BubbleController {
+      @Get('/child-error')
+      childError() {
+        throw new Error('child-handles');
+      }
+
+      @Get('/parent-error')
+      parentError() {
+        throw new Error('parent-handles');
+      }
+
+      @Get('/default-error')
+      defaultError() {
+        throw new Error('unhandled');
+      }
+    }
+
+    const app = createApp({
+      http: {
+        controllers: [],
+        errorHandlers: [ParentHandler],
+        children: [
+          {
+            path: '/api',
+            controllers: [BubbleController],
+            errorHandlers: [ChildHandler],
+          },
+        ],
+      },
+    });
+    await app.ready();
+
+    const childRes = await app.request('/api/test/child-error');
+    expect(childRes.status).toBe(422);
+    expect(await childRes.json()).toEqual({ handler: 'child' });
+
+    const parentRes = await app.request('/api/test/parent-error');
+    expect(parentRes.status).toBe(400);
+    expect(await parentRes.json()).toEqual({ handler: 'parent' });
+
+    const defaultRes = await app.request('/api/test/default-error');
+    expect(defaultRes.status).toBe(500);
+  });
+
   it('multi-level nesting works (3 levels)', async () => {
     @Controller('/items')
     class ItemController {

--- a/packages/core/src/modules/http/app.test.ts
+++ b/packages/core/src/modules/http/app.test.ts
@@ -793,6 +793,205 @@ describe('addFallbackConfig', () => {
   });
 });
 
+describe('nested children', () => {
+  it('child routes are accessible at prefixed paths', async () => {
+    @Controller('/users')
+    class UserController {
+      @Get('/')
+      list() {
+        return { users: [] };
+      }
+    }
+
+    const app = createApp({
+      http: {
+        controllers: [],
+        children: [
+          {
+            path: '/api',
+            controllers: [UserController],
+          },
+        ],
+      },
+    });
+    await app.ready();
+
+    const res = await app.request('/api/users/');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ users: [] });
+  });
+
+  it('middlewares accumulate from parent to child', async () => {
+    const order: string[] = [];
+    const parentMiddleware: MiddlewareHandler = async (_c, next) => {
+      order.push('parent');
+      await next();
+    };
+    const childMiddleware: MiddlewareHandler = async (_c, next) => {
+      order.push('child');
+      await next();
+    };
+
+    @Controller('/test')
+    class ChildController {
+      @Get('/')
+      get() {
+        order.push('handler');
+        return { ok: true };
+      }
+    }
+
+    const app = createApp({
+      http: {
+        controllers: [],
+        middlewares: [parentMiddleware],
+        children: [
+          {
+            path: '/api',
+            controllers: [ChildController],
+            middlewares: [childMiddleware],
+          },
+        ],
+      },
+    });
+    await app.ready();
+
+    await app.request('/api/test/');
+    expect(order).toEqual(['parent', 'child', 'handler']);
+  });
+
+  it('error handlers are scoped per child level', async () => {
+    @ErrorHandler
+    class ChildErrorHandler {
+      onError(error: Error, _c: Context) {
+        return Response.json({ scope: 'child', message: error.message }, { status: 400 });
+      }
+    }
+
+    @Controller('/test')
+    class ChildController {
+      @Get('/')
+      get() {
+        throw new Error('child error');
+      }
+    }
+
+    const app = createApp({
+      http: {
+        controllers: [],
+        children: [
+          {
+            path: '/api',
+            controllers: [ChildController],
+            errorHandlers: [ChildErrorHandler],
+          },
+        ],
+      },
+    });
+    await app.ready();
+
+    const res = await app.request('/api/test/');
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ scope: 'child', message: 'child error' });
+  });
+
+  it('multi-level nesting works (3 levels)', async () => {
+    @Controller('/items')
+    class ItemController {
+      @Get('/')
+      list() {
+        return { items: ['a', 'b'] };
+      }
+    }
+
+    const app = createApp({
+      http: {
+        controllers: [],
+        children: [
+          {
+            path: '/api',
+            children: [
+              {
+                path: '/v1',
+                controllers: [ItemController],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    await app.ready();
+
+    const res = await app.request('/api/v1/items/');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ items: ['a', 'b'] });
+  });
+
+  it('getControllers() returns flattened array including children', async () => {
+    @Controller('/a')
+    class ControllerA {
+      @Get('/')
+      get() {
+        return {};
+      }
+    }
+
+    @Controller('/b')
+    class ControllerB {
+      @Get('/')
+      get() {
+        return {};
+      }
+    }
+
+    const app = createApp({
+      http: {
+        controllers: [ControllerA],
+        children: [
+          {
+            path: '/child',
+            controllers: [ControllerB],
+          },
+        ],
+      },
+    });
+    await app.ready();
+
+    const controllers = app.getControllers();
+    expect(controllers).toContain(ControllerA);
+    expect(controllers).toContain(ControllerB);
+    expect(controllers).toHaveLength(2);
+  });
+
+  it('getMetadata() returns prefix-joined paths for children', async () => {
+    @Controller('/items')
+    class MetaController {
+      @Get('/:id')
+      getById() {
+        return {};
+      }
+    }
+
+    const app = createApp({
+      http: {
+        controllers: [],
+        children: [
+          {
+            path: '/api',
+            controllers: [MetaController],
+          },
+        ],
+      },
+    });
+    await app.ready();
+
+    const meta = app.getMetadata();
+    expect(meta.controllers).toHaveLength(1);
+    expect(meta.controllers[0]?.basePath).toBe('/api/items');
+    expect(meta.controllers[0]?.routes[0]?.fullPath).toBe('/api/items/:id');
+  });
+});
+
 describe('warmup option', () => {
   it('lazy mode (default): lifecycle starts on first request', async () => {
     const events: string[] = [];

--- a/packages/core/src/modules/http/http-children.lib.ts
+++ b/packages/core/src/modules/http/http-children.lib.ts
@@ -1,0 +1,44 @@
+import type { ControllerClass, HttpChildOptions, HttpOptions } from './http.types';
+import type { ControllerRouteInfo } from './routing';
+import { collectControllerRouteInfo, joinPath } from './routing';
+
+export const collectAllControllers = (options: HttpOptions): readonly ControllerClass[] => {
+  const result: ControllerClass[] = [...options.controllers];
+  const collectFromChildren = (children: readonly HttpChildOptions[]): void => {
+    for (const child of children) {
+      result.push(...(child.controllers ?? []));
+      collectFromChildren(child.children ?? []);
+    }
+  };
+  collectFromChildren(options.children ?? []);
+  return result;
+};
+
+export const collectAllControllerMetadata = (
+  options: HttpOptions,
+  prefix = '',
+): readonly ControllerRouteInfo[] => {
+  const result: ControllerRouteInfo[] = options.controllers.map((cls) => {
+    const info = collectControllerRouteInfo(cls);
+    if (!prefix) return info;
+    return {
+      ...info,
+      basePath: joinPath(prefix, info.basePath),
+      routes: info.routes.map((r) => ({
+        ...r,
+        fullPath: joinPath(prefix, r.fullPath),
+      })),
+    };
+  });
+
+  for (const child of options.children ?? []) {
+    const childPrefix = joinPath(prefix, child.path);
+    const childAsOptions: HttpOptions = {
+      controllers: child.controllers ?? [],
+      ...(child.children ? { children: child.children } : {}),
+    };
+    result.push(...collectAllControllerMetadata(childAsOptions, childPrefix));
+  }
+
+  return result;
+};

--- a/packages/core/src/modules/http/http.service.ts
+++ b/packages/core/src/modules/http/http.service.ts
@@ -97,10 +97,11 @@ export class HttpService implements Lifecycle<{ hono: Hono }> {
 
     for (const child of children) {
       const childMiddlewares = [...middlewares, ...(child.middlewares ?? [])];
+      const childErrorHandlers = [...(child.errorHandlers ?? []), ...errorHandlerClasses];
       const childHono = this.buildHonoInstance(
         child.controllers ?? [],
         childMiddlewares,
-        child.errorHandlers ?? [],
+        childErrorHandlers,
         child.children ?? [],
         fallbackHandler,
         resolver,

--- a/packages/core/src/modules/http/http.service.ts
+++ b/packages/core/src/modules/http/http.service.ts
@@ -34,7 +34,7 @@ export class HttpService implements Lifecycle<{ hono: Hono }> {
     this.ready = this.lifecycleManager.register(this);
     this.lifecycleManager.registerWarmup(async () => {
       await warmupControllers(
-        this.options.controllers,
+        collectAllControllers(this.options),
         {
           get: <T extends object>(cls: new (...args: never[]) => T): T =>
             resolve(this.container, cls),

--- a/packages/core/src/modules/http/http.service.ts
+++ b/packages/core/src/modules/http/http.service.ts
@@ -4,19 +4,16 @@ import type { Lifecycle } from '../../kernel';
 import { LifecycleManager } from '../../kernel';
 import { Injectable, inject, resolve } from '../../kernel/di';
 import { DefaultErrorHandler } from './error/default.error-handler';
-import type { ControllerClass } from './http.types';
+import type { ControllerClass, HttpChildOptions, HttpOptions } from './http.types';
+import { collectAllControllerMetadata, collectAllControllers } from './http-children.lib';
 import { createErrorHandler, resolveErrorHandlers } from './http-error-handlers.lib';
 import { CorsMiddleware } from './middleware/cors/cors.middleware';
 import type { ErrorHandlerClass, MiddlewareInput } from './middleware/middleware.types';
 import { SecureHeadersMiddleware } from './middleware/secure-headers/secure-headers.middleware';
 import type { ControllerRouteInfo } from './routing';
-import { buildRoutes, collectControllerRouteInfo, warmupControllers } from './routing';
+import { buildRoutes, warmupControllers } from './routing';
 
-export type HttpOptions = {
-  readonly controllers: readonly ControllerClass[];
-  readonly middlewares?: readonly MiddlewareInput[];
-  readonly errorHandlers?: readonly ErrorHandlerClass[];
-};
+export type { HttpChildOptions, HttpOptions } from './http.types';
 
 export type HttpMetadata = {
   readonly controllers: readonly ControllerRouteInfo[];
@@ -54,27 +51,63 @@ export class HttpService implements Lifecycle<{ hono: Hono }> {
 
   /** @throws {ZeltNotImplementedError | ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
   private async initializeHono(): Promise<Hono> {
-    const hono = new Hono({ strict: false });
-
-    const errorHandlers = resolveErrorHandlers(this.options.errorHandlers ?? [], this.container);
     const fallbackHandler = resolve(this.container, DefaultErrorHandler);
-    hono.onError(createErrorHandler(errorHandlers, fallbackHandler));
+    const resolver = {
+      get: <T extends object>(cls: new (...args: never[]) => T): T => resolve(this.container, cls),
+    };
 
     const securityMiddlewares: readonly MiddlewareInput[] = [
       CorsMiddleware,
       SecureHeadersMiddleware,
     ];
+    const rootMiddlewares = [...securityMiddlewares, ...(this.options.middlewares ?? [])];
+
+    const hono = this.buildHonoInstance(
+      this.options.controllers,
+      rootMiddlewares,
+      this.options.errorHandlers ?? [],
+      this.options.children ?? [],
+      fallbackHandler,
+      resolver,
+    );
+    return hono;
+  }
+
+  /** @throws {ZeltContextNotAvailableError | ZeltDecoratorUsageError} */
+  private buildHonoInstance(
+    controllers: readonly ControllerClass[],
+    middlewares: readonly MiddlewareInput[],
+    errorHandlerClasses: readonly ErrorHandlerClass[],
+    children: readonly HttpChildOptions[],
+    fallbackHandler: InstanceType<typeof DefaultErrorHandler>,
+    resolver: { get: <T extends object>(cls: new (...args: never[]) => T) => T },
+  ): Hono {
+    const hono = new Hono({ strict: false });
+
+    const errorHandlers = resolveErrorHandlers(errorHandlerClasses, this.container);
+    hono.onError(createErrorHandler(errorHandlers, fallbackHandler));
 
     buildRoutes({
       hono,
-      controllers: this.options.controllers,
-      resolver: {
-        get: <T extends object>(cls: new (...args: never[]) => T): T =>
-          resolve(this.container, cls),
-      },
+      controllers,
+      resolver,
       lifecycle: this.lifecycleManager,
-      globalMiddlewares: [...securityMiddlewares, ...(this.options.middlewares ?? [])],
+      globalMiddlewares: middlewares,
     });
+
+    for (const child of children) {
+      const childMiddlewares = [...middlewares, ...(child.middlewares ?? [])];
+      const childHono = this.buildHonoInstance(
+        child.controllers ?? [],
+        childMiddlewares,
+        child.errorHandlers ?? [],
+        child.children ?? [],
+        fallbackHandler,
+        resolver,
+      );
+      hono.route(child.path, childHono);
+    }
+
     return hono;
   }
 
@@ -92,12 +125,12 @@ export class HttpService implements Lifecycle<{ hono: Hono }> {
   }
 
   getControllers(): readonly ControllerClass[] {
-    return this.options.controllers;
+    return collectAllControllers(this.options);
   }
 
   getMetadata(): HttpMetadata {
     return {
-      controllers: this.options.controllers.map(collectControllerRouteInfo),
+      controllers: collectAllControllerMetadata(this.options),
     };
   }
 }

--- a/packages/core/src/modules/http/http.types.ts
+++ b/packages/core/src/modules/http/http.types.ts
@@ -1,1 +1,18 @@
+import type { ErrorHandlerClass, MiddlewareInput } from './middleware/middleware.types';
+
 export type ControllerClass = new (...args: never[]) => object;
+
+export type HttpChildOptions = {
+  readonly path: string;
+  readonly controllers?: readonly ControllerClass[];
+  readonly middlewares?: readonly MiddlewareInput[];
+  readonly errorHandlers?: readonly ErrorHandlerClass[];
+  readonly children?: readonly HttpChildOptions[];
+};
+
+export type HttpOptions = {
+  readonly controllers: readonly ControllerClass[];
+  readonly middlewares?: readonly MiddlewareInput[];
+  readonly errorHandlers?: readonly ErrorHandlerClass[];
+  readonly children?: readonly HttpChildOptions[];
+};

--- a/packages/core/src/modules/http/routing/index.ts
+++ b/packages/core/src/modules/http/routing/index.ts
@@ -1,3 +1,4 @@
+export { joinPath } from './path-utils.lib';
 export { buildRoutes, warmupControllers } from './route-builder.lib';
 export type { ControllerRouteInfo, HttpMethod, RouteInfo } from './routing-metadata.lib';
 export {


### PR DESCRIPTION
## Summary

- Add `HttpChildOptions` type and `children` property to `HttpOptions` for path-prefix grouping
- Implement recursive Hono sub-app mounting via `buildHonoInstance()` with scoped middleware inheritance and error handling
- Flatten `getControllers()` and `getMetadata()` to include all nested children

## Test plan

- [x] Child routes accessible at prefixed paths
- [x] Middlewares accumulate parent → child in correct order
- [x] Error handlers scoped per child level
- [x] Multi-level nesting works (3+ levels)
- [x] `getControllers()` / `getMetadata()` return flattened arrays
- [x] All 643 existing tests pass
- [x] No circular dependencies
- [x] throw-trace annotations added

Closes #243

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782724411&installation_id=133048706&pr_number=244&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F244&signature=ce098bae3252556fec2a8f0de4b9d14d0c352e685a77588dc7d90dbb9e787b7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTPモジュールでネストされた子ルーティングを正式サポート。子ルートを親パスへマウントし階層ごとのミドルウェア・エラーハンドラを適用可能。

* **Refactor**
  * 起動・コントローラ取得処理が子ルートを含む全体を扱うように変更。ルーティング情報の basePath/fullPath を階層反映。
  * 型定義を整理し再エクスポートを導入。

* **Tests**
  * ネスト動作（パス解決、ミドルウェア順序、エラーハンドラのスコープ/バブル、3層ネスト等）を検証するテストを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->