### PR TITLE
feat(rate-limit): add enabled flag to RateLimitConfig

### DIFF
--- a/integration/ec-backend/e2e/auth.spec.ts
+++ b/integration/ec-backend/e2e/auth.spec.ts
@@ -124,8 +124,7 @@ describe('Auth API', () => {
         }),
         headers: { 'Content-Type': 'application/json' },
       });
-      // May be 409 or 429 depending on rate limit state
-      expect([409, 429]).toContain(res.status);
+      expect(res.status).toBe(409);
     });
   });
 

--- a/integration/ec-backend/e2e/helpers/test-setup.ts
+++ b/integration/ec-backend/e2e/helpers/test-setup.ts
@@ -1,14 +1,21 @@
 import type { App, HttpModule } from '@zeltjs/core';
+import { Config } from '@zeltjs/core';
+import { RateLimitConfig } from '@zeltjs/rate-limit';
 import type { TestableApp } from '@zeltjs/testing';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 
 import { createEcApp } from '../../src/app';
 
+@Config
+class TestRateLimitConfig extends RateLimitConfig {
+  override readonly enabled = false;
+}
+
 export type TestApp = TestableApp<App<[HttpModule]>>;
 
 export const createTestApp = async () => {
   const app = createEcApp();
-  return onTest(app);
+  return onTest(app, { configs: [TestRateLimitConfig] });
 };
 
 export const registerUser = async (

--- a/integration/ec-backend/e2e/rate-limit.spec.ts
+++ b/integration/ec-backend/e2e/rate-limit.spec.ts
@@ -17,20 +17,10 @@ describe('Rate Limit', () => {
     await shutdownAll();
   });
 
-  it('returns rate limit headers on login', async () => {
-    await testApp.request('/api/auth/register', {
-      method: 'POST',
-      body: JSON.stringify({
-        email: 'login-test@example.com',
-        password: 'password123',
-        name: 'Login Test',
-      }),
-      headers: { 'Content-Type': 'application/json' },
-    });
-
+  it('returns rate limit headers on successful request', async () => {
     const res = await testApp.request('/api/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ email: 'login-test@example.com', password: 'password123' }),
+      body: JSON.stringify({ email: 'nobody@example.com', password: 'password123' }),
       headers: { 'Content-Type': 'application/json' },
     });
 
@@ -38,21 +28,19 @@ describe('Rate Limit', () => {
     expect(res.headers.get('X-RateLimit-Remaining')).toBeDefined();
   });
 
-  it('returns rate limit headers on register', async () => {
-    const res = await testApp.request('/api/auth/register', {
-      method: 'POST',
-      body: JSON.stringify({
-        email: 'ratelimit@example.com',
-        password: 'password123',
-        name: 'Rate Limit',
-      }),
-      headers: { 'Content-Type': 'application/json' },
-    });
+  it('returns 429 after exceeding limit', async () => {
+    for (let i = 0; i < 3; i++) {
+      await testApp.request('/api/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: `flood-${i}@example.com`,
+          password: 'password123',
+          name: `Flood ${i}`,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
-    expect(res.headers.get('X-RateLimit-Limit')).toBe('3');
-  });
-
-  it('returns 429 after exceeding register limit', async () => {
     const res = await testApp.request('/api/auth/register', {
       method: 'POST',
       body: JSON.stringify({

--- a/integration/ec-backend/e2e/rate-limit.spec.ts
+++ b/integration/ec-backend/e2e/rate-limit.spec.ts
@@ -18,18 +18,23 @@ describe('Rate Limit', () => {
   });
 
   it('returns rate limit headers on successful request', async () => {
-    const res = await testApp.request('/api/auth/login', {
+    const res = await testApp.request('/api/auth/register', {
       method: 'POST',
-      body: JSON.stringify({ email: 'nobody@example.com', password: 'password123' }),
+      body: JSON.stringify({
+        email: 'header-test@example.com',
+        password: 'password123',
+        name: 'Header Test',
+      }),
       headers: { 'Content-Type': 'application/json' },
     });
 
-    expect(res.headers.get('X-RateLimit-Limit')).toBe('5');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('3');
     expect(res.headers.get('X-RateLimit-Remaining')).toBeDefined();
   });
 
   it('returns 429 after exceeding limit', async () => {
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 2; i++) {
       await testApp.request('/api/auth/register', {
         method: 'POST',
         body: JSON.stringify({

--- a/integration/ec-backend/e2e/rate-limit.spec.ts
+++ b/integration/ec-backend/e2e/rate-limit.spec.ts
@@ -1,12 +1,16 @@
+import type { App, HttpModule } from '@zeltjs/core';
+import type { TestableApp } from '@zeltjs/testing';
+import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { TestApp } from './helpers/test-setup';
-import { createTestApp, shutdownAll } from './helpers/test-setup';
+
+import { createEcApp } from '../src/app';
 
 describe('Rate Limit', () => {
-  let testApp: TestApp;
+  let testApp: TestableApp<App<[HttpModule]>>;
 
   beforeAll(async () => {
-    testApp = await createTestApp();
+    const app = createEcApp();
+    testApp = await onTest(app);
   });
 
   afterAll(async () => {
@@ -14,7 +18,6 @@ describe('Rate Limit', () => {
   });
 
   it('returns rate limit headers on login', async () => {
-    // Register a user first so login doesn't 401 before rate limit middleware runs
     await testApp.request('/api/auth/register', {
       method: 'POST',
       body: JSON.stringify({
@@ -50,18 +53,6 @@ describe('Rate Limit', () => {
   });
 
   it('returns 429 after exceeding register limit', async () => {
-    for (let i = 0; i < 3; i++) {
-      await testApp.request('/api/auth/register', {
-        method: 'POST',
-        body: JSON.stringify({
-          email: `flood-${i}@example.com`,
-          password: 'password123',
-          name: `Flood ${i}`,
-        }),
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-
     const res = await testApp.request('/api/auth/register', {
       method: 'POST',
       body: JSON.stringify({

--- a/packages/rate-limit/src/rate-limit.config.test.ts
+++ b/packages/rate-limit/src/rate-limit.config.test.ts
@@ -23,4 +23,9 @@ describe('RateLimitConfig', () => {
     const { target } = await createTestTarget(RateLimitConfig);
     expect(target.kvStoreNamespace).toBe('rate-limit:');
   });
+
+  it('default enabled is true', async () => {
+    const { target } = await createTestTarget(RateLimitConfig);
+    expect(target.enabled).toBe(true);
+  });
 });

--- a/packages/rate-limit/src/rate-limit.config.ts
+++ b/packages/rate-limit/src/rate-limit.config.ts
@@ -6,6 +6,7 @@ import { MemoryKV } from '@zeltjs/kv';
 export class RateLimitConfig {
   constructor(readonly kv: AtomicKVAdaptor = inject(MemoryKV)) {}
 
+  readonly enabled: boolean = true;
   readonly kvStoreNamespace: string = 'rate-limit:';
   readonly defaultLimit: number = 100;
   readonly defaultWindowSec: number = 60;

--- a/packages/rate-limit/src/rate-limit.middleware.test.ts
+++ b/packages/rate-limit/src/rate-limit.middleware.test.ts
@@ -1,6 +1,8 @@
-import { Controller, createApp, Get } from '@zeltjs/core';
+import { Config, Controller, createApp, Get } from '@zeltjs/core';
+import { onTest } from '@zeltjs/testing';
 import { describe, expect, it } from 'vitest';
 
+import { RateLimitConfig } from './rate-limit.config';
 import { RateLimit } from './rate-limit.middleware';
 
 describe('@RateLimit decorator', () => {
@@ -65,6 +67,33 @@ describe('@RateLimit decorator', () => {
     const r2 = await app.request('/dyn');
     expect(r1.status).toBe(200);
     expect(r2.status).toBe(200);
+  });
+
+  it('skips rate limiting when enabled is false', async () => {
+    @Config
+    class DisabledRateLimitConfig extends RateLimitConfig {
+      override readonly enabled = false;
+    }
+
+    @Controller('/')
+    class TestController {
+      @Get('/disabled')
+      @RateLimit({ limit: 1, windowSec: 60, key: 'test:disabled' })
+      hit() {
+        return { ok: true };
+      }
+    }
+
+    const app = createApp({ http: { controllers: [TestController] } });
+    const testApp = await onTest(app, { configs: [DisabledRateLimitConfig] });
+
+    const r1 = await testApp.request('/disabled');
+    const r2 = await testApp.request('/disabled');
+    const r3 = await testApp.request('/disabled');
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(200);
+    expect(r1.headers.get('X-RateLimit-Limit')).toBeNull();
   });
 
   it('stacking: both decorators must allow', async () => {

--- a/packages/rate-limit/src/rate-limit.middleware.ts
+++ b/packages/rate-limit/src/rate-limit.middleware.ts
@@ -1,19 +1,28 @@
 import type { Next, RequestContext } from '@zeltjs/core';
 import { Injectable, inject, UseMiddleware } from '@zeltjs/core';
 
+import { RateLimitConfig } from './rate-limit.config';
 import { RateLimitExceededException, RateLimitUnavailableException } from './rate-limit.exceptions';
 import { RateLimitService } from './rate-limit.service';
 import type { RateLimitOptions } from './rate-limit.types';
 
 @Injectable()
 export class RateLimitMiddleware {
-  constructor(private readonly limiter = inject(RateLimitService)) {}
+  constructor(
+    private readonly limiter = inject(RateLimitService),
+    private readonly config = inject(RateLimitConfig),
+  ) {}
 
   /**
    * @throws {RateLimitExceededException} When rate limit is exceeded (429)
    * @throws {RateLimitUnavailableException} When rate limit service is unavailable (503)
    */
   async use(c: RequestContext, next: Next, opts: RateLimitOptions): Promise<Response | undefined> {
+    if (!this.config.enabled) {
+      await next();
+      return undefined;
+    }
+
     const key = typeof opts.key === 'string' ? opts.key : opts.key();
     const r = await this.limiter.hit(key, {
       limit: opts.limit,


### PR DESCRIPTION
## Summary

- Add `enabled` property to `RateLimitConfig` (default: `true`) so rate limiting can be disabled via config override in tests
- When `enabled` is `false`, the middleware passes through to `next()` without counting or setting headers
- Update ec-backend integration tests to disable rate limiting by default via `onTest` config override
- Isolate `rate-limit.spec.ts` with its own app instance where rate limiting remains active
- Fix flaky assertion in `auth.spec.ts` that accepted either 409 or 429 depending on rate limit state

## Test plan

- [x] Unit test: `RateLimitConfig.enabled` defaults to `true`
- [x] Unit test: middleware skips rate limiting when `enabled` is `false` (no headers, no 429)
- [x] All existing rate-limit unit tests pass (23/23)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (651/651)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782795443&installation_id=133048706&pr_number=251&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F251&signature=89f269685b0f539ac753e400efc01a1dc4565abca2350c9aacd627b2ead845af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * レート制限の有効/無効を設定で切り替え可能になりました（デフォルトは有効）。

* **バグ修正**
  * 重複メールでの登録時の応答ステータス期待値を 409 に固定しました。

* **テスト**
  * レート制限関連のテストを整理・拡充し、無効化設定時のスキップ動作やヘッダ挙動、閾値超過時の応答コード検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->