### PR TITLE
Add dual ESM/CJS output to all packages

### DIFF
--- a/packages/adapter-bun/package.json
+++ b/packages/adapter-bun/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -34,5 +40,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/adapter-bun/tsdown.config.ts
+++ b/packages/adapter-bun/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -33,5 +39,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/adapter-cloudflare-workers/tsdown.config.ts
+++ b/packages/adapter-cloudflare-workers/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/adapter-electron/package.json
+++ b/packages/adapter-electron/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -41,5 +47,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/adapter-electron/tsdown.config.ts
+++ b/packages/adapter-electron/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/adapter-lambda/package.json
+++ b/packages/adapter-lambda/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -34,5 +40,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/adapter-lambda/tsdown.config.ts
+++ b/packages/adapter-lambda/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -37,5 +43,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/adapter-node/tsdown.config.ts
+++ b/packages/adapter-node/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -38,5 +44,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/auth-jwt/tsdown.config.ts
+++ b/packages/auth-jwt/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/auth-session/package.json
+++ b/packages/auth-session/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -38,5 +44,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/auth-session/tsdown.config.ts
+++ b/packages/auth-session/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,12 +17,24 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./config": {
-      "types": "./dist/config/index.d.ts",
-      "import": "./dist/config/index.js"
+      "import": {
+        "types": "./dist/config/index.d.ts",
+        "default": "./dist/config/index.js"
+      },
+      "require": {
+        "types": "./dist/config/index.d.cts",
+        "default": "./dist/config/index.cjs"
+      }
     }
   },
   "files": [
@@ -54,5 +66,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/cli.ts', 'src/index.ts', 'src/config/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,16 +13,34 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./internal-bridge/testing": {
-      "types": "./dist/internal-bridge/testing.d.ts",
-      "import": "./dist/internal-bridge/testing.js"
+      "import": {
+        "types": "./dist/internal-bridge/testing.d.ts",
+        "default": "./dist/internal-bridge/testing.js"
+      },
+      "require": {
+        "types": "./dist/internal-bridge/testing.d.cts",
+        "default": "./dist/internal-bridge/testing.cjs"
+      }
     },
     "./internal-bridge/errors": {
-      "types": "./dist/internal-bridge/errors.d.ts",
-      "import": "./dist/internal-bridge/errors.js"
+      "import": {
+        "types": "./dist/internal-bridge/errors.d.ts",
+        "default": "./dist/internal-bridge/errors.js"
+      },
+      "require": {
+        "types": "./dist/internal-bridge/errors.d.cts",
+        "default": "./dist/internal-bridge/errors.cjs"
+      }
     }
   },
   "files": [
@@ -47,5 +65,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/internal-bridge/testing.ts', 'src/internal-bridge/errors.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -34,5 +40,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/db/tsdown.config.ts
+++ b/packages/db/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/decorator-metadata/package.json
+++ b/packages/decorator-metadata/package.json
@@ -14,12 +14,24 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./inspect": {
-      "types": "./dist/inspect/index.d.ts",
-      "import": "./dist/inspect/index.js"
+      "import": {
+        "types": "./dist/inspect/index.d.ts",
+        "default": "./dist/inspect/index.js"
+      },
+      "require": {
+        "types": "./dist/inspect/index.d.cts",
+        "default": "./dist/inspect/index.cjs"
+      }
     }
   },
   "files": [
@@ -52,5 +64,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/decorator-metadata/tsdown.config.ts
+++ b/packages/decorator-metadata/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/inspect/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,11 +11,17 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/eslint-plugin/tsdown.config.ts
+++ b/packages/eslint-plugin/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/eventbus/package.json
+++ b/packages/eventbus/package.json
@@ -13,16 +13,34 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./adaptor-memory": {
-      "types": "./dist/adaptor-memory/index.d.ts",
-      "import": "./dist/adaptor-memory/index.js"
+      "import": {
+        "types": "./dist/adaptor-memory/index.d.ts",
+        "default": "./dist/adaptor-memory/index.js"
+      },
+      "require": {
+        "types": "./dist/adaptor-memory/index.d.cts",
+        "default": "./dist/adaptor-memory/index.cjs"
+      }
     },
     "./adaptor-redis": {
-      "types": "./dist/adaptor-redis/index.d.ts",
-      "import": "./dist/adaptor-redis/index.js"
+      "import": {
+        "types": "./dist/adaptor-redis/index.d.ts",
+        "default": "./dist/adaptor-redis/index.js"
+      },
+      "require": {
+        "types": "./dist/adaptor-redis/index.d.cts",
+        "default": "./dist/adaptor-redis/index.cjs"
+      }
     }
   },
   "files": [
@@ -52,5 +70,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/eventbus/tsdown.config.ts
+++ b/packages/eventbus/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/adaptor-memory/index.ts', 'src/adaptor-redis/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/hono-client/package.json
+++ b/packages/hono-client/package.json
@@ -16,8 +16,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -47,5 +53,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/hono-client/tsdown.config.ts
+++ b/packages/hono-client/tsdown.config.ts
@@ -8,14 +8,26 @@ const swcDecoratorPlugin = swc({
   },
 });
 
