### PR TITLE
fix(integration): replace fake wildcard tests with real wildcard route

### DIFF
--- a/integration/hello-world/e2e/exclude-middleware.spec.ts
+++ b/integration/hello-world/e2e/exclude-middleware.spec.ts
@@ -54,20 +54,8 @@ class TestController {
   }
 
   @SkipMiddleware(GlobalMiddleware)
-  @Get('/wildcard/overview')
-  testOverview() {
-    return RETURN_VALUE;
-  }
-
-  @SkipMiddleware(GlobalMiddleware)
-  @Get('/legacy-wildcard/overview')
-  legacyWildcard() {
-    return RETURN_VALUE;
-  }
-
-  @SkipMiddleware(GlobalMiddleware)
-  @Get('/splat-wildcard/overview')
-  splatWildcard() {
+  @Get('/wildcard/*')
+  wildcard() {
     return RETURN_VALUE;
   }
 
@@ -127,23 +115,16 @@ describe('Exclude middleware (@SkipMiddleware)', () => {
     expect(await res.json()).toBe(RETURN_VALUE);
   });
 
-  it('should exclude "/wildcard/overview" endpoint (by wildcard)', async () => {
+  it('should exclude wildcard route "/wildcard/*"', async () => {
     await setup();
-    const res = await testApp.request('/wildcard/overview');
+    const res = await testApp.request('/wildcard/anything');
     expect(res.status).toBe(200);
     expect(await res.json()).toBe(RETURN_VALUE);
   });
 
-  it('should exclude "/legacy-wildcard/overview" endpoint (by wildcard, legacy syntax)', async () => {
+  it('should exclude wildcard route at nested path "/wildcard/deep/path"', async () => {
     await setup();
-    const res = await testApp.request('/legacy-wildcard/overview');
-    expect(res.status).toBe(200);
-    expect(await res.json()).toBe(RETURN_VALUE);
-  });
-
-  it('should exclude "/splat-wildcard/overview" endpoint (by wildcard, new syntax)', async () => {
-    await setup();
-    const res = await testApp.request('/splat-wildcard/overview');
+    const res = await testApp.request('/wildcard/deep/path');
     expect(res.status).toBe(200);
     expect(await res.json()).toBe(RETURN_VALUE);
   });


### PR DESCRIPTION
## Summary

- Removed 3 fake wildcard test routes (`/wildcard/overview`, `/legacy-wildcard/overview`, `/splat-wildcard/overview`) that claimed to test wildcard matching but only used literal paths with `@SkipMiddleware`
- Added a real wildcard route `@Get('/wildcard/*')` with `@SkipMiddleware` to honestly test middleware exclusion on wildcard patterns
- Added 2 test cases verifying wildcard matching at different path depths (`/wildcard/anything`, `/wildcard/deep/path`)

Closes #e0985487 (bit issue)

## Test plan

- [x] `exclude-middleware.spec.ts` — 8 tests pass
- [x] Full `pnpm run precommit` passes (649 tests, typecheck, lint, build)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782783878&installation_id=133048706&pr_number=250&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F250&signature=da9e05ae9bcc769030c659bfef8917685c0b381aa5ef45be6e7f742ac76bd712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * ワイルドカードルートのエンドポイント処理に関するテストケースを整理し、複数の個別エンドポイント定義から統一されたパターンマッチングに変更。複数パスパターンに対するミドルウェア除外動作の検証を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->