### PR TITLE
feat(adapter-electron): expose IpcMainInvokeEvent via request context and fix sandbox preload

### DIFF
--- a/packages/adapter-electron/src/ipc-bridge.test.ts
+++ b/packages/adapter-electron/src/ipc-bridge.test.ts
@@ -1,6 +1,7 @@
+import type { IpcMainInvokeEvent } from 'electron';
 import { describe, expect, it } from 'vitest';
-
-import { toIpcResponse, toRequest } from './main/ipc-bridge';
+import { ipcEvent, setupIpcBridge, toIpcResponse, toRequest } from './main/ipc-bridge';
+import type { IpcFetchRequest } from './shared/ipc.types';
 
 describe('toRequest', () => {
   it('converts IpcFetchRequest to Request with correct URL', () => {
@@ -154,5 +155,89 @@ describe('toIpcResponse', () => {
     const ipcResponse = await toIpcResponse(response, 'GET');
 
     expect(ipcResponse.body.kind).toBe('arrayBuffer');
+  });
+});
+
+describe('setupIpcBridge', () => {
+  const createFakeIpcMain = () => {
+    let registeredHandler: (event: IpcMainInvokeEvent, payload: IpcFetchRequest) => unknown = () =>
+      undefined;
+    return {
+      ipcMain: {
+        handle: (
+          _channel: string,
+          listener: (event: IpcMainInvokeEvent, payload: IpcFetchRequest) => unknown,
+        ) => {
+          registeredHandler = listener;
+        },
+        removeHandler: () => {},
+      },
+      invoke: (event: IpcMainInvokeEvent, payload: IpcFetchRequest) =>
+        registeredHandler(event, payload),
+    };
+  };
+
+  it('makes IpcMainInvokeEvent accessible via ipcEvent() during fetch', async () => {
+    const fakeEvent = { sender: { id: 42 } } as unknown as IpcMainInvokeEvent;
+    let capturedEvent: IpcMainInvokeEvent | undefined;
+
+    const fakeFetch = async (_request: Request): Promise<Response> => {
+      capturedEvent = ipcEvent();
+      return new Response('ok');
+    };
+
+    const { ipcMain, invoke } = createFakeIpcMain();
+    setupIpcBridge(ipcMain, fakeFetch, 'http://test');
+
+    await invoke(fakeEvent, {
+      method: 'GET',
+      path: '/api/test',
+      headers: [],
+      body: { kind: 'none' },
+    });
+
+    expect(capturedEvent).toBe(fakeEvent);
+  });
+
+  it('isolates ipcEvent across concurrent requests', async () => {
+    const events: unknown[] = [];
+
+    const fakeFetch = async (_request: Request): Promise<Response> => {
+      await new Promise((r) => setTimeout(r, 5));
+      events.push(ipcEvent());
+      return new Response('ok');
+    };
+
+    const { ipcMain, invoke } = createFakeIpcMain();
+    setupIpcBridge(ipcMain, fakeFetch, 'http://test');
+
+    const payload: IpcFetchRequest = {
+      method: 'GET',
+      path: '/test',
+      headers: [],
+      body: { kind: 'none' },
+    };
+
+    await Promise.all([
+      invoke({ id: 'event-a' } as unknown as IpcMainInvokeEvent, payload),
+      invoke({ id: 'event-b' } as unknown as IpcMainInvokeEvent, payload),
+    ]);
+
+    expect(events).toEqual([{ id: 'event-a' }, { id: 'event-b' }]);
+  });
+
+  it('returns cleanup function that removes handler', () => {
+    let removedChannel: string | undefined;
+    const fakeIpcMain = {
+      handle: () => {},
+      removeHandler: (channel: string) => {
+        removedChannel = channel;
+      },
+    } as unknown as Parameters<typeof setupIpcBridge>[0];
+
+    const cleanup = setupIpcBridge(fakeIpcMain, async () => new Response('ok'), 'http://test');
+    cleanup();
+
+    expect(removedChannel).toBe('http://test');
   });
 });

--- a/packages/adapter-electron/src/main/index.ts
+++ b/packages/adapter-electron/src/main/index.ts
@@ -2,7 +2,7 @@ export { ElectronAdaptor, type ElectronReady } from './electron.adaptor';
 export { ElectronEnvAdaptor } from './electron-env.adaptor';
 export { ElectronWindowRegistryService } from './electron-window-registry.service';
 export { ElectronWindowRuntimeService } from './electron-window-runtime.service';
-export { setupIpcBridge, toIpcResponse, toRequest } from './ipc-bridge';
+export { ipcEvent, setupIpcBridge, toIpcResponse, toRequest } from './ipc-bridge';
 export { type ElectronAppOptions, type OnElectronApp, onElectron } from './on-electron';
 export type {
   WindowDefinition,

--- a/packages/adapter-electron/src/main/ipc-bridge.ts
+++ b/packages/adapter-electron/src/main/ipc-bridge.ts
@@ -1,3 +1,5 @@
+import { getContext, runInContext, setContext } from '@zeltjs/core';
+import type { IpcMainInvokeEvent } from 'electron';
 import { match } from 'ts-pattern';
 
 import type { IpcBody, IpcFetchRequest, IpcFetchResponse } from '../shared/ipc.types';
@@ -60,21 +62,37 @@ export const toIpcResponse = async (
   };
 };
 
+declare module '@zeltjs/core' {
+  interface RequestContextSchema {
+    ipcEvent: IpcMainInvokeEvent;
+  }
+}
+
 type IpcMainLike = {
-  handle(channel: string, listener: (event: unknown, payload: IpcFetchRequest) => unknown): void;
+  handle(
+    channel: string,
+    listener: (event: IpcMainInvokeEvent, payload: IpcFetchRequest) => unknown,
+  ): void;
   removeHandler(channel: string): void;
 };
 
+/** @throws {ZeltContextNotAvailableError} */
+export const ipcEvent = (): IpcMainInvokeEvent | undefined => getContext('ipcEvent');
+
+/** @throws {ZeltContextNotAvailableError} */
 export const setupIpcBridge = (
   ipcMain: IpcMainLike,
   fetch: (request: Request) => Promise<Response>,
   channel: string,
 ): (() => void) => {
-  ipcMain.handle(channel, async (_event: unknown, payload: IpcFetchRequest) => {
-    const request = toRequest(payload, channel);
-    const response = await fetch(request);
-    return toIpcResponse(response, payload.method);
-  });
+  ipcMain.handle(channel, async (event, payload) =>
+    runInContext(async () => {
+      setContext('ipcEvent', event);
+      const request = toRequest(payload, channel);
+      const response = await fetch(request);
+      return toIpcResponse(response, payload.method);
+    }),
+  );
 
   return () => {
     ipcMain.removeHandler(channel);

--- a/packages/adapter-electron/src/main/on-electron.ts
+++ b/packages/adapter-electron/src/main/on-electron.ts
@@ -31,6 +31,7 @@ export type OnElectronApp = {
 
 const DEFAULT_IPC_CHANNEL = 'http://zelt-ipc';
 
+/** @throws {ZeltContextNotAvailableError} */
 export const onElectron = async (
   app: HttpApp,
   options: ElectronAppOptions = {},

--- a/packages/adapter-electron/src/preload/expose-ipc.ts
+++ b/packages/adapter-electron/src/preload/expose-ipc.ts
@@ -1,4 +1,4 @@
-import type { ContextBridge, IpcRenderer } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 
 import type { IpcFetchRequest, IpcFetchResponse } from '../shared/ipc.types';
 
@@ -8,20 +8,8 @@ export type ExposeIpcOptions = {
   readonly channel?: string;
 };
 
-type ElectronPreload = {
-  readonly contextBridge: ContextBridge;
-  readonly ipcRenderer: IpcRenderer;
-};
-
-// In the preload context electron is only available via require (no ESM in preload).
-const loadElectron = (): ElectronPreload => {
-  const mod: ElectronPreload = require('electron');
-  return mod;
-};
-
 export const exposeIpc = (options: ExposeIpcOptions = {}): void => {
   const channel = options.channel ?? DEFAULT_IPC_CHANNEL;
-  const { contextBridge, ipcRenderer } = loadElectron();
 
   const sender = (request: IpcFetchRequest): Promise<IpcFetchResponse> =>
     ipcRenderer.invoke(channel, request);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,7 +157,7 @@ export { Scheduled } from './features/scheduler/schedule/scheduled.decorator';
 export { Weekly } from './features/scheduler/schedule/weekly.decorator';
 export type { SchedulerClass } from './features/scheduler/scheduler.types';
 export type { Lifecycle } from './kernel';
-export { LifecycleManager } from './kernel';
+export { LifecycleManager, runInContext } from './kernel';
 // DI primitives
 // DI
 export { Injectable, inject } from './kernel/di';

--- a/packages/core/src/kernel/internal/context-key.lib.test.ts
+++ b/packages/core/src/kernel/internal/context-key.lib.test.ts
@@ -50,6 +50,33 @@ describe('context-key', () => {
       expect(b).toBe('B');
     });
 
+    it('inherits parent context in nested runInContext', () => {
+      const OUTER = createContextKey<string>('test:outer');
+      const INNER = createContextKey<string>('test:inner');
+      runInContext(() => {
+        setInternal(OUTER, 'from-parent');
+        runInContext(() => {
+          expect(getInternal(OUTER)).toBe('from-parent');
+          setInternal(INNER, 'from-child');
+          expect(getInternal(INNER)).toBe('from-child');
+        });
+        expect(getInternal(OUTER)).toBe('from-parent');
+        expect(getInternal(INNER)).toBeUndefined();
+      });
+    });
+
+    it('does not leak inner setInternal to outer context', () => {
+      const KEY = createContextKey<string>('test:leak');
+      runInContext(() => {
+        setInternal(KEY, 'outer');
+        runInContext(() => {
+          setInternal(KEY, 'inner');
+          expect(getInternal(KEY)).toBe('inner');
+        });
+        expect(getInternal(KEY)).toBe('outer');
+      });
+    });
+
     it('isolates different keys', () => {
       const KEY1 = createContextKey<string>('test:key1');
       const KEY2 = createContextKey<number>('test:key2');

--- a/packages/core/src/kernel/internal/context-key.lib.ts
+++ b/packages/core/src/kernel/internal/context-key.lib.ts
@@ -16,7 +16,10 @@ type ContextStore = Record<symbol, unknown>;
 
 const storage = new AsyncLocalStorage<ContextStore>();
 
-export const runInContext = <T>(fn: () => T): T => storage.run({}, fn);
+export const runInContext = <T>(fn: () => T): T => {
+  const parent = storage.getStore();
+  return storage.run({ ...parent }, fn);
+};
 
 /** @throws {ZeltContextNotAvailableError} */
 export const getInternal = <T>(key: ContextKey<T>): T | undefined => {


### PR DESCRIPTION
## Summary

- `runInContext` を nest 対応にし、親 store を shallow copy で引き継ぐようにした
- `setupIpcBridge` 内で `IpcMainInvokeEvent` を `setContext('ipcEvent', event)` で request context に格納
- `ipcEvent()` getter を export し、controller 内で型安全に `IpcMainInvokeEvent` にアクセス可能に
- `@zeltjs/adapter-electron/preload` の `require('electron')` を ESM import に変更し、sandbox preload で動作するようにした
- `runInContext` を `@zeltjs/core` public API として export

## Test plan

- [x] `runInContext` の nest テスト（親 context 引き継ぎ、内側から外側への非漏洩）
- [x] `setupIpcBridge` で `ipcEvent()` から event を取得できることのテスト
- [x] 並行リクエストでの `ipcEvent` 分離テスト
- [x] cleanup 関数のテスト
- [x] 既存の core テスト全通過（427 tests）
- [x] precommit 全通過（typecheck, lint, build, test, knip）

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783557659&installation_id=133048706&pr_number=265&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F265&signature=d605f512a37decc036f0b843bbbe2aa05e2d2b30d2fc95c3da616d60229f5b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ネストされたコンテキスト実行時に親コンテキストの値が保持されるよう改善し、複数の同時処理が互いに分離される動作を強化
  * IPC通信の堅牢性を向上させ、イベント管理がより安定するように改善

* **新機能**
  * コンテキスト管理機能を公開API として利用可能に

* **テスト**
  * コンテキスト分離と親値継承に関するテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->