-export default defineConfig({
-  plugins: [swcDecoratorPlugin],
-  entry: ['src/index.ts', 'src/cli.ts'],
-  format: ['esm'],
-  dts: true,
-  clean: true,
-  fixedExtension: false,
-  deps: {
-    neverBundle: ['hono', /^hono\//, /^@hono\//, '@zeltjs/core', '@zeltjs/adapter-node'],
+export default defineConfig([
+  {
+    plugins: [swcDecoratorPlugin],
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: true,
+    fixedExtension: false,
+    deps: {
+      neverBundle: ['hono', /^hono\//, /^@hono\//, '@zeltjs/core', '@zeltjs/adapter-node'],
+    },
   },
-});
+  {
+    plugins: [swcDecoratorPlugin],
+    entry: ['src/cli.ts'],
+    format: ['esm'],
+    dts: true,
+    fixedExtension: false,
+    deps: {
+      neverBundle: ['hono', /^hono\//, /^@hono\//, '@zeltjs/core', '@zeltjs/adapter-node'],
+    },
+  },
+]);

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -13,16 +13,34 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./adaptor-memory": {
-      "types": "./dist/adaptor-memory/index.d.ts",
-      "import": "./dist/adaptor-memory/index.js"
+      "import": {
+        "types": "./dist/adaptor-memory/index.d.ts",
+        "default": "./dist/adaptor-memory/index.js"
+      },
+      "require": {
+        "types": "./dist/adaptor-memory/index.d.cts",
+        "default": "./dist/adaptor-memory/index.cjs"
+      }
     },
     "./adaptor-redis": {
-      "types": "./dist/adaptor-redis/index.d.ts",
-      "import": "./dist/adaptor-redis/index.js"
+      "import": {
+        "types": "./dist/adaptor-redis/index.d.ts",
+        "default": "./dist/adaptor-redis/index.js"
+      },
+      "require": {
+        "types": "./dist/adaptor-redis/index.d.cts",
+        "default": "./dist/adaptor-redis/index.cjs"
+      }
     }
   },
   "files": [
@@ -52,5 +70,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/kv/tsdown.config.ts
+++ b/packages/kv/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/adaptor-memory/index.ts', 'src/adaptor-redis/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -39,5 +45,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/openapi/tsdown.config.ts
+++ b/packages/openapi/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/rate-limit/package.json
+++ b/packages/rate-limit/package.json
@@ -13,8 +13,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -39,5 +45,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/rate-limit/tsdown.config.ts
+++ b/packages/rate-limit/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -13,12 +13,24 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./testing": {
-      "types": "./dist/testing/index.d.ts",
-      "import": "./dist/testing/index.js"
+      "import": {
+        "types": "./dist/testing/index.d.ts",
+        "default": "./dist/testing/index.js"
+      },
+      "require": {
+        "types": "./dist/testing/index.d.cts",
+        "default": "./dist/testing/index.cjs"
+      }
     }
   },
   "files": [
@@ -53,5 +65,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/redis/tsdown.config.ts
+++ b/packages/redis/tsdown.config.ts
@@ -11,7 +11,7 @@ const swcDecoratorPlugin = swc({
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
   entry: ['src/index.ts', 'src/testing/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -13,24 +13,54 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./vitest": {
-      "types": "./dist/adapters/vitest.d.ts",
-      "import": "./dist/adapters/vitest.js"
+      "import": {
+        "types": "./dist/adapters/vitest.d.ts",
+        "default": "./dist/adapters/vitest.js"
+      },
+      "require": {
+        "types": "./dist/adapters/vitest.d.cts",
+        "default": "./dist/adapters/vitest.cjs"
+      }
     },
     "./jest": {
-      "types": "./dist/adapters/jest.d.ts",
-      "import": "./dist/adapters/jest.js"
+      "import": {
+        "types": "./dist/adapters/jest.d.ts",
+        "default": "./dist/adapters/jest.js"
+      },
+      "require": {
+        "types": "./dist/adapters/jest.d.cts",
+        "default": "./dist/adapters/jest.cjs"
+      }
     },
     "./bun": {
-      "types": "./dist/adapters/bun.d.ts",
-      "import": "./dist/adapters/bun.js"
+      "import": {
+        "types": "./dist/adapters/bun.d.ts",
+        "default": "./dist/adapters/bun.js"
+      },
+      "require": {
+        "types": "./dist/adapters/bun.d.cts",
+        "default": "./dist/adapters/bun.cjs"
+      }
     },
     "./node": {
-      "types": "./dist/adapters/node.d.ts",
-      "import": "./dist/adapters/node.js"
+      "import": {
+        "types": "./dist/adapters/node.d.ts",
+        "default": "./dist/adapters/node.js"
+      },
+      "require": {
+        "types": "./dist/adapters/node.d.cts",
+        "default": "./dist/adapters/node.cjs"
+      }
     }
   },
   "files": [
@@ -69,5 +99,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/testing/tsdown.config.ts
+++ b/packages/testing/tsdown.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     'src/adapters/bun.ts',
     'src/adapters/node.ts',
   ],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/unsafe-type-lib/package.json
+++ b/packages/unsafe-type-lib/package.json
@@ -11,8 +11,14 @@
   "private": true,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [
@@ -27,5 +33,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/unsafe-type-lib/tsdown.config.ts
+++ b/packages/unsafe-type-lib/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/validator-valibot/package.json
+++ b/packages/validator-valibot/package.json
@@ -13,12 +13,24 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./openapi": {
-      "types": "./dist/openapi/index.d.ts",
-      "import": "./dist/openapi/index.js"
+      "import": {
+        "types": "./dist/openapi/index.d.ts",
+        "default": "./dist/openapi/index.js"
+      },
+      "require": {
+        "types": "./dist/openapi/index.d.cts",
+        "default": "./dist/openapi/index.cjs"
+      }
     }
   },
   "files": [
@@ -52,5 +64,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "main": "./dist/index.cjs"
 }

--- a/packages/validator-valibot/tsdown.config.ts
+++ b/packages/validator-valibot/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/openapi/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   fixedExtension: false,


### PR DESCRIPTION
## Summary

- Configure tsdown to emit both ESM (`.js`) and CJS (`.cjs`) formats for all packages
- Update `package.json` exports with `import`/`require` conditions for dual-format consumption
- Add `main` field pointing to CJS entry for legacy bundler compatibility
- Split `hono-client` build config to keep `cli.ts` ESM-only (top-level await)

## Test plan

- [x] Full monorepo build passes (`pnpm build`)
- [x] All 703 tests pass (`pnpm test`)
- [x] `verify-dist` confirms importability
- [x] Verified `.cjs` and `.d.cts` files are emitted alongside `.js`/`.d.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783359663&installation_id=133048706&pr_number=260&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F260&signature=1d16c37b94e08281783f58d632e2031758ddac36db734d18347e0c599bb5c0bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 複数のパッケージに対して CommonJS (CJS) モジュール形式のサポートを追加しました。これにより、ESM と CJS の両方の環境で利用可能になります。

* **改善**
  * パッケージエントリーポイントの設定を最適化し、モジュール形式の自動選択が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->