### PR TITLE
fix(core): replace direct HTTPException with defineHttpException

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -190,8 +190,7 @@ export default tseslint.config(
         'error',
         {
           selector: 'NewExpression[callee.name="HTTPException"]',
-          message:
-            'Use defineHttpException() in *.exceptions.ts instead of direct HTTPException',
+          message: 'Use defineHttpException() in *.exceptions.ts instead of direct HTTPException',
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -176,6 +176,27 @@ export default tseslint.config(
     },
   },
   {
+    // Forbid direct HTTPException — use defineHttpException in *.exceptions.ts instead
+    files: ['packages/**/*.{ts,tsx}'],
+    ignores: [
+      ...TEST_FILES,
+      ...FIXTURE_FILES,
+      '**/errors/**',
+      '**/define-http-exception.lib.ts',
+      '**/*.exceptions.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'NewExpression[callee.name="HTTPException"]',
+          message:
+            'Use defineHttpException() in *.exceptions.ts instead of direct HTTPException',
+        },
+      ],
+    },
+  },
+  {
     // decorator-metadata/inspect uses TypeScript Compiler API which requires
     // type assertions for internal type narrowing (e.g., StringLiteralType, TypeReference)
     files: ['packages/decorator-metadata/src/inspect/**/*.ts'],

--- a/integration/zelt-application/e2e/body-parser.spec.ts
+++ b/integration/zelt-application/e2e/body-parser.spec.ts
@@ -75,7 +75,9 @@ describe('Body parsing', () => {
         body: '',
       });
       expect(res.status).toBe(400);
-      expect(await res.text()).toBe('Invalid JSON: Unexpected end of JSON input');
+      const json = (await res.json()) as { code: string; message: string };
+      expect(json.code).toBe('BAD_REQUEST');
+      expect(json.message).toBe('Invalid JSON: Unexpected end of JSON input');
     });
 
     it('parses empty application/x-www-form-urlencoded body as empty object', async () => {

--- a/packages/core/src/modules/http/error/default.error-handler.test.ts
+++ b/packages/core/src/modules/http/error/default.error-handler.test.ts
@@ -1,0 +1,99 @@
+import { HTTPException } from 'hono/http-exception';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { createApp } from '../../../app';
+import { Config } from '../../../built-in-service/config';
+import { EnvAdaptor } from '../../../built-in-service/env/env.adaptor';
+import { BadRequestException } from '../http.exceptions';
+
+import { DefaultErrorHandler } from './default.error-handler';
+
+let handler: DefaultErrorHandler;
+let devHandler: DefaultErrorHandler;
+
+const setupHandlers = async () => {
+  @Config
+  class ProdEnvAdaptor extends EnvAdaptor {
+    override get(key: string) {
+      return key === 'NODE_ENV' ? 'production' : undefined;
+    }
+  }
+
+  @Config
+  class DevEnvAdaptor extends EnvAdaptor {
+    override get(key: string) {
+      return key === 'NODE_ENV' ? 'development' : undefined;
+    }
+  }
+
+  const prodApp = createApp({ configs: [ProdEnvAdaptor] });
+  const { get: prodGet } = await prodApp.ready();
+  handler = prodGet(DefaultErrorHandler);
+
+  const devApp = createApp({ configs: [DevEnvAdaptor] });
+  const { get: devGet } = await devApp.ready();
+  devHandler = devGet(DefaultErrorHandler);
+};
+
+const dummyContext = {} as Parameters<DefaultErrorHandler['onError']>[1];
+
+describe('DefaultErrorHandler', () => {
+  beforeAll(async () => {
+    await setupHandlers();
+  });
+
+  describe('HTTPException with res (defineHttpException pattern)', () => {
+    it('returns JSON response from BadRequestException', async () => {
+      const err = new BadRequestException({ reason: 'invalid input' });
+
+      const res = handler.onError(err, dummyContext);
+
+      expect(res.status).toBe(400);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      await expect(res.json()).resolves.toEqual({
+        code: 'BAD_REQUEST',
+        message: 'invalid input',
+      });
+    });
+
+    it('preserves custom res from HTTPException', async () => {
+      const err = new HTTPException(409, {
+        res: Response.json({ code: 'CONFLICT', detail: 'duplicate' }, { status: 409 }),
+      });
+
+      const res = handler.onError(err, dummyContext);
+
+      expect(res.status).toBe(409);
+      await expect(res.json()).resolves.toEqual({
+        code: 'CONFLICT',
+        detail: 'duplicate',
+      });
+    });
+  });
+
+  describe('generic Error', () => {
+    it('hides message in production', async () => {
+      const err = new Error('secret details');
+
+      const res = handler.onError(err, dummyContext);
+
+      expect(res.status).toBe(500);
+      await expect(res.json()).resolves.toEqual({
+        code: 'INTERNAL_ERROR',
+        message: 'internal server error',
+      });
+    });
+
+    it('exposes message in development', async () => {
+      const err = new Error('something broke');
+
+      const res = devHandler.onError(err, dummyContext);
+
+      expect(res.status).toBe(500);
+      await expect(res.json()).resolves.toEqual({
+        code: 'INTERNAL_ERROR',
+        message: 'something broke',
+      });
+    });
+  });
+});

--- a/packages/core/src/modules/http/http.exceptions.ts
+++ b/packages/core/src/modules/http/http.exceptions.ts
@@ -1,0 +1,21 @@
+import { defineHttpException } from '../../kernel/errors';
+
+export const BadRequestException = defineHttpException(
+  'BadRequestException',
+  400,
+  (ctx: { reason: string }) => ctx.reason,
+  {
+    buildResponse: (_ctx, status, message) =>
+      Response.json({ code: 'BAD_REQUEST', message }, { status }),
+  },
+);
+
+export const UnsupportedMediaTypeException = defineHttpException(
+  'UnsupportedMediaTypeException',
+  415,
+  (ctx: { expected: string; actual: string }) => `Expected ${ctx.expected} body, got ${ctx.actual}`,
+  {
+    buildResponse: (_ctx, status, message) =>
+      Response.json({ code: 'UNSUPPORTED_MEDIA_TYPE', message }, { status }),
+  },
+);

--- a/packages/core/src/modules/http/request/injection/body.lib.ts
+++ b/packages/core/src/modules/http/request/injection/body.lib.ts
@@ -1,7 +1,6 @@
-import { HTTPException } from 'hono/http-exception';
-
 import { ZeltContextNotAvailableError } from '../../../../kernel/errors';
 import { createContextKey, getInternal, setInternal } from '../../../../kernel/internal';
+import { UnsupportedMediaTypeException } from '../../http.exceptions';
 
 type FormBody = Record<string, string | File | (string | File)[]>;
 
@@ -29,20 +28,18 @@ const getBody = (): ParsedBody => {
   return ctx;
 };
 
-/** @throws {ZeltContextNotAvailableError | HTTPException} */
+/** @throws {ZeltContextNotAvailableError | UnsupportedMediaTypeException} */
 export function body(type?: 'json'): unknown;
-/** @throws {ZeltContextNotAvailableError | HTTPException} */
+/** @throws {ZeltContextNotAvailableError | UnsupportedMediaTypeException} */
 export function body(type: 'form'): FormBody;
-/** @throws {ZeltContextNotAvailableError | HTTPException} */
+/** @throws {ZeltContextNotAvailableError | UnsupportedMediaTypeException} */
 export function body(type: 'text'): string;
-/** @throws {ZeltContextNotAvailableError | HTTPException} */
+/** @throws {ZeltContextNotAvailableError | UnsupportedMediaTypeException} */
 export function body(type: 'json' | 'form' | 'text' = 'json'): unknown {
   const parsedBody = getBody();
 
   if (parsedBody.type !== type) {
-    throw new HTTPException(415, {
-      message: `Expected ${type} body, got ${parsedBody.type}`,
-    });
+    throw new UnsupportedMediaTypeException({ expected: type, actual: parsedBody.type });
   }
 
   return parsedBody.val;

--- a/packages/core/src/modules/http/routing/route-builder.lib.test.ts
+++ b/packages/core/src/modules/http/routing/route-builder.lib.test.ts
@@ -85,7 +85,7 @@ describe('parseRequestBody — malformed body handling', () => {
   const app = createApp({ http: { controllers: [BodyController] } });
   const ready = app.ready();
 
-  it('returns 400 for malformed JSON', async () => {
+  it('returns 400 JSON for malformed JSON', async () => {
     await ready;
     const res = await app.fetch(
       new Request('http://localhost/body/json', {
@@ -95,8 +95,10 @@ describe('parseRequestBody — malformed body handling', () => {
       }),
     );
     expect(res.status).toBe(400);
-    const text = await res.text();
-    expect(text).toMatch(/Invalid JSON/);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const json = (await res.json()) as { code: string; message: string };
+    expect(json.code).toBe('BAD_REQUEST');
+    expect(json.message).toMatch(/Invalid JSON/);
   });
 
   it('returns 200 for valid JSON', async () => {

--- a/packages/core/src/modules/http/routing/route-builder.lib.ts
+++ b/packages/core/src/modules/http/routing/route-builder.lib.ts
@@ -1,5 +1,4 @@
 import type { Context, Env, Hono, Input } from 'hono';
-import { HTTPException } from 'hono/http-exception';
 import type { LifecycleManager } from '../../../kernel';
 import type { ResolverHandle } from '../../../kernel/di';
 import {
@@ -8,6 +7,7 @@ import {
   ZeltRouteConfigurationError,
 } from '../../../kernel/errors';
 import { runInContext } from '../../../kernel/internal';
+import { BadRequestException } from '../http.exceptions';
 import { currentRoles, currentUser } from '../middleware/auth';
 import type {
   FunctionMiddleware,
@@ -87,7 +87,7 @@ type ParsedBody =
   | { type: 'text'; val: string }
   | { type: 'none'; val: undefined };
 
-/** @throws {HTTPException} */
+/** @throws {BadRequestException} */
 const parseRequestBody = async (
   c: Parameters<Parameters<Hono['on']>[2]>[0],
 ): Promise<ParsedBody> => {
@@ -95,7 +95,7 @@ const parseRequestBody = async (
 
   if (contentType.includes('application/json')) {
     const val = await c.req.json<unknown>().catch((e: Error) => {
-      throw new HTTPException(400, { message: `Invalid JSON: ${e.message}` });
+      throw new BadRequestException({ reason: `Invalid JSON: ${e.message}` });
     });
     return { type: 'json', val };
   }
@@ -105,14 +105,14 @@ const parseRequestBody = async (
     contentType.includes('application/x-www-form-urlencoded')
   ) {
     const val: FormBody = await c.req.parseBody({ all: true }).catch((e: Error) => {
-      throw new HTTPException(400, { message: `Invalid form data: ${e.message}` });
+      throw new BadRequestException({ reason: `Invalid form data: ${e.message}` });
     });
     return { type: 'form', val };
   }
 
   if (contentType.startsWith('text/')) {
     const val = await c.req.text().catch((e: Error) => {
-      throw new HTTPException(400, { message: `Invalid text body: ${e.message}` });
+      throw new BadRequestException({ reason: `Invalid text body: ${e.message}` });
     });
     return { type: 'text', val };
   }
@@ -305,7 +305,7 @@ const registerRoute = (
     ctx.resolver,
   );
 
-  /** @throws {HTTPException | ZeltContextNotAvailableError | ZeltMiddlewareExecutionError | ZeltRouteConfigurationError} */
+  /** @throws {BadRequestException | ZeltContextNotAvailableError | ZeltMiddlewareExecutionError | ZeltRouteConfigurationError} */
   const handler = async (c: MiddlewareContext): Promise<Response> => {
     const instance = getOrCreateInstance(ctx, route.controllerClass);
     await ctx.lifecycle.startupPending();

--- a/packages/validator-valibot/package.json
+++ b/packages/validator-valibot/package.json
@@ -32,7 +32,6 @@
   "peerDependencies": {
     "@zeltjs/core": "workspace:*",
     "@zeltjs/openapi": "workspace:*",
-    "hono": "catalog:",
     "valibot": "catalog:peer",
     "@valibot/to-json-schema": "catalog:peer"
   },
@@ -49,7 +48,6 @@
     "@valibot/to-json-schema": "catalog:",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/openapi": "workspace:*",
-    "hono": "catalog:",
     "valibot": "catalog:"
   },
   "volta": {

--- a/packages/validator-valibot/src/validated.exceptions.ts
+++ b/packages/validator-valibot/src/validated.exceptions.ts
@@ -1,0 +1,13 @@
+import { defineHttpException } from '@zeltjs/core';
+import type { BaseIssue } from 'valibot';
+
+export const ValidationFailedException = defineHttpException(
+  'ValidationFailedException',
+  400,
+  (ctx: { issues: readonly BaseIssue<unknown>[] }) =>
+    `Validation failed: ${ctx.issues.length} issue(s)`,
+  {
+    buildResponse: (ctx, status) =>
+      Response.json({ code: 'VALIDATION_FAILED', issues: ctx.issues }, { status }),
+  },
+);

--- a/packages/validator-valibot/src/validated.lib.ts
+++ b/packages/validator-valibot/src/validated.lib.ts
@@ -1,20 +1,21 @@
 import type { ValidatedMarker, ValidationTarget } from '@zeltjs/core';
 import { body } from '@zeltjs/core';
-import { HTTPException } from 'hono/http-exception';
 import type { GenericSchema, InferOutput } from 'valibot';
 import { safeParse } from 'valibot';
 
-/** @throws {HTTPException | ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
+import { ValidationFailedException } from './validated.exceptions';
+
+/** @throws {ValidationFailedException | ZeltContextNotAvailableError | UnsupportedMediaTypeException} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target?: 'json',
 ): ValidatedMarker<InferOutput<Schema>, 'json'>;
-/** @throws {HTTPException | ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
+/** @throws {ValidationFailedException | ZeltContextNotAvailableError | UnsupportedMediaTypeException} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target: 'form',
 ): ValidatedMarker<InferOutput<Schema>, 'form'>;
-/** @throws {HTTPException | ZeltContextNotAvailableError | ZeltBodyTypeMismatchError} */
+/** @throws {ValidationFailedException | ZeltContextNotAvailableError | UnsupportedMediaTypeException} */
 export function validated<Schema extends GenericSchema>(
   schema: Schema,
   target: ValidationTarget = 'json',
@@ -23,9 +24,7 @@ export function validated<Schema extends GenericSchema>(
 
   const result = safeParse(schema, raw);
   if (!result.success) {
-    throw new HTTPException(400, {
-      res: Response.json({ code: 'VALIDATION_FAILED', issues: result.issues }, { status: 400 }),
-    });
+    throw new ValidationFailedException({ issues: result.issues });
   }
   return result.output;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,9 +577,6 @@ importers:
       '@zeltjs/openapi':
         specifier: workspace:*
         version: link:../openapi
-      hono:
-        specifier: 'catalog:'
-        version: 4.12.16
       valibot:
         specifier: 'catalog:'
         version: 1.3.1(typescript@6.0.2)


### PR DESCRIPTION
## Summary

- Centralize scattered `new HTTPException(status, { message })` calls into `defineHttpException` definitions in `*.exceptions.ts` files
- Add ESLint rule (`no-restricted-syntax`) to prevent direct `new HTTPException()` usage in production code
- Remove unused `hono` dependency from `validator-valibot` (no longer directly imported)

## Motivation

`new HTTPException(status, { message })` returns `text/plain` via Hono's `getResponse()`. Using `defineHttpException` with `buildResponse` ensures consistent JSON API responses.

## Changes

| File | Change |
|------|--------|
| `http.exceptions.ts` (new) | `BadRequestException` (400), `UnsupportedMediaTypeException` (415) |
| `validated.exceptions.ts` (new) | `ValidationFailedException` (400) |
| `default.error-handler.test.ts` (new) | Unit tests for DefaultErrorHandler |
| `route-builder.lib.ts` | 3x `new HTTPException` → `BadRequestException` |
| `body.lib.ts` | `new HTTPException` → `UnsupportedMediaTypeException` |
| `validated.lib.ts` | `new HTTPException` → `ValidationFailedException` |
| `eslint.config.mjs` | Lint rule to forbid direct `new HTTPException()` |
| `package.json` (validator-valibot) | Remove unused `hono` from peer/dev deps |

## Test plan

- [ ] All 641 tests pass (`pnpm test`)
- [ ] ESLint clean (`pnpm eslint packages/`)
- [ ] knip clean (`pnpm knip`)
- [ ] Verify malformed JSON request returns `{ code: "BAD_REQUEST", message: "..." }` with `application/json` content-type

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782724743&installation_id=133048706&pr_number=245&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F245&signature=2fd2fdb092f26ac1515b1350ccdc40691e3c7ff21d94f770dad23f3f3b31d0e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * HTTP用例外を追加（BadRequest 400・UnsupportedMediaType 415・ValidationFailed 400）。
  * バリデーション失敗やボディ解析エラーで、コード付きJSONエラー応答（issues や reason を含む）を返すよう改善。

* **テスト**
  * エラーハンドラーの環境別挙動検証テストを追加。
  * リクエストボディ解析／不正JSON時の検証テストを強化。

* **雑務**
  * ESLint設定の追加とルール強化。
  * バリデータ関連パッケージの依存定義を更新。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->