### PR TITLE
fix(integration): enable tsc --noEmit for all integration tests

### DIFF
--- a/integration/discovery/e2e/discover-by-meta.spec.ts
+++ b/integration/discovery/e2e/discover-by-meta.spec.ts
@@ -1,4 +1,6 @@
+import type { App, HttpModule } from '@zeltjs/core';
 import { getClassMetadata } from '@zeltjs/decorator-metadata';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -17,7 +19,7 @@ import { providers } from '../src/providers';
 import { WebhooksExplorer } from '../src/webhooks.explorer';
 
 describe('Discovery', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/discovery/tsconfig.json
+++ b/integration/discovery/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist"

--- a/integration/ec-backend/tsconfig.json
+++ b/integration/ec-backend/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist"

--- a/integration/hello-world/e2e/exceptions.spec.ts
+++ b/integration/hello-world/e2e/exceptions.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('Exceptions', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/hello-world/e2e/exclude-middleware.spec.ts
+++ b/integration/hello-world/e2e/exclude-middleware.spec.ts
@@ -1,4 +1,4 @@
-import type { Next, RequestContext } from '@zeltjs/core';
+import type { App, HttpModule, Next, RequestContext } from '@zeltjs/core';
 import {
   Controller,
   createApp,
@@ -8,6 +8,7 @@ import {
   SkipMiddleware,
   UseMiddleware,
 } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -78,7 +79,7 @@ class TestController {
 }
 
 describe('Exclude middleware (@SkipMiddleware)', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   afterEach(async () => {
     await shutdownAll();

--- a/integration/hello-world/e2e/guards.spec.ts
+++ b/integration/hello-world/e2e/guards.spec.ts
@@ -1,4 +1,6 @@
+import type { App, HttpModule } from '@zeltjs/core';
 import { createApp } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -6,7 +8,7 @@ import { authMiddleware } from '../src/auth.middleware';
 import { GuardsController } from '../src/guards.controller';
 
 describe('Guards (Authorization)', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     const app = createApp({

--- a/integration/hello-world/e2e/hello-world.spec.ts
+++ b/integration/hello-world/e2e/hello-world.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('Hello World', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/hello-world/e2e/interceptors.spec.ts
+++ b/integration/hello-world/e2e/interceptors.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('Interceptors (via Middleware)', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/hello-world/e2e/local-pipes.spec.ts
+++ b/integration/hello-world/e2e/local-pipes.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('Local Pipes (Parameter Transformation)', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/hello-world/e2e/middleware-class.spec.ts
+++ b/integration/hello-world/e2e/middleware-class.spec.ts
@@ -1,5 +1,6 @@
-import type { FunctionMiddleware, Next, RequestContext } from '@zeltjs/core';
+import type { App, FunctionMiddleware, HttpModule, Next, RequestContext } from '@zeltjs/core';
 import { Controller, createApp, Get, Middleware, Post, UseMiddleware } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -42,7 +43,7 @@ class TestController {
 }
 
 describe('Middleware (class)', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   afterEach(async () => {
     await shutdownAll();

--- a/integration/hello-world/e2e/middleware.spec.ts
+++ b/integration/hello-world/e2e/middleware.spec.ts
@@ -1,5 +1,6 @@
-import type { FunctionMiddleware } from '@zeltjs/core';
+import type { App, FunctionMiddleware, HttpModule } from '@zeltjs/core';
 import { createApp } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
@@ -7,7 +8,7 @@ import { app } from '../src/app';
 import { WildcardController } from '../src/wildcard.controller';
 
 describe('Middleware', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);
@@ -37,7 +38,7 @@ describe('Middleware', () => {
 });
 
 describe('Middleware (global)', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   afterEach(async () => {
     await shutdownAll();

--- a/integration/hello-world/tsconfig.json
+++ b/integration/hello-world/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist"

--- a/integration/hooks/tsconfig.json
+++ b/integration/hooks/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist"

--- a/integration/injector/e2e/error-paths.spec.ts
+++ b/integration/injector/e2e/error-paths.spec.ts
@@ -26,7 +26,7 @@ class OptionalDepConsumer {
 class SelfReferencingService {
   // Self-injection inside the same constructor must be detected by needle-di.
   // biome-ignore lint: intentional self-injection for circular-dependency test
-  constructor(public readonly self = inject(SelfReferencingService)) {}
+  constructor(public readonly self: SelfReferencingService = inject(SelfReferencingService)) {}
 }
 
 @Controller('/broken')

--- a/integration/injector/e2e/injector.spec.ts
+++ b/integration/injector/e2e/injector.spec.ts
@@ -1,3 +1,5 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -11,7 +13,7 @@ import { MiddleService } from '../src/middle.service';
 import { RootService } from '../src/root.service';
 
 describe('Injector', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/injector/tsconfig.json
+++ b/integration/injector/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist"

--- a/integration/scopes/e2e/middleware-context.spec.ts
+++ b/integration/scopes/e2e/middleware-context.spec.ts
@@ -1,3 +1,5 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -11,7 +13,7 @@ type ContextResponse = {
 };
 
 describe('Middleware <-> handler context integration', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/scopes/e2e/overlap-scope.spec.ts
+++ b/integration/scopes/e2e/overlap-scope.spec.ts
@@ -1,3 +1,5 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -6,7 +8,7 @@ import { app } from '../src/app';
 const OVERLAP_REQUEST_COUNT = 1000;
 
 describe('Overlapping requests preserve per-request context isolation', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/scopes/e2e/request-scope.spec.ts
+++ b/integration/scopes/e2e/request-scope.spec.ts
@@ -1,3 +1,5 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -5,7 +7,7 @@ import { app } from '../src/app';
 import { RequestIdService } from '../src/request-id.service';
 
 describe('Request-scoped data via getContext/setContext', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
   let serviceCallsAtStart = 0;
 
   beforeAll(async () => {

--- a/integration/scopes/e2e/singleton-scope.spec.ts
+++ b/integration/scopes/e2e/singleton-scope.spec.ts
@@ -1,3 +1,5 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -6,7 +8,7 @@ import { CounterService } from '../src/counter.service';
 import { ScopesController } from '../src/scopes.controller';
 
 describe('Singleton (DEFAULT) scope', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
   let controllerCallsAtStart = 0;
   let serviceCallsAtStart = 0;
 

--- a/integration/scopes/tsconfig.json
+++ b/integration/scopes/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist"

--- a/integration/scripts/run-tests.sh
+++ b/integration/scripts/run-tests.sh
@@ -47,6 +47,13 @@ run_tests() {
     echo "Running tests: $name"
     echo "=========================================="
 
+    if (cd "$dir" && npx tsc --noEmit); then
+      echo "✓ $name: tsc --noEmit passed"
+    else
+      echo "✗ $name: tsc --noEmit FAILED"
+      exit_code=1
+    fi
+
     if (cd "$dir" && pnpm test); then
       echo "✓ $name: PASSED"
     else

--- a/integration/scripts/switch-mode.sh
+++ b/integration/scripts/switch-mode.sh
@@ -158,10 +158,11 @@ generate_package_json() {
   overrides="${overrides%,}"
 
   # integration テストが直接 import するライブラリ。版は root catalog を単一の情報源とする
-  local hono_ver valibot_ver to_json_schema_ver
+  local hono_ver valibot_ver to_json_schema_ver types_node_ver
   hono_ver=$(get_catalog_version "hono")
   valibot_ver=$(get_catalog_version "valibot")
   to_json_schema_ver=$(get_catalog_version "@valibot/to-json-schema")
+  types_node_ver=$(get_catalog_version "@types/node")
 
   # @zeltjs/* が catalog: で参照する依存を実バージョンに固定する overrides 断片
   local catalog_overrides
@@ -185,7 +186,8 @@ generate_package_json() {
     "vitest": "3.2.4",
     "valibot": "$valibot_ver",
     "@valibot/to-json-schema": "$to_json_schema_ver",
-    "hono": "$hono_ver"
+    "hono": "$hono_ver",
+    "@types/node": "$types_node_ver"
   }
 }
 EOF
@@ -210,7 +212,8 @@ EOF
     "vitest": "3.2.4",
     "valibot": "$valibot_ver",
     "@valibot/to-json-schema": "$to_json_schema_ver",
-    "hono": "$hono_ver"
+    "hono": "$hono_ver",
+    "@types/node": "$types_node_ver"
   },
   "pnpm": {
     "overrides": {

--- a/integration/scripts/switch-mode.sh
+++ b/integration/scripts/switch-mode.sh
@@ -158,11 +158,12 @@ generate_package_json() {
   overrides="${overrides%,}"
 
   # integration テストが直接 import するライブラリ。版は root catalog を単一の情報源とする
-  local hono_ver valibot_ver to_json_schema_ver types_node_ver
+  local hono_ver valibot_ver to_json_schema_ver types_node_ver typescript_ver
   hono_ver=$(get_catalog_version "hono")
   valibot_ver=$(get_catalog_version "valibot")
   to_json_schema_ver=$(get_catalog_version "@valibot/to-json-schema")
   types_node_ver=$(get_catalog_version "@types/node")
+  typescript_ver=$(get_catalog_version "typescript")
 
   # @zeltjs/* が catalog: で参照する依存を実バージョンに固定する overrides 断片
   local catalog_overrides
@@ -187,7 +188,8 @@ generate_package_json() {
     "valibot": "$valibot_ver",
     "@valibot/to-json-schema": "$to_json_schema_ver",
     "hono": "$hono_ver",
-    "@types/node": "$types_node_ver"
+    "@types/node": "$types_node_ver",
+    "typescript": "$typescript_ver"
   }
 }
 EOF
@@ -213,7 +215,8 @@ EOF
     "valibot": "$valibot_ver",
     "@valibot/to-json-schema": "$to_json_schema_ver",
     "hono": "$hono_ver",
-    "@types/node": "$types_node_ver"
+    "@types/node": "$types_node_ver",
+    "typescript": "$typescript_ver"
   },
   "pnpm": {
     "overrides": {

--- a/integration/send-files/e2e/send-files.spec.ts
+++ b/integration/send-files/e2e/send-files.spec.ts
@@ -1,3 +1,5 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -5,7 +7,7 @@ import { app } from '../src/app';
 import { README_BUFFER, README_STRING } from '../src/fixtures';
 
 describe('Send Files', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/send-files/src/file.service.ts
+++ b/integration/send-files/src/file.service.ts
@@ -19,7 +19,7 @@ export class FileService {
     return Readable.toWeb(createReadStream(README_PATH)) as ReadableStream<Uint8Array>;
   }
 
-  getBuffer(): Uint8Array {
+  getBuffer(): Uint8Array<ArrayBuffer> {
     // Return a fresh Uint8Array view so the consumer can't mutate the shared buffer.
     return new Uint8Array(README_BUFFER);
   }

--- a/integration/send-files/tsconfig.json
+++ b/integration/send-files/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist"

--- a/integration/tsconfig.base.json
+++ b/integration/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": false,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "lib": ["ES2022", "DOM"]
+  }
+}

--- a/integration/versioning/e2e/middleware-versioning.spec.ts
+++ b/integration/versioning/e2e/middleware-versioning.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('URI Versioning - with middleware applied', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/versioning/e2e/uri-versioning.spec.ts
+++ b/integration/versioning/e2e/uri-versioning.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('URI Versioning', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/versioning/tsconfig.json
+++ b/integration/versioning/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist"

--- a/integration/zelt-application/e2e/body-parser.spec.ts
+++ b/integration/zelt-application/e2e/body-parser.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('Body parsing', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/zelt-application/e2e/global-prefix.spec.ts
+++ b/integration/zelt-application/e2e/global-prefix.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('Global prefix (via @Controller path)', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/zelt-application/e2e/response-builder.spec.ts
+++ b/integration/zelt-application/e2e/response-builder.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('Response builder', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/zelt-application/e2e/routing.spec.ts
+++ b/integration/zelt-application/e2e/routing.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('Routing behaviour', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/zelt-application/e2e/sse.spec.ts
+++ b/integration/zelt-application/e2e/sse.spec.ts
@@ -1,10 +1,12 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
 
 describe('Server-Sent Events', () => {
-  let testApp: Awaited<ReturnType<typeof onTest>>;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
     testApp = await onTest(app);

--- a/integration/zelt-application/tsconfig.json
+++ b/integration/zelt-application/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist"


### PR DESCRIPTION
## Summary

- integration テスト共通の `tsconfig.base.json` を追加（strict, skipLibCheck, DOM lib）
- 全 spec ファイルで `Awaited<ReturnType<typeof onTest>>` → `TestableApp<App<[HttpModule]>>` に置換し、型推論を修正
- `switch-mode.sh` に `@types/node` を devDependencies として追加
- `run-tests.sh` に `tsc --noEmit` ステップを追加し、CI で型安全性を検証
- TS6 の `Uint8Array` ジェネリクス互換性修正（send-files）

## Test plan

- [x] 全 9 integration テストで `tsc --noEmit` が 0 エラー
- [x] `pnpm run precommit` 通過（649 テスト pass）
- [x] vitest による regression なし

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782774569&installation_id=133048706&pr_number=248&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F248&signature=e5346cdeb011b94536c3c40a686bc55d1209be45cc0d8374bcf401c36cfe46e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores（保守）**
  * 統合された共通TypeScript設定を追加・参照先を統一
  * テストの型定義を整理・統一して型安全性を向上
  * 統合テスト実行時にTypeScript型チェックを追加
  * テスト関連スクリプトとパッケージ生成のデベロッパー依存指定を調整

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->