### PR TITLE
refactor(core): remove Feature bind

### DIFF
--- a/integration/hooks/e2e/warmup.spec.ts
+++ b/integration/hooks/e2e/warmup.spec.ts
@@ -18,7 +18,7 @@ describe('Lifecycle warmup', () => {
     activeLog.current = undefined;
   });
 
-  it('runs registered warmup handlers when createRuntime({ warmup: true })', async () => {
+  it('eagerly resolves feature classes when createRuntime({ warmup: true })', async () => {
     readyApp = await buildApp().createRuntime({ warmup: true });
     const instance = await readyApp.get(WarmupSpy);
 
@@ -26,7 +26,7 @@ describe('Lifecycle warmup', () => {
     expect(log.events.some((e) => e.phase === 'warmup')).toBe(true);
   });
 
-  it('runs all warmup handlers before completing createRuntime()', async () => {
+  it('resolves all warmup targets before completing createRuntime()', async () => {
     readyApp = await buildApp().createRuntime({ warmup: true });
 
     const phases = log.events.map((e) => e.phase);

--- a/integration/hooks/src/app.ts
+++ b/integration/hooks/src/app.ts
@@ -10,12 +10,9 @@ type NoCapabilities = Record<never, never>;
 
 const warmupProbe = (): ConfiguredFeature<'warmupProbe', NoCapabilities> => ({
   key: 'warmupProbe',
+  featureClasses: () => [WarmupSpy],
   staticCapabilities: () => ({}),
   createCapabilities: () => ({}),
-  warmup: async (runtime) => {
-    const spy = await runtime.get(WarmupSpy);
-    spy.recordWarmup();
-  },
 });
 
 // Factory because each spec needs an isolated app instance for clean lifecycle counting.

--- a/integration/hooks/src/lifecycle-spy.ts
+++ b/integration/hooks/src/lifecycle-spy.ts
@@ -85,7 +85,7 @@ export class DisposableSpy implements Lifecycle {
 export class WarmupSpy {
   warmupCalls = 0;
 
-  recordWarmup(): void {
+  constructor() {
     this.warmupCalls++;
     activeLog.current?.push({ source: 'warmup', phase: 'warmup' });
   }

--- a/packages/adapter-bun/src/on-bun.test.ts
+++ b/packages/adapter-bun/src/on-bun.test.ts
@@ -59,6 +59,7 @@ class FakeHttpLikeFeature extends Feature<
 > {
   readonly key = 'http' as const;
 
+  featureClasses = () => [];
   staticCapabilities = () => ({});
   createCapabilities = () => ({
     fetch: async () => new Response('fake'),

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -53,6 +53,7 @@ class FakeHttpLikeFeature extends Feature<
 > {
   readonly key = 'http' as const;
 
+  featureClasses = () => [];
   staticCapabilities = () => ({});
   createCapabilities = () => ({
     fetch: async () => new Response('fake'),

--- a/packages/core/src/app/create-app.lib.test.ts
+++ b/packages/core/src/app/create-app.lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { Feature } from '../features';
+import { Injectable } from '../kernel';
 import type { RuntimeApp } from './create-app.lib';
 import { createApp } from './create-app.lib';
 import type { ConfiguredFeature } from './feature.types';
@@ -10,12 +11,14 @@ const createStubFeature = <TKey extends string, TCaps extends object>(
   caps: TCaps,
 ): ConfiguredFeature<TKey, TCaps> => ({
   key,
+  featureClasses: () => [],
   staticCapabilities: () => ({}),
   createCapabilities: () => caps,
 });
 
 const createEmptyFeature = (key: string): ConfiguredFeature<string, object> => ({
   key,
+  featureClasses: () => [],
   staticCapabilities: () => ({}),
   createCapabilities: () => ({}),
 });
@@ -23,6 +26,7 @@ const createEmptyFeature = (key: string): ConfiguredFeature<string, object> => (
 class TypedFeature extends Feature<'typed', { readonly value: () => string }> {
   readonly key = 'typed' as const;
 
+  featureClasses = () => [];
   staticCapabilities = () => ({});
   createCapabilities = () => ({ value: () => 'ok' });
 }
@@ -30,6 +34,7 @@ class TypedFeature extends Feature<'typed', { readonly value: () => string }> {
 class UserFeature extends Feature<'userFeature', { readonly run: () => number }> {
   readonly key = 'userFeature' as const;
 
+  featureClasses = () => [];
   staticCapabilities = () => ({});
   createCapabilities = () => ({ run: () => 123 });
 }
@@ -37,6 +42,7 @@ class UserFeature extends Feature<'userFeature', { readonly run: () => number }>
 class OtherFeature extends Feature<'otherFeature', { readonly other: () => string }> {
   readonly key = 'otherFeature' as const;
 
+  featureClasses = () => [];
   staticCapabilities = () => ({});
   createCapabilities = () => ({ other: () => 'no' });
 }
@@ -45,12 +51,14 @@ const duplicateStaticCapabilities = vi.fn(() => ({}));
 
 class DuplicateA extends Feature<'dup', { readonly a: () => string }> {
   readonly key = 'dup' as const;
+  featureClasses = () => [];
   staticCapabilities = duplicateStaticCapabilities;
   createCapabilities = () => ({ a: () => 'a' });
 }
 
 class DuplicateB extends Feature<'dup', { readonly b: () => string }> {
   readonly key = 'dup' as const;
+  featureClasses = () => [];
   staticCapabilities = () => ({});
   createCapabilities = () => ({ b: () => 'b' });
 }
@@ -59,8 +67,18 @@ const reservedStaticCapabilities = vi.fn(() => ({}));
 
 class ReservedCreateRuntimeFeature extends Feature<'createRuntime', { readonly run: () => void }> {
   readonly key = 'createRuntime' as const;
+  featureClasses = () => [];
   staticCapabilities = reservedStaticCapabilities;
   createCapabilities = () => ({ run: () => {} });
+}
+
+@Injectable()
+class WarmupTarget {
+  static instances = 0;
+
+  constructor() {
+    WarmupTarget.instances++;
+  }
 }
 
 describe('createApp', () => {
@@ -109,6 +127,23 @@ describe('createApp', () => {
     const app = createApp([createEmptyFeature('stub')]);
     const readyApp = await app.createRuntime({ configs: [] });
     expect(typeof readyApp.get).toBe('function');
+    await readyApp.shutdown();
+  });
+
+  it('createRuntime({ warmup: true }) resolves featureClasses eagerly', async () => {
+    WarmupTarget.instances = 0;
+    const app = createApp([
+      {
+        key: 'warmupTarget',
+        featureClasses: () => [WarmupTarget],
+        staticCapabilities: () => ({}),
+        createCapabilities: () => ({}),
+      },
+    ]);
+
+    const readyApp = await app.createRuntime({ warmup: true });
+
+    expect(WarmupTarget.instances).toBe(1);
     await readyApp.shutdown();
   });
 

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -96,12 +96,14 @@ const createStaticCapabilities = <const F extends readonly ConfiguredFeature[]>(
   return unsafeObjectFromNonEmptyKeyedValuesSync(features, 'staticCapabilities');
 };
 
-const warmupFeatures = async (
+const warmupFeatureClasses = async (
   runtime: FeatureRuntime,
   features: readonly ConfiguredFeature[],
 ): Promise<void> => {
   for (const feature of features) {
-    await feature.warmup?.(runtime);
+    for (const cls of feature.featureClasses()) {
+      await runtime.get(cls);
+    }
   }
 };
 
@@ -152,7 +154,7 @@ export const createApp = <const F extends readonly ConfiguredFeature[]>(
       const caps = await createNamespacedCapabilities(readyResult, features);
 
       if (runtimeOptions?.warmup) {
-        await warmupFeatures(readyResult, features);
+        await warmupFeatureClasses(readyResult, features);
       }
 
       const readyApp: RuntimeApp<F> = {

--- a/packages/core/src/app/feature.types.ts
+++ b/packages/core/src/app/feature.types.ts
@@ -8,6 +8,8 @@ export type FeatureRuntime = {
   readonly get: <T extends object>(cls: new (...args: never[]) => T) => Promise<T>;
 };
 
+export type FeatureManagedClass = new (...args: never[]) => object;
+
 type EmptyCapabilities = Record<never, never>;
 
 export abstract class Feature<
@@ -16,9 +18,9 @@ export abstract class Feature<
   TStaticCaps extends object = EmptyCapabilities,
 > {
   abstract readonly key: TKey;
+  abstract featureClasses(): readonly FeatureManagedClass[];
   abstract staticCapabilities(): TStaticCaps;
   abstract createCapabilities(runtime: FeatureRuntime): TReadyCaps | Promise<TReadyCaps>;
-  warmup?(runtime: FeatureRuntime): Promise<void> | void;
 }
 
 export type ConfiguredFeature<

--- a/packages/core/src/app/index.ts
+++ b/packages/core/src/app/index.ts
@@ -12,6 +12,7 @@ export type {
   ConfiguredFeature,
   FeatureCaps,
   FeatureClass,
+  FeatureManagedClass,
   FeatureReadyCapabilities,
   FeatureRuntime,
   NamespacedCaps,

--- a/packages/core/src/features/command/command.feature.test.ts
+++ b/packages/core/src/features/command/command.feature.test.ts
@@ -37,6 +37,7 @@ describe('command feature', () => {
   it('returns a ConfiguredFeature with key "commands"', () => {
     const feature = command([GreetCommand]);
     expect(feature.key).toBe('commands');
+    expect(feature.featureClasses()).toEqual([GreetCommand]);
     expect(typeof feature.createCapabilities).toBe('function');
   });
 

--- a/packages/core/src/features/command/command.feature.ts
+++ b/packages/core/src/features/command/command.feature.ts
@@ -17,6 +17,10 @@ export class CommandFeature extends Feature<'commands', CommandCapabilities> {
     super();
   }
 
+  readonly featureClasses = (): readonly CommandClass[] => {
+    return this.commands;
+  };
+
   readonly staticCapabilities = (): Record<never, never> => {
     return {};
   };

--- a/packages/core/src/features/http/http.feature.test.ts
+++ b/packages/core/src/features/http/http.feature.test.ts
@@ -63,6 +63,7 @@ describe('http feature', () => {
   it('returns a ConfiguredFeature with key "http"', () => {
     const feature = http({ controllers: [TestController] });
     expect(feature.key).toBe('http');
+    expect(feature.featureClasses()).toEqual([TestController]);
     expect(typeof feature.createCapabilities).toBe('function');
     expect(typeof feature.staticCapabilities).toBe('function');
   });

--- a/packages/core/src/features/http/http.feature.ts
+++ b/packages/core/src/features/http/http.feature.ts
@@ -32,6 +32,10 @@ export class HttpFeature extends Feature<'http', HttpCapabilities, HttpStaticCap
     this.metadata = { controllers: collectAllControllerMetadata(opts) };
   }
 
+  readonly featureClasses = (): readonly ControllerClass[] => {
+    return this.controllers;
+  };
+
   readonly staticCapabilities = (): HttpStaticCapabilities => {
     return {
       getControllers: () => this.controllers,
@@ -50,11 +54,6 @@ export class HttpFeature extends Feature<'http', HttpCapabilities, HttpStaticCap
         return router.fetch(req);
       },
     };
-  };
-
-  override readonly warmup = async (runtime: FeatureRuntime): Promise<void> => {
-    const service = await runtime.get(HttpService);
-    await service.warmupControllers(this.opts);
   };
 }
 

--- a/packages/core/src/features/http/http.service.ts
+++ b/packages/core/src/features/http/http.service.ts
@@ -3,7 +3,6 @@ import type { Hono } from 'hono';
 import { Injectable, inject, LifecycleManager, resolve } from '../../kernel';
 import { DefaultErrorHandler } from './error/default.error-handler';
 import type { ControllerClass, HttpChildOptions, HttpOptions } from './http.types';
-import { collectAllControllers } from './http-children.lib';
 import { createErrorHandler, resolveErrorHandlers } from './http-error-handlers.lib';
 import { CorsMiddleware } from './middleware/cors/cors.middleware';
 import type {
@@ -13,7 +12,7 @@ import type {
 } from './middleware/middleware.types';
 import { SecureHeadersMiddleware } from './middleware/secure-headers/secure-headers.middleware';
 import type { ControllerRouteInfo } from './routing';
-import { buildRoutes, warmupControllers } from './routing';
+import { buildRoutes } from './routing';
 
 export type { HttpChildOptions, HttpOptions } from './http.types';
 
@@ -62,18 +61,6 @@ export class HttpService {
     } catch (cause) {
       throw new Error('HttpService buildRouter failed', { cause });
     }
-  }
-
-  /** @throws {ZeltReadyFailedError | ZeltLifecycleStateError} */
-  async warmupControllers(options: HttpOptions): Promise<void> {
-    await warmupControllers(
-      collectAllControllers(options),
-      {
-        get: <T extends object>(cls: new (...args: never[]) => T): T =>
-          resolve(this.container, cls),
-      },
-      this.lifecycleManager,
-    );
   }
 
   /** @throws {ZeltNotImplementedError | ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */

--- a/packages/core/src/features/http/routing/index.ts
+++ b/packages/core/src/features/http/routing/index.ts
@@ -1,5 +1,5 @@
 export { joinPath } from './path-utils.lib';
-export { buildRoutes, collectRoutes, warmupControllers } from './route-builder.lib';
+export { buildRoutes, collectRoutes } from './route-builder.lib';
 export type { ControllerRouteInfo, HttpMethod, RouteInfo } from './routing-metadata.lib';
 export {
   collectControllerRouteInfo,

--- a/packages/core/src/features/http/routing/route-builder.lib.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.ts
@@ -366,15 +366,3 @@ export const buildRoutes = (options: BuildRoutesOptions): void => {
     registerRoute(options.hono, ctx, route, options.globalMiddlewares ?? []);
   }
 };
-
-/** @throws {ZeltReadyFailedError | ZeltLifecycleStateError} */
-export const warmupControllers = async (
-  controllers: readonly ControllerClass[],
-  resolver: ResolverHandle,
-  lifecycle: LifecycleManager,
-): Promise<void> => {
-  for (const cls of controllers) {
-    resolver.get(cls);
-  }
-  await lifecycle.startupPending();
-};

--- a/packages/core/src/features/index.ts
+++ b/packages/core/src/features/index.ts
@@ -2,6 +2,7 @@ export type {
   ConfiguredFeature,
   FeatureCaps,
   FeatureClass,
+  FeatureManagedClass,
   FeatureReadyCapabilities,
   FeatureRuntime,
   NamespacedCaps,

--- a/packages/core/src/features/scheduler/scheduler.feature.test.ts
+++ b/packages/core/src/features/scheduler/scheduler.feature.test.ts
@@ -37,6 +37,7 @@ describe('scheduler feature', () => {
   it('returns a ConfiguredFeature with key "schedulers"', () => {
     const feature = scheduler([TestScheduler]);
     expect(feature.key).toBe('schedulers');
+    expect(feature.featureClasses()).toEqual([TestScheduler]);
     expect(typeof feature.createCapabilities).toBe('function');
   });
 

--- a/packages/core/src/features/scheduler/scheduler.feature.ts
+++ b/packages/core/src/features/scheduler/scheduler.feature.ts
@@ -18,6 +18,10 @@ export class SchedulerFeature extends Feature<'schedulers', SchedulerCapabilitie
     super();
   }
 
+  readonly featureClasses = (): readonly SchedulerClass[] => {
+    return this.schedulers;
+  };
+
   readonly staticCapabilities = (): Record<never, never> => {
     return {};
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export type {
   ConfiguredFeature,
   FeatureCaps,
   FeatureClass,
+  FeatureManagedClass,
   FeatureReadyCapabilities,
   FeatureRuntime,
   HttpCapabilities,

--- a/packages/eventbus/src/eventbus.feature.test.ts
+++ b/packages/eventbus/src/eventbus.feature.test.ts
@@ -72,7 +72,17 @@ describe('eventbus feature', () => {
   it('returns a ConfiguredFeature with key "eventbus"', () => {
     const feature = eventbus({ adaptor: MemoryEventBusAdaptor });
     expect(feature.key).toBe('eventbus');
+    expect(feature.featureClasses()).toEqual([MemoryEventBusAdaptor]);
     expect(typeof feature.createCapabilities).toBe('function');
+  });
+
+  it('returns adaptor and handlers as feature classes', () => {
+    const feature = eventbus({
+      adaptor: MemoryEventBusAdaptor,
+      handlers: [ConfigAwareEventBusHandler],
+    });
+
+    expect(feature.featureClasses()).toEqual([MemoryEventBusAdaptor, ConfigAwareEventBusHandler]);
   });
 
   it('resolves adaptor and handlers after config binding and starts pending lifecycle', async () => {

--- a/packages/eventbus/src/eventbus.feature.ts
+++ b/packages/eventbus/src/eventbus.feature.ts
@@ -28,6 +28,7 @@ export const eventbus = (
   opts: EventBusOptions,
 ): ConfiguredFeature<'eventbus', EventBusCapabilities> => ({
   key: 'eventbus',
+  featureClasses: () => [opts.adaptor, ...(opts.handlers ?? [])],
   staticCapabilities: () => ({}),
   createCapabilities: async (runtime) => {
     for (const handler of opts.handlers ?? []) {


### PR DESCRIPTION
## Summary

- remove the imperative \`Feature.bind()\` hook and keep feature setup on capability creation
- replace \`Feature.warmup()\` with mandatory \`featureClasses()\` declarations
- make \`createRuntime({ warmup: true })\` eagerly resolve declared feature classes in the app layer
- update built-in features, eventbus, adapters, and lifecycle warmup tests for the new contract

## Validation

- \`pnpm run precommit\`
- pre-push hook: \`knip\`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783468132&installation_id=133048706&pr_number=264&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F264&signature=9ec43b0b9c66d460e56b9bbd0461a064c148c71c794ddc9536c354a4614c6f0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * ウォームアップ処理を従来の任意フックから機能クラスの明示的な登録と段階的解決に変更し、起動時の初期化がより確実で予測可能になりました。

* **テスト**
  * 新しいウォームアップ機構の動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->