### PR TITLE
refactor: remove bind from Feature, make Services stateless

### DIFF
--- a/integration/hooks/src/app.ts
+++ b/integration/hooks/src/app.ts
@@ -10,7 +10,6 @@ type NoCapabilities = Record<never, never>;
 
 const warmupProbe = (): ConfiguredFeature<'warmupProbe', NoCapabilities> => ({
   key: 'warmupProbe',
-  bind: () => undefined,
   staticCapabilities: () => ({}),
   createCapabilities: () => ({}),
   warmup: async (runtime) => {

--- a/packages/adapter-bun/src/on-bun.test.ts
+++ b/packages/adapter-bun/src/on-bun.test.ts
@@ -59,7 +59,6 @@ class FakeHttpLikeFeature extends Feature<
 > {
   readonly key = 'http' as const;
 
-  bind = vi.fn();
   staticCapabilities = () => ({});
   createCapabilities = () => ({
     fetch: async () => new Response('fake'),

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -53,7 +53,6 @@ class FakeHttpLikeFeature extends Feature<
 > {
   readonly key = 'http' as const;
 
-  bind = vi.fn();
   staticCapabilities = () => ({});
   createCapabilities = () => ({
     fetch: async () => new Response('fake'),

--- a/packages/core/src/app/create-app.lib.test.ts
+++ b/packages/core/src/app/create-app.lib.test.ts
@@ -10,14 +10,12 @@ const createStubFeature = <TKey extends string, TCaps extends object>(
   caps: TCaps,
 ): ConfiguredFeature<TKey, TCaps> => ({
   key,
-  bind: vi.fn(),
   staticCapabilities: () => ({}),
   createCapabilities: () => caps,
 });
 
 const createEmptyFeature = (key: string): ConfiguredFeature<string, object> => ({
   key,
-  bind: vi.fn(),
   staticCapabilities: () => ({}),
   createCapabilities: () => ({}),
 });
@@ -25,7 +23,6 @@ const createEmptyFeature = (key: string): ConfiguredFeature<string, object> => (
 class TypedFeature extends Feature<'typed', { readonly value: () => string }> {
   readonly key = 'typed' as const;
 
-  bind = vi.fn();
   staticCapabilities = () => ({});
   createCapabilities = () => ({ value: () => 'ok' });
 }
@@ -33,7 +30,6 @@ class TypedFeature extends Feature<'typed', { readonly value: () => string }> {
 class UserFeature extends Feature<'userFeature', { readonly run: () => number }> {
   readonly key = 'userFeature' as const;
 
-  bind = vi.fn();
   staticCapabilities = () => ({});
   createCapabilities = () => ({ run: () => 123 });
 }
@@ -41,7 +37,6 @@ class UserFeature extends Feature<'userFeature', { readonly run: () => number }>
 class OtherFeature extends Feature<'otherFeature', { readonly other: () => string }> {
   readonly key = 'otherFeature' as const;
 
-  bind = vi.fn();
   staticCapabilities = () => ({});
   createCapabilities = () => ({ other: () => 'no' });
 }
@@ -50,14 +45,12 @@ const duplicateStaticCapabilities = vi.fn(() => ({}));
 
 class DuplicateA extends Feature<'dup', { readonly a: () => string }> {
   readonly key = 'dup' as const;
-  bind = vi.fn();
   staticCapabilities = duplicateStaticCapabilities;
   createCapabilities = () => ({ a: () => 'a' });
 }
 
 class DuplicateB extends Feature<'dup', { readonly b: () => string }> {
   readonly key = 'dup' as const;
-  bind = vi.fn();
   staticCapabilities = () => ({});
   createCapabilities = () => ({ b: () => 'b' });
 }
@@ -66,7 +59,6 @@ const reservedStaticCapabilities = vi.fn(() => ({}));
 
 class ReservedCreateRuntimeFeature extends Feature<'createRuntime', { readonly run: () => void }> {
   readonly key = 'createRuntime' as const;
-  bind = vi.fn();
   staticCapabilities = reservedStaticCapabilities;
   createCapabilities = () => ({ run: () => {} });
 }

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -51,12 +51,6 @@ export type RuntimeApp<F extends readonly ConfiguredFeature[]> = {
 
 // ─── Helpers ───
 
-const bindFeatures = (container: Container, features: readonly ConfiguredFeature[]): void => {
-  for (const feature of features) {
-    feature.bind(container);
-  }
-};
-
 const reservedFeatureKeys = new Set([
   '__proto__',
   'createRuntime',
@@ -145,8 +139,6 @@ export const createApp = <const F extends readonly ConfiguredFeature[]>(
     ...staticCaps,
     createRuntime: async (runtimeOptions?: CreateRuntimeOptions): Promise<RuntimeApp<F>> => {
       const container = new Container();
-
-      bindFeatures(container, features);
 
       const runtime = container.get(AppRuntime);
       const configRegistry = container.get(ConfigRegistry);

--- a/packages/core/src/app/feature.types.ts
+++ b/packages/core/src/app/feature.types.ts
@@ -1,4 +1,3 @@
-import type { Container } from '@needle-di/core';
 import type {
   KeyedMethodValue,
   ObjectFromKeyedValues,
@@ -17,7 +16,6 @@ export abstract class Feature<
   TStaticCaps extends object = EmptyCapabilities,
 > {
   abstract readonly key: TKey;
-  abstract bind(container: Container): void;
   abstract staticCapabilities(): TStaticCaps;
   abstract createCapabilities(runtime: FeatureRuntime): TReadyCaps | Promise<TReadyCaps>;
   warmup?(runtime: FeatureRuntime): Promise<void> | void;

--- a/packages/core/src/features/command/command.feature.test.ts
+++ b/packages/core/src/features/command/command.feature.test.ts
@@ -1,7 +1,6 @@
 import { Container } from '@needle-di/core';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { LifecycleManager } from '../../kernel';
 import { CommandFeature, command } from './command.feature';
 import { Command } from './definition/command.decorator';
 import { cliSchema } from './input/command-schema.types';
@@ -30,23 +29,20 @@ describe('command feature', () => {
 
   it('keeps feature methods callable when destructured', () => {
     const feature = command([GreetCommand]);
-    const { bind } = feature;
-    const container = new Container();
+    const { staticCapabilities } = feature;
 
-    expect(() => bind(container)).not.toThrow();
+    expect(() => staticCapabilities()).not.toThrow();
   });
 
   it('returns a ConfiguredFeature with key "commands"', () => {
     const feature = command([GreetCommand]);
     expect(feature.key).toBe('commands');
-    expect(typeof feature.bind).toBe('function');
     expect(typeof feature.createCapabilities).toBe('function');
   });
 
   it('createCapabilities returns CommandCapabilities', async () => {
     const feature = command([GreetCommand]);
     const container = new Container();
-    feature.bind(container);
     const caps = await feature.createCapabilities(createRuntime(container));
     expect(typeof caps.hasCommand).toBe('function');
     expect(typeof caps.getCommands).toBe('function');
@@ -56,7 +52,6 @@ describe('command feature', () => {
   it('caps.hasCommand detects registered commands', async () => {
     const feature = command([GreetCommand]);
     const container = new Container();
-    feature.bind(container);
     const caps = await feature.createCapabilities(createRuntime(container));
 
     expect(caps.hasCommand('greet')).toBe(true);
@@ -66,15 +61,9 @@ describe('command feature', () => {
   it('caps.execCommand runs a registered command', async () => {
     const feature = command([GreetCommand]);
     const container = new Container();
-    feature.bind(container);
     const caps = await feature.createCapabilities(createRuntime(container));
-
-    const lifecycle = container.get(LifecycleManager);
-    await lifecycle.startup();
 
     const result = await caps.execCommand(['greet']);
     expect(result.exitCode).toBe(0);
-
-    await lifecycle.shutdown();
   });
 });

--- a/packages/core/src/features/command/command.feature.ts
+++ b/packages/core/src/features/command/command.feature.ts
@@ -1,7 +1,6 @@
-import type { Container } from '@needle-di/core';
 import type { FeatureRuntime } from '../../app';
 import { Feature } from '../../app';
-import { COMMAND_OPTIONS, CommandService } from './command.service';
+import { CommandService } from './command.service';
 import type { CommandClass } from './command.types';
 import type { ExecResult } from './exec-result.types';
 
@@ -18,20 +17,17 @@ export class CommandFeature extends Feature<'commands', CommandCapabilities> {
     super();
   }
 
-  readonly bind = (container: Container): void => {
-    container.bind({ provide: COMMAND_OPTIONS, useValue: this.commands });
-  };
-
   readonly staticCapabilities = (): Record<never, never> => {
     return {};
   };
 
   readonly createCapabilities = async (runtime: FeatureRuntime): Promise<CommandCapabilities> => {
     const service = await runtime.get(CommandService);
+    const registry = service.buildRegistry(this.commands);
     return {
-      hasCommand: (name) => service.hasCommand(name),
-      getCommands: () => service.getCommands(),
-      execCommand: (argv) => service.exec(argv),
+      hasCommand: (name) => registry.has(name),
+      getCommands: () => registry,
+      execCommand: (argv) => service.exec(registry, argv),
     };
   };
 }

--- a/packages/core/src/features/command/command.service.ts
+++ b/packages/core/src/features/command/command.service.ts
@@ -1,9 +1,7 @@
-import { Container, InjectionToken } from '@needle-di/core';
-import type { Lifecycle } from '../../kernel';
+import { Container } from '@needle-di/core';
 import {
   Injectable,
   inject,
-  LifecycleManager,
   resolve,
   ZeltAppConfigurationError,
   ZeltCommandExecutionError,
@@ -15,31 +13,16 @@ import type { ExecResult } from './exec-result.types';
 import { parseArgv, runInCommandContext } from './input';
 import type { SchemaDefinition } from './input/command-schema.types';
 
-export const COMMAND_OPTIONS = new InjectionToken<readonly CommandClass[]>('COMMAND_OPTIONS');
+export type CommandRegistry = ReadonlyMap<string, CommandClass>;
 
 @Injectable()
-export class CommandService implements Lifecycle {
-  private readonly commandMap = new Map<string, CommandClass>();
-
-  /** @throws {ZeltAppConfigurationError | ZeltDecoratorUsageError} */
-  constructor(
-    private readonly commands: readonly CommandClass[] = inject(COMMAND_OPTIONS),
-    private readonly lifecycleManager: LifecycleManager = inject(LifecycleManager),
-    private readonly container: Container = inject(Container),
-  ) {
-    this.lifecycleManager.register(this);
-    this.validateAndRegisterCommands();
-  }
-
-  async startup(): Promise<void> {}
-
-  async shutdown(): Promise<void> {
-    this.commandMap.clear();
-  }
+export class CommandService {
+  constructor(private readonly container: Container = inject(Container)) {}
 
   /** @throws {ZeltDecoratorUsageError | ZeltAppConfigurationError} */
-  private validateAndRegisterCommands(): void {
-    for (const cls of this.commands) {
+  buildRegistry(commands: readonly CommandClass[]): CommandRegistry {
+    const registry = new Map<string, CommandClass>();
+    for (const cls of commands) {
       const meta = getCommandMetadata(cls);
       if (!meta) {
         throw new ZeltDecoratorUsageError({
@@ -48,19 +31,33 @@ export class CommandService implements Lifecycle {
           targetName: cls.name,
         });
       }
-      if (this.commandMap.has(meta.name)) {
+      if (registry.has(meta.name)) {
         throw new ZeltAppConfigurationError({ reason: 'duplicate_command', details: meta.name });
       }
-      this.commandMap.set(meta.name, cls);
+      registry.set(meta.name, cls);
     }
+    return registry;
   }
 
-  hasCommand(name: string): boolean {
-    return this.commandMap.has(name);
-  }
+  async exec(registry: CommandRegistry, argv: readonly string[]): Promise<ExecResult> {
+    const commandName = argv[0];
 
-  getCommands(): ReadonlyMap<string, CommandClass> {
-    return this.commandMap;
+    if (!commandName) {
+      return {
+        exitCode: 1,
+        reason: new ZeltCommandExecutionError({ reason: 'no_command_specified' }),
+      };
+    }
+
+    const CommandClass = registry.get(commandName);
+    if (!CommandClass) {
+      return {
+        exitCode: 1,
+        reason: new ZeltCommandExecutionError({ reason: 'command_not_found', commandName }),
+      };
+    }
+
+    return this.runCommand(CommandClass, commandName, argv.slice(1));
   }
 
   private async runCommand(
@@ -95,26 +92,5 @@ export class CommandService implements Lifecycle {
         reason: new ZeltCommandExecutionError({ reason: 'run_error', commandName, details }, cause),
       };
     }
-  }
-
-  async exec(argv: readonly string[]): Promise<ExecResult> {
-    const commandName = argv[0];
-
-    if (!commandName) {
-      return {
-        exitCode: 1,
-        reason: new ZeltCommandExecutionError({ reason: 'no_command_specified' }),
-      };
-    }
-
-    const CommandClass = this.commandMap.get(commandName);
-    if (!CommandClass) {
-      return {
-        exitCode: 1,
-        reason: new ZeltCommandExecutionError({ reason: 'command_not_found', commandName }),
-      };
-    }
-
-    return this.runCommand(CommandClass, commandName, argv.slice(1));
   }
 }

--- a/packages/core/src/features/http/http.feature.test.ts
+++ b/packages/core/src/features/http/http.feature.test.ts
@@ -2,7 +2,6 @@ import { Container } from '@needle-di/core';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { createApp } from '../../app';
-import { LifecycleManager } from '../../kernel';
 import { HttpFeature, http } from './http.feature';
 import { Controller } from './routing/controller.decorator';
 import { Get } from './routing/http-method.decorator';
@@ -64,7 +63,6 @@ describe('http feature', () => {
   it('returns a ConfiguredFeature with key "http"', () => {
     const feature = http({ controllers: [TestController] });
     expect(feature.key).toBe('http');
-    expect(typeof feature.bind).toBe('function');
     expect(typeof feature.createCapabilities).toBe('function');
     expect(typeof feature.staticCapabilities).toBe('function');
   });
@@ -80,7 +78,6 @@ describe('http feature', () => {
   it('createCapabilities returns fetch and request', async () => {
     const feature = http({ controllers: [TestController] });
     const container = new Container();
-    feature.bind(container);
     const caps = await feature.createCapabilities(createRuntime(container));
     expect(typeof caps.fetch).toBe('function');
     expect(typeof caps.request).toBe('function');
@@ -89,16 +86,10 @@ describe('http feature', () => {
   it('caps.request handles HTTP requests', async () => {
     const feature = http({ controllers: [TestController] });
     const container = new Container();
-    feature.bind(container);
     const caps = await feature.createCapabilities(createRuntime(container));
-
-    const lifecycle = container.get(LifecycleManager);
-    await lifecycle.startup();
 
     const res = await caps.request('/');
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
-
-    await lifecycle.shutdown();
   });
 });

--- a/packages/core/src/features/http/http.feature.ts
+++ b/packages/core/src/features/http/http.feature.ts
@@ -1,8 +1,7 @@
-import type { Container } from '@needle-di/core';
 import type { FeatureRuntime } from '../../app';
 import { Feature } from '../../app';
 import type { HttpMetadata, HttpOptions } from './http.service';
-import { HTTP_OPTIONS, HttpService } from './http.service';
+import { HttpService } from './http.service';
 import type { ControllerClass } from './http.types';
 import { collectAllControllerMetadata, collectAllControllers } from './http-children.lib';
 import { collectRoutes } from './routing';
@@ -33,10 +32,6 @@ export class HttpFeature extends Feature<'http', HttpCapabilities, HttpStaticCap
     this.metadata = { controllers: collectAllControllerMetadata(opts) };
   }
 
-  readonly bind = (container: Container): void => {
-    container.bind({ provide: HTTP_OPTIONS, useValue: this.opts });
-  };
-
   readonly staticCapabilities = (): HttpStaticCapabilities => {
     return {
       getControllers: () => this.controllers,
@@ -46,15 +41,20 @@ export class HttpFeature extends Feature<'http', HttpCapabilities, HttpStaticCap
 
   readonly createCapabilities = async (runtime: FeatureRuntime): Promise<HttpCapabilities> => {
     const service = await runtime.get(HttpService);
+    const router = await service.buildRouter(this.opts);
     return {
-      fetch: (req) => service.fetch(req),
-      request: (input, init) => service.request(input, init),
+      fetch: async (req) => router.fetch(req),
+      request: async (input, init) => {
+        const req =
+          typeof input === 'string' ? new Request(new URL(input, 'http://localhost'), init) : input;
+        return router.fetch(req);
+      },
     };
   };
 
   override readonly warmup = async (runtime: FeatureRuntime): Promise<void> => {
     const service = await runtime.get(HttpService);
-    await service.warmupControllers();
+    await service.warmupControllers(this.opts);
   };
 }
 

--- a/packages/core/src/features/http/http.service.ts
+++ b/packages/core/src/features/http/http.service.ts
@@ -1,10 +1,9 @@
-import { Container, InjectionToken } from '@needle-di/core';
+import { Container } from '@needle-di/core';
 import type { Hono } from 'hono';
-import type { Lifecycle } from '../../kernel';
 import { Injectable, inject, LifecycleManager, resolve } from '../../kernel';
 import { DefaultErrorHandler } from './error/default.error-handler';
 import type { ControllerClass, HttpChildOptions, HttpOptions } from './http.types';
-import { collectAllControllerMetadata, collectAllControllers } from './http-children.lib';
+import { collectAllControllers } from './http-children.lib';
 import { createErrorHandler, resolveErrorHandlers } from './http-error-handlers.lib';
 import { CorsMiddleware } from './middleware/cors/cors.middleware';
 import type {
@@ -22,7 +21,7 @@ export type HttpMetadata = {
   readonly controllers: readonly ControllerRouteInfo[];
 };
 
-export const HTTP_OPTIONS = new InjectionToken<HttpOptions>('HTTP_OPTIONS');
+export type HttpRouter = Hono;
 
 type RouteHandler = (c: RequestContext) => Promise<Response>;
 
@@ -50,22 +49,25 @@ type _HonoInstanceCheck = HonoInstance extends {
   : never;
 
 @Injectable()
-export class HttpService implements Lifecycle<{ hono: HonoInstance }> {
-  private readonly ready;
-
-  /** @throws {ZeltNotImplementedError | ZeltLifecycleStateError} */
+export class HttpService {
   constructor(
-    private readonly options: HttpOptions = inject(HTTP_OPTIONS),
     private readonly container: Container = inject(Container),
     private readonly lifecycleManager: LifecycleManager = inject(LifecycleManager),
-  ) {
-    this.ready = this.lifecycleManager.register(this);
+  ) {}
+
+  /** @throws {Error} */
+  async buildRouter(options: HttpOptions): Promise<HttpRouter> {
+    try {
+      return await this.initializeHono(options);
+    } catch (cause) {
+      throw new Error('HttpService buildRouter failed', { cause });
+    }
   }
 
   /** @throws {ZeltReadyFailedError | ZeltLifecycleStateError} */
-  async warmupControllers(): Promise<void> {
+  async warmupControllers(options: HttpOptions): Promise<void> {
     await warmupControllers(
-      collectAllControllers(this.options),
+      collectAllControllers(options),
       {
         get: <T extends object>(cls: new (...args: never[]) => T): T =>
           resolve(this.container, cls),
@@ -74,17 +76,8 @@ export class HttpService implements Lifecycle<{ hono: HonoInstance }> {
     );
   }
 
-  /** @throws {Error} */
-  async startup(): Promise<{ hono: HonoInstance }> {
-    try {
-      return { hono: await this.initializeHono() };
-    } catch (cause) {
-      throw new Error('HttpService startup failed', { cause });
-    }
-  }
-
   /** @throws {ZeltNotImplementedError | ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
-  private async initializeHono(): Promise<HonoInstance> {
+  private async initializeHono(options: HttpOptions): Promise<HonoInstance> {
     const Hono = await this.loadHonoConstructor();
     const fallbackHandler = resolve(this.container, DefaultErrorHandler);
     const resolver = {
@@ -95,13 +88,13 @@ export class HttpService implements Lifecycle<{ hono: HonoInstance }> {
       CorsMiddleware,
       SecureHeadersMiddleware,
     ];
-    const rootMiddlewares = [...securityMiddlewares, ...(this.options.middlewares ?? [])];
+    const rootMiddlewares = [...securityMiddlewares, ...(options.middlewares ?? [])];
 
     const hono = this.buildHonoInstance(
-      this.options.controllers,
+      options.controllers,
       rootMiddlewares,
-      this.options.errorHandlers ?? [],
-      this.options.children ?? [],
+      options.errorHandlers ?? [],
+      options.children ?? [],
       fallbackHandler,
       resolver,
       Hono,
@@ -153,28 +146,5 @@ export class HttpService implements Lifecycle<{ hono: HonoInstance }> {
     }
 
     return hono;
-  }
-
-  async shutdown(): Promise<void> {}
-
-  /** @throws {ZeltLifecycleStateError} */
-  async fetch(req: Request): Promise<Response> {
-    return this.ready.hono.fetch(req);
-  }
-
-  request(input: string | Request, init?: RequestInit): Promise<Response> {
-    const req =
-      typeof input === 'string' ? new Request(new URL(input, 'http://localhost'), init) : input;
-    return this.fetch(req);
-  }
-
-  getControllers(): readonly ControllerClass[] {
-    return collectAllControllers(this.options);
-  }
-
-  getMetadata(): HttpMetadata {
-    return {
-      controllers: collectAllControllerMetadata(this.options),
-    };
   }
 }

--- a/packages/core/src/features/scheduler/scheduler.feature.test.ts
+++ b/packages/core/src/features/scheduler/scheduler.feature.test.ts
@@ -1,7 +1,6 @@
 import { Container } from '@needle-di/core';
-import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { LifecycleManager } from '../../kernel';
 import { Cron } from './schedule/cron.decorator';
 import { Scheduled } from './schedule/scheduled.decorator';
 import { SchedulerFeature, scheduler } from './scheduler.feature';
@@ -17,16 +16,6 @@ class TestScheduler {
 }
 
 describe('scheduler feature', () => {
-  let container: Container | undefined;
-
-  afterEach(async () => {
-    if (container) {
-      const lifecycle = container.get(LifecycleManager);
-      await lifecycle.shutdown();
-      container = undefined;
-    }
-  });
-
   it('scheduler() returns SchedulerFeature instance', () => {
     const feature = scheduler([TestScheduler]);
 
@@ -40,28 +29,21 @@ describe('scheduler feature', () => {
 
   it('keeps feature methods callable when destructured', () => {
     const feature = scheduler([TestScheduler]);
-    const { bind } = feature;
-    const testContainer = new Container();
-    container = testContainer;
+    const { staticCapabilities } = feature;
 
-    expect(() => bind(testContainer)).not.toThrow();
+    expect(() => staticCapabilities()).not.toThrow();
   });
 
   it('returns a ConfiguredFeature with key "schedulers"', () => {
     const feature = scheduler([TestScheduler]);
     expect(feature.key).toBe('schedulers');
-    expect(typeof feature.bind).toBe('function');
     expect(typeof feature.createCapabilities).toBe('function');
   });
 
   it('createCapabilities returns SchedulerCapabilities', async () => {
     const feature = scheduler([TestScheduler]);
-    container = new Container();
-    feature.bind(container);
+    const container = new Container();
     const caps = await feature.createCapabilities(createRuntime(container));
-
-    const lifecycle = container.get(LifecycleManager);
-    await lifecycle.startup();
 
     expect(typeof caps.startScheduler).toBe('function');
     expect(typeof caps.stopScheduler).toBe('function');
@@ -69,14 +51,10 @@ describe('scheduler feature', () => {
     expect(typeof caps.getSchedulerJobs).toBe('function');
   });
 
-  it('scheduler is not running by default after startup', async () => {
+  it('scheduler is not running by default', async () => {
     const feature = scheduler([TestScheduler]);
-    container = new Container();
-    feature.bind(container);
+    const container = new Container();
     const caps = await feature.createCapabilities(createRuntime(container));
-
-    const lifecycle = container.get(LifecycleManager);
-    await lifecycle.startup();
 
     expect(caps.isSchedulerRunning()).toBe(false);
   });

--- a/packages/core/src/features/scheduler/scheduler.feature.ts
+++ b/packages/core/src/features/scheduler/scheduler.feature.ts
@@ -1,7 +1,6 @@
-import type { Container } from '@needle-di/core';
 import type { FeatureRuntime } from '../../app';
 import { Feature } from '../../app';
-import { SCHEDULER_OPTIONS, SchedulerService } from './scheduler.service';
+import { SchedulerService } from './scheduler.service';
 import type { SchedulerClass } from './scheduler.types';
 import type { JobInfo } from './scheduler-runner.lib';
 
@@ -19,21 +18,22 @@ export class SchedulerFeature extends Feature<'schedulers', SchedulerCapabilitie
     super();
   }
 
-  readonly bind = (container: Container): void => {
-    container.bind({ provide: SCHEDULER_OPTIONS, useValue: this.schedulers });
-  };
-
   readonly staticCapabilities = (): Record<never, never> => {
     return {};
   };
 
   readonly createCapabilities = async (runtime: FeatureRuntime): Promise<SchedulerCapabilities> => {
     const service = await runtime.get(SchedulerService);
+    const runner = service.createRunner(this.schedulers);
     return {
-      startScheduler: () => service.startScheduler(),
-      stopScheduler: () => service.stopScheduler(),
-      isSchedulerRunning: () => service.isSchedulerRunning(),
-      getSchedulerJobs: () => service.getSchedulerJobs(),
+      startScheduler: async () => {
+        if (!runner.isRunning()) await runner.startup();
+      },
+      stopScheduler: async () => {
+        if (runner.isRunning()) await runner.shutdown();
+      },
+      isSchedulerRunning: () => runner.isRunning(),
+      getSchedulerJobs: () => runner.getJobs(),
     };
   };
 }

--- a/packages/core/src/features/scheduler/scheduler.service.ts
+++ b/packages/core/src/features/scheduler/scheduler.service.ts
@@ -1,55 +1,19 @@
-import { Container, InjectionToken } from '@needle-di/core';
-import type { Lifecycle } from '../../kernel';
-import { Injectable, inject, LifecycleManager, resolve } from '../../kernel';
+import { Container } from '@needle-di/core';
+import { Injectable, inject, resolve } from '../../kernel';
 import type { SchedulerClass } from './scheduler.types';
-import type { JobInfo, SchedulerRunner } from './scheduler-runner.lib';
+import type { SchedulerRunner } from './scheduler-runner.lib';
 import { createSchedulerRunner } from './scheduler-runner.lib';
 
-export const SCHEDULER_OPTIONS = new InjectionToken<readonly SchedulerClass[]>('SCHEDULER_OPTIONS');
+export type { SchedulerRunner } from './scheduler-runner.lib';
 
 @Injectable()
-export class SchedulerService implements Lifecycle<{ runner: SchedulerRunner }> {
-  private readonly ready;
+export class SchedulerService {
+  constructor(private readonly container: Container = inject(Container)) {}
 
-  constructor(
-    private readonly schedulers: readonly SchedulerClass[] = inject(SCHEDULER_OPTIONS),
-    private readonly container: Container = inject(Container),
-    private readonly lifecycleManager: LifecycleManager = inject(LifecycleManager),
-  ) {
-    this.ready = this.lifecycleManager.register(this);
-  }
-
-  /** @throws {ZeltNotImplementedError} */
-  async startup(): Promise<{ runner: SchedulerRunner }> {
+  createRunner(schedulers: readonly SchedulerClass[]): SchedulerRunner {
     const resolver = {
       get: <T extends object>(cls: new (...args: never[]) => T): T => resolve(this.container, cls),
     };
-    return { runner: createSchedulerRunner(this.schedulers, resolver) };
-  }
-
-  async shutdown(): Promise<void> {
-    if (this.ready.runner.isRunning()) {
-      await this.ready.runner.shutdown();
-    }
-  }
-
-  async startScheduler(): Promise<void> {
-    if (!this.ready.runner.isRunning()) {
-      await this.ready.runner.startup();
-    }
-  }
-
-  async stopScheduler(): Promise<void> {
-    if (this.ready.runner.isRunning()) {
-      await this.ready.runner.shutdown();
-    }
-  }
-
-  isSchedulerRunning(): boolean {
-    return this.ready.runner.isRunning();
-  }
-
-  getSchedulerJobs(): readonly JobInfo[] {
-    return this.ready.runner.getJobs();
+    return createSchedulerRunner(schedulers, resolver);
   }
 }

--- a/packages/eventbus/package.json
+++ b/packages/eventbus/package.json
@@ -61,7 +61,6 @@
     }
   },
   "devDependencies": {
-    "@needle-di/core": "catalog:",
     "@types/node": "catalog:",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/redis": "workspace:*",

--- a/packages/eventbus/src/eventbus.feature.test.ts
+++ b/packages/eventbus/src/eventbus.feature.test.ts
@@ -1,4 +1,3 @@
-import { Container } from '@needle-di/core';
 import type { Lifecycle } from '@zeltjs/core';
 import { Config, createApp, Injectable, inject, LifecycleManager } from '@zeltjs/core';
 import { describe, expect, it } from 'vitest';
@@ -6,10 +5,6 @@ import { describe, expect, it } from 'vitest';
 import { MemoryEventBusAdaptor } from './adaptor-memory';
 import { eventbus } from './eventbus.feature';
 import type { EventBusAdaptor, EventBusSchema } from './eventbus.types';
-
-const createRuntime = (container: Container) => ({
-  get: async <T extends object>(cls: new (...args: never[]) => T): Promise<T> => container.get(cls),
-});
 
 @Config
 class BaseEventBusConfig {
@@ -77,18 +72,7 @@ describe('eventbus feature', () => {
   it('returns a ConfiguredFeature with key "eventbus"', () => {
     const feature = eventbus({ adaptor: MemoryEventBusAdaptor });
     expect(feature.key).toBe('eventbus');
-    expect(typeof feature.bind).toBe('function');
     expect(typeof feature.createCapabilities).toBe('function');
-  });
-
-  it('createCapabilities returns EventBus capabilities', async () => {
-    const feature = eventbus({ adaptor: MemoryEventBusAdaptor });
-    const container = new Container();
-    feature.bind(container);
-    const caps = await feature.createCapabilities(createRuntime(container));
-    expect(typeof caps.emit).toBe('function');
-    expect(typeof caps.on).toBe('function');
-    expect(typeof caps.once).toBe('function');
   });
 
   it('resolves adaptor and handlers after config binding and starts pending lifecycle', async () => {

--- a/packages/eventbus/src/eventbus.feature.ts
+++ b/packages/eventbus/src/eventbus.feature.ts
@@ -28,12 +28,6 @@ export const eventbus = (
   opts: EventBusOptions,
 ): ConfiguredFeature<'eventbus', EventBusCapabilities> => ({
   key: 'eventbus',
-  bind: (container) => {
-    container.bind({ provide: opts.adaptor, useClass: opts.adaptor });
-    for (const handler of opts.handlers ?? []) {
-      container.bind({ provide: handler, useClass: handler });
-    }
-  },
   staticCapabilities: () => ({}),
   createCapabilities: async (runtime) => {
     for (const handler of opts.handlers ?? []) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,9 +434,6 @@ importers:
 
   packages/eventbus:
     devDependencies:
-      '@needle-di/core':
-        specifier: 'catalog:'
-        version: 1.1.2
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -16740,7 +16737,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

- Remove abstract bind(container) from Feature interface
- Make Services stateless for config: config is passed as method arguments instead of being injected via InjectionToken
- Feature createCapabilities passes config directly to stateless Service methods, capturing the returned data in closures
- Remove InjectionToken config indirection (COMMAND_OPTIONS, HTTP_OPTIONS, SCHEDULER_OPTIONS)
- Remove bindFeatures from createApp

## Motivation

bind(container) existed solely to relay config from Feature to Service via DI. Since Feature already holds config and has access to runtime.get() for DI resolution, the indirection was unnecessary. Services are now pure behavior providers that receive config as arguments.

## Test plan

- [ ] All existing tests pass (typecheck, lint, knip, 702 tests)
- [ ] precommit verification passes
- [ ] Integration tests (adapter-node, adapter-bun, eventbus, testing) pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783463817&installation_id=133048706&pr_number=263&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F263&signature=6cfc273f4dd45ba31eb25c9a7bf2806ec75a3bb7f72b0c86600b56f089762635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 内部アーキテクチャの最適化を実施しました。フィーチャーの初期化フローを改善し、依存性注入メカニズムを刷新しました。

* **Tests**
  * テストスイートを更新し、新しいアーキテクチャに対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->