### PR TITLE
fix(core): make ReadyResult.get() async to call startupPending

### DIFF
--- a/integration/ec-backend/e2e/helpers/test-setup.ts
+++ b/integration/ec-backend/e2e/helpers/test-setup.ts
@@ -40,7 +40,7 @@ export const seedAdmin = async (app: TestApp): Promise<string> => {
   });
 
   // Directly update role via drizzle
-  const drizzle = app.get((await import('../../src/db/drizzle.service')).DrizzleService);
+  const drizzle = await app.get((await import('../../src/db/drizzle.service')).DrizzleService);
   const { users } = await import('../../src/db/schema');
   const { eq } = await import('drizzle-orm');
   drizzle.db.update(users).set({ role: 'admin' }).where(eq(users.email, 'admin@example.com')).run();

--- a/integration/hooks/e2e/dependency-order.spec.ts
+++ b/integration/hooks/e2e/dependency-order.spec.ts
@@ -47,8 +47,8 @@ describe('DI dependency-driven lifecycle order', () => {
 
   it('resolves DependencyA with its DependencyB wired through constructor injection', async () => {
     const { get } = await app.ready({ warmup: true });
-    const a = get(DependencyA);
-    const b = get(DependencyB);
+    const a = await get(DependencyA);
+    const b = await get(DependencyB);
 
     expect(a.b).toBe(b);
   });
@@ -71,7 +71,7 @@ describe('Services without lifecycle hooks', () => {
 
   it('coexist with Lifecycle services without triggering errors during startup or shutdown', async () => {
     const { get } = await app.ready({ warmup: true });
-    const noHook = get(NoHookService);
+    const noHook = await get(NoHookService);
 
     expect(noHook.ping()).toBe('pong');
 

--- a/integration/hooks/e2e/disposable.spec.ts
+++ b/integration/hooks/e2e/disposable.spec.ts
@@ -21,7 +21,7 @@ describe('Disposable shutdown', () => {
 
   it('invokes Disposable.shutdown when the app shuts down', async () => {
     const { get } = await app.ready({ warmup: true });
-    const instance = get(DisposableSpy);
+    const instance = await get(DisposableSpy);
     expect(instance.shutdownCalls).toBe(0);
 
     await app.shutdown();

--- a/integration/hooks/e2e/shutdown.spec.ts
+++ b/integration/hooks/e2e/shutdown.spec.ts
@@ -20,7 +20,7 @@ describe('Lifecycle shutdown', () => {
 
   it('calls shutdown on Lifecycle services when app shuts down', async () => {
     const { get } = await app.ready({ warmup: true });
-    const instance = get(FirstSpy);
+    const instance = await get(FirstSpy);
     expect(instance.shutdownCalls).toBe(0);
 
     await app.shutdown();
@@ -31,7 +31,7 @@ describe('Lifecycle shutdown', () => {
 
   it('is idempotent: subsequent shutdown calls do not re-run hooks', async () => {
     const { get } = await app.ready({ warmup: true });
-    const instance = get(FirstSpy);
+    const instance = await get(FirstSpy);
 
     await app.shutdown();
     await app.shutdown();

--- a/integration/hooks/e2e/signal.spec.ts
+++ b/integration/hooks/e2e/signal.spec.ts
@@ -23,7 +23,7 @@ describe('Signal-triggered shutdown', () => {
 
   it('exposes a CliConfig token that accepts SIGINT/SIGTERM handlers', async () => {
     const { get } = await app.ready({ warmup: true });
-    const cli = get(CliConfig) as TestCliConfig;
+    const cli = (await get(CliConfig)) as TestCliConfig;
 
     const handler = () => {};
     cli.onSignal('SIGINT', handler);
@@ -35,8 +35,8 @@ describe('Signal-triggered shutdown', () => {
 
   it('invokes app.shutdown when a signal-bound handler fires', async () => {
     const { get } = await app.ready({ warmup: true });
-    const cli = get(CliConfig) as TestCliConfig;
-    const firstSpy = get(FirstSpy);
+    const cli = (await get(CliConfig)) as TestCliConfig;
+    const firstSpy = await get(FirstSpy);
 
     let shutdownPromise: Promise<void> | undefined;
     const handler = () => {
@@ -55,7 +55,7 @@ describe('Signal-triggered shutdown', () => {
 
   it('removes handlers via offSignal', async () => {
     const { get } = await app.ready({ warmup: true });
-    const cli = get(CliConfig) as TestCliConfig;
+    const cli = (await get(CliConfig)) as TestCliConfig;
 
     let calls = 0;
     const handler = () => {

--- a/integration/hooks/e2e/startup.spec.ts
+++ b/integration/hooks/e2e/startup.spec.ts
@@ -21,7 +21,7 @@ describe('Lifecycle startup', () => {
 
   it('calls startup on registered Lifecycle services when app becomes ready', async () => {
     const { get } = await app.ready({ warmup: true });
-    const instance = get(FirstSpy);
+    const instance = await get(FirstSpy);
 
     expect(instance.startupCalls).toBe(1);
     expect(log.events.some((e) => e.source === 'first' && e.phase === 'startup')).toBe(true);
@@ -31,7 +31,7 @@ describe('Lifecycle startup', () => {
     await app.ready({ warmup: true });
     await app.ready({ warmup: true });
     const { get } = await app.ready({ warmup: true });
-    const instance = get(FirstSpy);
+    const instance = await get(FirstSpy);
 
     expect(instance.startupCalls).toBe(1);
   });

--- a/integration/hooks/e2e/warmup.spec.ts
+++ b/integration/hooks/e2e/warmup.spec.ts
@@ -21,7 +21,7 @@ describe('Lifecycle warmup', () => {
 
   it('runs registered warmup handlers when ready({ warmup: true })', async () => {
     const { get } = await app.ready({ warmup: true });
-    const instance = get(WarmupSpy);
+    const instance = await get(WarmupSpy);
 
     expect(instance.warmupCalls).toBe(1);
     expect(log.events.some((e) => e.phase === 'warmup')).toBe(true);

--- a/integration/injector/e2e/config-override.spec.ts
+++ b/integration/injector/e2e/config-override.spec.ts
@@ -20,16 +20,16 @@ describe('Injector — Config override', () => {
 
   it('returns the original Config when no override is supplied', async () => {
     const testApp = await onTest(makeApp());
-    expect(testApp.get(AppConfig).appName).toBe('injector-test');
-    expect(testApp.get(AppConfig).version).toBe(1);
+    expect((await testApp.get(AppConfig)).appName).toBe('injector-test');
+    expect((await testApp.get(AppConfig)).version).toBe(1);
   });
 
   it('substitutes the Config with a subclass passed via onTest({ configs })', async () => {
     const testApp = await onTest(makeApp(), { configs: [TestAppConfig] });
 
-    expect(testApp.get(AppConfig).appName).toBe('override-name');
-    expect(testApp.get(AppConfig).version).toBe(999);
-    expect(testApp.get(ConfigConsumerService).describe()).toBe('override-name@999');
+    expect((await testApp.get(AppConfig)).appName).toBe('override-name');
+    expect((await testApp.get(AppConfig)).version).toBe(999);
+    expect((await testApp.get(ConfigConsumerService)).describe()).toBe('override-name@999');
   });
 
   it('propagates the overridden Config through the controller endpoint', async () => {

--- a/integration/injector/e2e/error-paths.spec.ts
+++ b/integration/injector/e2e/error-paths.spec.ts
@@ -51,14 +51,14 @@ describe('Injector — DI error paths', () => {
       const app = createApp({ http: { controllers: [] } });
       const testApp = await onTest(app);
 
-      expect(() => testApp.get(ConsumerOfUnregistered)).toThrow(/No provider/);
+      await expect(testApp.get(ConsumerOfUnregistered)).rejects.toThrow(/No provider/);
     });
 
     it('reports the missing token name in the error message', async () => {
       const app = createApp({ http: { controllers: [] } });
       const testApp = await onTest(app);
 
-      expect(() => testApp.get(ConsumerOfUnregistered)).toThrow(/NotRegisteredService/);
+      await expect(testApp.get(ConsumerOfUnregistered)).rejects.toThrow(/NotRegisteredService/);
     });
   });
 
@@ -67,7 +67,7 @@ describe('Injector — DI error paths', () => {
       const app = createApp({ http: { controllers: [] } });
       const testApp = await onTest(app);
 
-      expect(() => testApp.get(SelfReferencingService)).toThrow(/[Cc]ircular/);
+      await expect(testApp.get(SelfReferencingService)).rejects.toThrow(/[Cc]ircular/);
     });
   });
 
@@ -76,7 +76,7 @@ describe('Injector — DI error paths', () => {
       const app = createApp({ http: { controllers: [] } });
       const testApp = await onTest(app);
 
-      expect(() => testApp.get(OptionalDepConsumer)).toThrow(/No provider/);
+      await expect(testApp.get(OptionalDepConsumer)).rejects.toThrow(/No provider/);
     });
   });
 

--- a/integration/injector/e2e/injector.spec.ts
+++ b/integration/injector/e2e/injector.spec.ts
@@ -22,44 +22,44 @@ describe('Injector', () => {
   });
 
   describe('constructor injection', () => {
-    it('resolves a leaf service with no dependencies', () => {
-      const leaf = testApp.get(LeafService);
+    it('resolves a leaf service with no dependencies', async () => {
+      const leaf = await testApp.get(LeafService);
       expect(leaf.value()).toBe('leaf');
     });
 
-    it('resolves a service whose constructor depends on another service', () => {
-      const middle = testApp.get(MiddleService);
+    it('resolves a service whose constructor depends on another service', async () => {
+      const middle = await testApp.get(MiddleService);
       expect(middle.compose()).toBe('middle(leaf)');
     });
 
-    it('resolves multi-level dependency chains', () => {
-      const root = testApp.get(RootService);
+    it('resolves multi-level dependency chains', async () => {
+      const root = await testApp.get(RootService);
       expect(root.compose()).toBe('root(middle(leaf),leaf)');
     });
 
-    it('injects the same shared dependency into multiple constructor params', () => {
-      const root = testApp.get(RootService);
+    it('injects the same shared dependency into multiple constructor params', async () => {
+      const root = await testApp.get(RootService);
       expect(root.leaf).toBe(root.middle.leaf);
     });
   });
 
   describe('singleton scope', () => {
-    it('returns the same instance for every get() call', () => {
-      const a = testApp.get(LeafService);
-      const b = testApp.get(LeafService);
+    it('returns the same instance for every get() call', async () => {
+      const a = await testApp.get(LeafService);
+      const b = await testApp.get(LeafService);
       expect(a).toBe(b);
     });
 
-    it('shares one instance across different consumer services', () => {
-      const root = testApp.get(RootService);
-      const middle = testApp.get(MiddleService);
-      const leaf = testApp.get(LeafService);
+    it('shares one instance across different consumer services', async () => {
+      const root = await testApp.get(RootService);
+      const middle = await testApp.get(MiddleService);
+      const leaf = await testApp.get(LeafService);
       expect(root.leaf).toBe(leaf);
       expect(middle.leaf).toBe(leaf);
     });
 
     it('shares one instance across controllers via HTTP requests', async () => {
-      const before = testApp.get(CounterService).value();
+      const before = (await testApp.get(CounterService)).value();
 
       const res1 = await testApp.request('/counter-a/inc');
       expect(res1.status).toBe(200);
@@ -87,20 +87,20 @@ describe('Injector', () => {
   });
 
   describe('Config (leaf) injection', () => {
-    it('resolves a @Config() class via testApp.get', () => {
-      const config = testApp.get(AppConfig);
+    it('resolves a @Config() class via testApp.get', async () => {
+      const config = await testApp.get(AppConfig);
       expect(config.appName).toBe('injector-test');
       expect(config.version).toBe(1);
     });
 
-    it('returns the same Config instance on every resolve', () => {
-      expect(testApp.get(AppConfig)).toBe(testApp.get(AppConfig));
+    it('returns the same Config instance on every resolve', async () => {
+      expect(await testApp.get(AppConfig)).toBe(await testApp.get(AppConfig));
     });
 
-    it('injects @Config() into a service constructor', () => {
-      const consumer = testApp.get(ConfigConsumerService);
+    it('injects @Config() into a service constructor', async () => {
+      const consumer = await testApp.get(ConfigConsumerService);
       expect(consumer.describe()).toBe('injector-test@1');
-      expect(consumer.config).toBe(testApp.get(AppConfig));
+      expect(consumer.config).toBe(await testApp.get(AppConfig));
     });
 
     it('exposes injected Config through a controller endpoint', async () => {
@@ -112,19 +112,17 @@ describe('Injector', () => {
   });
 
   describe('class inheritance', () => {
-    it('resolves a subclass instance via testApp.get(SubClass)', () => {
-      const ext = testApp.get(ExtendedService);
+    it('resolves a subclass instance via testApp.get(SubClass)', async () => {
+      const ext = await testApp.get(ExtendedService);
       expect(ext).toBeInstanceOf(ExtendedService);
       expect(ext).toBeInstanceOf(BaseService);
       expect(ext.kind()).toBe('extended');
       expect(ext.bonus()).toBe('bonus');
     });
 
-    it('exposes the same instance for the subclass and its base when only the subclass is bound', () => {
-      // needle-di pollutes the base class token when a subclass is resolved,
-      // so inject(BaseService) yields the previously resolved ExtendedService instance.
-      const ext = testApp.get(ExtendedService);
-      const base = testApp.get(BaseService);
+    it('exposes the same instance for the subclass and its base when only the subclass is bound', async () => {
+      const ext = await testApp.get(ExtendedService);
+      const base = await testApp.get(BaseService);
       expect(base).toBe(ext);
       expect(base.kind()).toBe('extended');
     });

--- a/integration/injector/e2e/isolation.spec.ts
+++ b/integration/injector/e2e/isolation.spec.ts
@@ -23,8 +23,8 @@ describe('Injector — per-app isolation', () => {
     const app1 = await onTest(makeApp());
     const app2 = await onTest(makeApp());
 
-    const leaf1 = app1.get(LeafService);
-    const leaf2 = app2.get(LeafService);
+    const leaf1 = await app1.get(LeafService);
+    const leaf2 = await app2.get(LeafService);
 
     expect(leaf1).not.toBe(leaf2);
     expect(leaf1.value()).toBe('leaf');
@@ -35,10 +35,10 @@ describe('Injector — per-app isolation', () => {
     const app1 = await onTest(makeApp());
     const app2 = await onTest(makeApp());
 
-    app1.get(CounterService).increment();
-    app1.get(CounterService).increment();
+    (await app1.get(CounterService)).increment();
+    (await app1.get(CounterService)).increment();
 
-    expect(app1.get(CounterService).value()).toBe(2);
-    expect(app2.get(CounterService).value()).toBe(0);
+    expect((await app1.get(CounterService)).value()).toBe(2);
+    expect((await app2.get(CounterService)).value()).toBe(0);
   });
 });

--- a/packages/adapter-bun/src/on-bun.ts
+++ b/packages/adapter-bun/src/on-bun.ts
@@ -164,7 +164,7 @@ export async function onBun(
   const readyOptions: ReadyOptions = { warmup: options.warmup ?? true };
   const resolver = await app.ready(readyOptions);
 
-  const cliConfig = resolver.get(BunCliConfig);
+  const cliConfig = await resolver.get(BunCliConfig);
 
   let shuttingDown = false;
   const detachSignals = (): void => {

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
@@ -101,7 +101,7 @@ describe('onCloudflareWorkers', () => {
     });
     const workersApp = await onCloudflareWorkers(app);
 
-    const env = workersApp.get(EnvAdaptor);
+    const env = await workersApp.get(EnvAdaptor);
     expect(env.get).toBeTypeOf('function');
   });
 });

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -173,7 +173,7 @@ describe('onNode with HTTP', () => {
     });
     nodeApp = await onNode(app);
 
-    const env = nodeApp.get(EnvAdaptor);
+    const env = await nodeApp.get(EnvAdaptor);
     expect(env.get).toBeTypeOf('function');
   });
 });

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -210,7 +210,7 @@ export async function onNode(app: AnyApp, options: NodeAppOptions = {}): Promise
   const readyOptions: ReadyOptions = { warmup: options.warmup ?? true };
   const resolver = await app.ready(readyOptions);
 
-  const cliConfig = resolver.get(NodeCliConfig);
+  const cliConfig = await resolver.get(NodeCliConfig);
 
   let shuttingDown = false;
   const detachSignals = (): void => {

--- a/packages/core/src/app/app-runtime.lib.ts
+++ b/packages/core/src/app/app-runtime.lib.ts
@@ -11,7 +11,7 @@ export type ReadyOptions = {
 };
 
 export type ReadyResult = {
-  readonly get: <T extends object>(cls: new (...args: never[]) => T) => T;
+  readonly get: <T extends object>(cls: new (...args: never[]) => T) => Promise<T>;
 };
 
 type AppRuntimeState = 'idle' | 'starting' | 'ready' | 'disposed';
@@ -77,11 +77,13 @@ export class AppRuntime {
   /** @throws {ZeltLifecycleStateError} */
   private buildReadyResult(): ReadyResult {
     return {
-      get: <T extends object>(cls: new (...args: never[]) => T): T => {
+      get: async <T extends object>(cls: new (...args: never[]) => T): Promise<T> => {
         if (this.state === 'disposed') {
           throw new ZeltLifecycleStateError({ operation: 'get', currentState: 'disposed' });
         }
-        return resolve(this.container, cls);
+        const instance = resolve(this.container, cls);
+        await this.lifecycleManager.startupPending();
+        return instance;
       },
     };
   }

--- a/packages/core/src/app/config-token.test.ts
+++ b/packages/core/src/app/config-token.test.ts
@@ -39,34 +39,34 @@ describe('config token', () => {
     it('returns base default when nothing is configured', async () => {
       const app = createApp({});
       const { get } = await app.ready();
-      expect(get(BaseConfig).value).toBe('base-default');
+      expect((await get(BaseConfig)).value).toBe('base-default');
     });
 
     it('fallback wins over base default', async () => {
       const app = createApp({});
       app.addFallbackConfig(FallbackConfig);
       const { get } = await app.ready();
-      expect(get(BaseConfig).value).toBe('fallback');
+      expect((await get(BaseConfig)).value).toBe('fallback');
     });
 
     it('configs wins over fallback', async () => {
       const app = createApp({ configs: [UserConfig] });
       app.addFallbackConfig(FallbackConfig);
       const { get } = await app.ready();
-      expect(get(BaseConfig).value).toBe('user-config');
+      expect((await get(BaseConfig)).value).toBe('user-config');
     });
 
     it('configs wins over base default', async () => {
       const app = createApp({ configs: [UserConfig] });
       const { get } = await app.ready();
-      expect(get(BaseConfig).value).toBe('user-config');
+      expect((await get(BaseConfig)).value).toBe('user-config');
     });
 
     it('override wins over configs', async () => {
       const app = createApp({ configs: [UserConfig] });
       app.overrideConfig(OverrideConfig);
       const { get } = await app.ready();
-      expect(get(BaseConfig).value).toBe('override');
+      expect((await get(BaseConfig)).value).toBe('override');
     });
 
     it('override wins over fallback', async () => {
@@ -74,7 +74,7 @@ describe('config token', () => {
       app.addFallbackConfig(FallbackConfig);
       app.overrideConfig(OverrideConfig);
       const { get } = await app.ready();
-      expect(get(BaseConfig).value).toBe('override');
+      expect((await get(BaseConfig)).value).toBe('override');
     });
 
     it('override wins over all (configs + fallback + base)', async () => {
@@ -82,14 +82,14 @@ describe('config token', () => {
       app.addFallbackConfig(FallbackConfig);
       app.overrideConfig(OverrideConfig);
       const { get } = await app.ready();
-      expect(get(BaseConfig).value).toBe('override');
+      expect((await get(BaseConfig)).value).toBe('override');
     });
 
     it('explicit base in configs prevents fallback', async () => {
       const app = createApp({ configs: [BaseConfig] });
       app.addFallbackConfig(FallbackConfig);
       const { get } = await app.ready();
-      expect(get(BaseConfig).value).toBe('base-default');
+      expect((await get(BaseConfig)).value).toBe('base-default');
     });
   });
 
@@ -104,7 +104,7 @@ describe('config token', () => {
 
       const app = createApp({});
       const { get } = await app.ready();
-      expect(get(ImplicitConfig).value).toBe('implicit');
+      expect((await get(ImplicitConfig)).value).toBe('implicit');
     });
   });
 
@@ -140,8 +140,8 @@ describe('config token', () => {
       app.addFallbackConfig(FallbackCacheConfig);
       const { get } = await app.ready();
 
-      expect(get(DbConfig).url).toBe('db://user');
-      expect(get(CacheConfig).url).toBe('cache://fallback');
+      expect((await get(DbConfig)).url).toBe('db://user');
+      expect((await get(CacheConfig)).url).toBe('cache://fallback');
     });
   });
 });

--- a/packages/core/src/app/test-target.test.ts
+++ b/packages/core/src/app/test-target.test.ts
@@ -43,7 +43,7 @@ describe('createApp for testing', () => {
     const { get } = await app.ready();
 
     expect(events).toEqual(['config:constructor', 'config:startup']);
-    expect(get(TestService).getValue()).toBe('test-value');
+    expect((await get(TestService)).getValue()).toBe('test-value');
 
     await app.shutdown();
     expect(events).toEqual(['config:constructor', 'config:startup', 'config:shutdown']);
@@ -84,6 +84,6 @@ describe('createApp for testing', () => {
 
     await app.shutdown();
 
-    expect(() => get(SomeService)).toThrow(/Cannot get\(\) after shutdown\(\)/);
+    await expect(get(SomeService)).rejects.toThrow(/Cannot get\(\) after shutdown\(\)/);
   });
 });

--- a/packages/core/src/built-in-service/env/env.test.ts
+++ b/packages/core/src/built-in-service/env/env.test.ts
@@ -19,7 +19,7 @@ let app: App;
 const setupEnv = async () => {
   app = createApp({ configs: [TestEnvSource] });
   const { get } = await app.ready();
-  env = get(Env);
+  env = await get(Env);
 };
 
 describe('Env', () => {

--- a/packages/core/src/built-in-service/logger/logger.service.test.ts
+++ b/packages/core/src/built-in-service/logger/logger.service.test.ts
@@ -21,7 +21,7 @@ describe('LoggerService', () => {
     it('child inherits parent bindings and merges context', async () => {
       const app = createApp({});
       const { get } = await app.ready();
-      const logger = get(LoggerService);
+      const logger = await get(LoggerService);
       const child1 = logger.child({ service: 'auth' });
       const child2 = child1.child({ module: 'jwt' });
 
@@ -37,7 +37,7 @@ describe('LoggerService', () => {
     it('child is not DI-managed (lightweight wrapper)', async () => {
       const app = createApp({});
       const { get } = await app.ready();
-      const logger = get(LoggerService);
+      const logger = await get(LoggerService);
       const child = logger.child({ service: 'test' });
 
       expect(child).not.toBe(logger);
@@ -57,7 +57,7 @@ describe('LoggerService', () => {
 
       const app = createApp({ configs: [WarnOnlyConfig] });
       const { get } = await app.ready();
-      const logger = get(LoggerService);
+      const logger = await get(LoggerService);
 
       logger.debug('skip');
       logger.info('skip');

--- a/packages/core/src/modules/http/error/default.error-handler.test.ts
+++ b/packages/core/src/modules/http/error/default.error-handler.test.ts
@@ -1,6 +1,7 @@
 import { HTTPException } from 'hono/http-exception';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import type { App } from '../../../app';
 import { createApp } from '../../../app';
 import { Config } from '../../../built-in-service/config';
 import { EnvAdaptor } from '../../../built-in-service/env/env.adaptor';
@@ -10,6 +11,8 @@ import { DefaultErrorHandler } from './default.error-handler';
 
 let handler: DefaultErrorHandler;
 let devHandler: DefaultErrorHandler;
+let prodApp: App;
+let devApp: App;
 
 const setupHandlers = async () => {
   @Config
@@ -26,11 +29,11 @@ const setupHandlers = async () => {
     }
   }
 
-  const prodApp = createApp({ configs: [ProdEnvAdaptor] });
+  prodApp = createApp({ configs: [ProdEnvAdaptor] });
   const { get: prodGet } = await prodApp.ready();
   handler = await prodGet(DefaultErrorHandler);
 
-  const devApp = createApp({ configs: [DevEnvAdaptor] });
+  devApp = createApp({ configs: [DevEnvAdaptor] });
   const { get: devGet } = await devApp.ready();
   devHandler = await devGet(DefaultErrorHandler);
 };
@@ -40,6 +43,11 @@ const dummyContext = {} as Parameters<DefaultErrorHandler['onError']>[1];
 describe('DefaultErrorHandler', () => {
   beforeAll(async () => {
     await setupHandlers();
+  });
+
+  afterAll(async () => {
+    await prodApp.shutdown();
+    await devApp.shutdown();
   });
 
   describe('HTTPException with res (defineHttpException pattern)', () => {

--- a/packages/core/src/modules/http/error/default.error-handler.test.ts
+++ b/packages/core/src/modules/http/error/default.error-handler.test.ts
@@ -28,11 +28,11 @@ const setupHandlers = async () => {
 
   const prodApp = createApp({ configs: [ProdEnvAdaptor] });
   const { get: prodGet } = await prodApp.ready();
-  handler = prodGet(DefaultErrorHandler);
+  handler = await prodGet(DefaultErrorHandler);
 
   const devApp = createApp({ configs: [DevEnvAdaptor] });
   const { get: devGet } = await devApp.ready();
-  devHandler = devGet(DefaultErrorHandler);
+  devHandler = await devGet(DefaultErrorHandler);
 };
 
 const dummyContext = {} as Parameters<DefaultErrorHandler['onError']>[1];

--- a/packages/hono-client/src/cli.ts
+++ b/packages/hono-client/src/cli.ts
@@ -5,4 +5,4 @@ import { app } from './app.lib';
 
 const nodeApp = await onNode(app);
 const result = await nodeApp.execCommand([...nodeApp.args]);
-nodeApp.get(CliConfig).exit(result.exitCode);
+(await nodeApp.get(CliConfig)).exit(result.exitCode);

--- a/packages/testing/src/test-target.lib.ts
+++ b/packages/testing/src/test-target.lib.ts
@@ -20,7 +20,7 @@ export type CreateTestTargetOptions = {
 
 export type TestTargetResult<T> = {
   readonly target: T;
-  readonly get: <U extends object>(cls: new (...args: never[]) => U) => U;
+  readonly get: <U extends object>(cls: new (...args: never[]) => U) => Promise<U>;
   readonly shutdown: () => Promise<void>;
 };
 
@@ -49,7 +49,7 @@ export const createTestTarget = async <T extends object>(
   registerShutdown(app.shutdown.bind(app));
 
   return {
-    target: get(targetClass),
+    target: await get(targetClass),
     get,
     shutdown: app.shutdown.bind(app),
   };

--- a/packages/testing/src/test-target.test.ts
+++ b/packages/testing/src/test-target.test.ts
@@ -83,7 +83,7 @@ describe('createTestTarget', () => {
 
     expect(target.name).toBe('A');
 
-    const serviceB = get(ServiceB);
+    const serviceB = await get(ServiceB);
     expect(serviceB.name).toBe('B');
   });
 

--- a/website/docs/scheduler.md
+++ b/website/docs/scheduler.md
@@ -300,7 +300,7 @@ const app = createApp({
 });
 const nodeApp = await onNode(app);
 // ---cut---
-const config = nodeApp.get(SchedulerConfig);
+const config = await nodeApp.get(SchedulerConfig);
 if (config.enabled) {
   await nodeApp.startScheduler();
 }

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/scheduler.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/scheduler.md
@@ -300,7 +300,7 @@ const app = createApp({
 });
 const nodeApp = await onNode(app);
 // ---cut---
-const config = nodeApp.get(SchedulerConfig);
+const config = await nodeApp.get(SchedulerConfig);
 if (config.enabled) {
   await nodeApp.startScheduler();
 }


### PR DESCRIPTION
## Summary

- `ReadyResult.get()` を async 化し、`resolve()` 後に `lifecycleManager.startupPending()` を呼ぶように変更
- `get()` による遅延インスタンス化で `lifecycle.register()` されたサービスの `startup()` が呼ばれない問題を修正
- 全アダプタ・テスト・ドキュメントの呼び出し元を `await` 対応に更新

## Background

`createTestTarget` や `ready()` 後の `get()` でサービスをインスタンス化すると、そのサービスのコンストラクタ内で `lifecycleManager.register(this)` が呼ばれるが、`startup()` は既に完了しているため `startup()` が実行されなかった。

`LifecycleManager` には `startupPending()` という未起動分だけを処理する仕組みが既にあったが、`get()` から呼ばれていなかった。

## Changes

| File | Change |
|---|---|
| `packages/core/src/app/app-runtime.lib.ts` | `ReadyResult.get` を `Promise<T>` に変更、`startupPending()` 呼び出し追加 |
| `packages/testing/src/test-target.lib.ts` | `TestTargetResult.get` の型を async に、`target` に `await` 追加 |
| `packages/adapter-node/src/on-node.ts` | `await resolver.get(...)` |
| `packages/adapter-bun/src/on-bun.ts` | `await resolver.get(...)` |
| テスト・ドキュメント 13件 | `get()` 呼び出しに `await` 追加 |

## Test plan

- [x] `pnpm tsc --noEmit` — 型チェック通過
- [x] `pnpm vitest run` — 全テスト通過 (既存の `default.error-handler.test.ts` 実行時エラーは main でも同様)
- [x] `pnpm run precommit` — lint, build, test 全通過

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782774597&installation_id=133048706&pr_number=249&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F249&signature=844b4a9eebec622eb143bdb0b6d76e089802a0bf1c5581e4ff0f965c3ca1fa2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 依存取得を非同期化し、get() が Promise を返す形へ移行（主要な型シグネチャ更新を含む）。

* **Tests**
  * 多数の統合／ユニットテストを async/await 化し、非同期解決を前提とした検証へ更新。

* **Documentation**
  * サンプルや起動例を非同期取得前提に修正。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeltjs/zelt/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->