### PR TITLE
[codex] Add manual canary publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,9 +3,16 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Canary version to publish, e.g. 0.1.0-canary.0"
+        required: true
+        type: string
 
 jobs:
   publish:
+    if: github.event_name == 'release' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -25,11 +32,25 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate canary version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+        run: |
+          node -e "const version = process.env.PACKAGE_VERSION?.replace(/^v/, '') ?? ''; if (!/^[0-9]+\\.[0-9]+\\.[0-9]+-canary(?:\\.[0-9A-Za-z-]+)*$/.test(version)) { console.error('Canary version must look like 0.1.0-canary.0'); process.exit(1); }"
+
       - name: Update versions
-        run: pnpm -r exec npm version ${{ github.event.release.tag_name }} --no-git-tag-version --allow-same-version
+        env:
+          PACKAGE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.release.tag_name }}
+        run: pnpm -r exec npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version
 
       - name: Build
         run: pnpm build
 
       - name: Publish packages
-        run: pnpm -r publish --access public --no-git-checks --provenance
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            pnpm -r publish --access public --no-git-checks --provenance --tag canary
+          else
+            pnpm -r publish --access public --no-git-checks --provenance
+          fi


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` to the existing trusted-publishing release workflow.
- Allow manually specified canary versions such as `0.1.0-canary.0`.
- Publish manual runs with the npm `canary` dist-tag while preserving the existing GitHub Release publish path.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-please.yml`
- Canary version validation accepts `0.1.0-canary.0` and `v0.1.0-canary.1`, rejects `0.1.0`.
- `pnpm run precommit`
- pre-push hook `knip`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783174688&installation_id=133048706&pr_number=255&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F255&signature=1de733688f1c09c1ada28a9b352aa40755c5aeec6e19b02f2c228577f771d350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->