### PR TITLE
fix(precommit): run biome format on all files before lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run",
     "test:integration": "./integration/scripts/run-tests.sh dist",
     "typecheck": "tsc -b",
-    "precommit": "pnpx lint-staged && pnpm typecheck && pnpm lint:cycle && pnpm build && pnpm --filter '@examples/*' typecheck && pnpm --filter website verify:docs && pnpm verify-dist && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
+    "precommit": "./scripts/format-staged.sh && pnpx lint-staged && pnpm typecheck && pnpm lint:cycle && pnpm build && pnpm --filter '@examples/*' typecheck && pnpm --filter website verify:docs && pnpm verify-dist && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
     "prepare": "pnpx lefthook install",
     "codepolicy:diff": "time codepolicy --filter=diff 2>&1 | tee codepolicy.diff.log",
     "throw-trace": "throw-trace check --exclude '**/*.test.ts' packages",
@@ -60,7 +60,6 @@
     "npm": "11.14.1"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx,json}": "biome check --write --unsafe",
     "*.{ts,tsx,js,jsx}": [
       "eslint --fix",
       "oxlint --fix"

--- a/scripts/format-staged.sh
+++ b/scripts/format-staged.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 # Unstaged files get formatted in the working tree (benefiting future commits)
 # but are NOT added to the current commit.
 
-STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+STAGED=$(git diff --cached -z --name-only --diff-filter=ACMR)
 
 pnpm format
 
 if [ -n "$STAGED" ]; then
-  echo "$STAGED" | xargs git add
+  printf '%s' "$STAGED" | xargs -0 git add
 fi

--- a/scripts/format-staged.sh
+++ b/scripts/format-staged.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Format all files, but only re-stage files that were already staged.
+# Unstaged files get formatted in the working tree (benefiting future commits)
+# but are NOT added to the current commit.
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+
+pnpm format
+
+if [ -n "$STAGED" ]; then
+  echo "$STAGED" | xargs git add
+fi


### PR DESCRIPTION
## Summary

- biome format を lint-staged から分離し、precommit の最初に全ファイル対象で実行するように変更
- staged files のリストを保存してから `pnpm format` を実行し、元々 staged だったファイルのみ再 stage
- lint-staged は eslint + oxlint のみに縮小

## Background

CI 失敗の統計調査により、precommit-verify ✓ のコミットでも CI の format check (full) で落ちるケースが多数発見された。根本原因は lint-staged のグロブに `.mjs` が含まれておらず、また staged files のみを対象とするため全ファイルの format 一貫性を保証できなかったこと。

## Test plan

- [x] format 壊れた staged ファイルが自動修正 + 再 stage されることを確認
- [x] 意図的に unstaged にしたファイルが stage されないことを確認
- [x] `pnpm precommit` が正常に通過することを確認

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782729956&installation_id=133048706&pr_number=247&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F247&signature=422300a8ca06c2a4e119fff3b5e60b0f64f83670d959739240e0ccd3c824efee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * コミット前の処理を改善しました：変更がステージ済みのファイルのみをフォーマットして再ステージするようになり、作業ツリーの未ステージ変更は影響しません。
  * リント/整形の対象を整理しました：JSON を対象とする一部の自動整形は除外され、TypeScript/JavaScript 系ファイルには ESLint/OxLint による自動修正が適用されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->