### PR TITLE
fix(core): stop scheduler runner on runtime shutdown

### DIFF
--- a/packages/core/src/features/scheduler/scheduler.feature.ts
+++ b/packages/core/src/features/scheduler/scheduler.feature.ts
@@ -28,7 +28,7 @@ export class SchedulerFeature extends Feature<'schedulers', SchedulerCapabilitie
 
   readonly createCapabilities = async (runtime: FeatureRuntime): Promise<SchedulerCapabilities> => {
     const service = await runtime.get(SchedulerService);
-    const runner = service.createRunner(this.schedulers);
+    const runner = await service.createRunner(this.schedulers);
     return {
       startScheduler: async () => {
         if (!runner.isRunning()) await runner.startup();

--- a/packages/core/src/features/scheduler/scheduler.feature.ts
+++ b/packages/core/src/features/scheduler/scheduler.feature.ts
@@ -28,7 +28,7 @@ export class SchedulerFeature extends Feature<'schedulers', SchedulerCapabilitie
 
   readonly createCapabilities = async (runtime: FeatureRuntime): Promise<SchedulerCapabilities> => {
     const service = await runtime.get(SchedulerService);
-    const runner = await service.createRunner(this.schedulers);
+    const runner = service.createRunner(this.schedulers);
     return {
       startScheduler: async () => {
         if (!runner.isRunning()) await runner.startup();

--- a/packages/core/src/features/scheduler/scheduler.module.test.ts
+++ b/packages/core/src/features/scheduler/scheduler.module.test.ts
@@ -101,13 +101,13 @@ describe('createApp with schedulers', () => {
     }
 
     const app = createApp([http({ controllers: [] }), scheduler([TestScheduler])]);
-    const localRuntimeApp = await app.createRuntime();
-    await localRuntimeApp.schedulers.startScheduler();
-    expect(localRuntimeApp.schedulers.isSchedulerRunning()).toBe(true);
+    readyApp = await app.createRuntime();
+    await readyApp.schedulers.startScheduler();
+    expect(readyApp.schedulers.isSchedulerRunning()).toBe(true);
 
-    await localRuntimeApp.shutdown();
+    await readyApp.shutdown();
 
-    expect(localRuntimeApp.schedulers.isSchedulerRunning()).toBe(false);
+    expect(readyApp.schedulers.isSchedulerRunning()).toBe(false);
   });
 
   it('works without schedulers option', async () => {

--- a/packages/core/src/features/scheduler/scheduler.module.test.ts
+++ b/packages/core/src/features/scheduler/scheduler.module.test.ts
@@ -93,6 +93,23 @@ describe('createApp with schedulers', () => {
     expect(taskFn.mock.calls.length).toBe(callCountBefore);
   });
 
+  it('shutdown() stops a running scheduler without explicit stopScheduler()', async () => {
+    @Scheduled()
+    class TestScheduler {
+      @Cron('* * * * * *')
+      everySecond() {}
+    }
+
+    const app = createApp([http({ controllers: [] }), scheduler([TestScheduler])]);
+    const localRuntimeApp = await app.createRuntime();
+    await localRuntimeApp.schedulers.startScheduler();
+    expect(localRuntimeApp.schedulers.isSchedulerRunning()).toBe(true);
+
+    await localRuntimeApp.shutdown();
+
+    expect(localRuntimeApp.schedulers.isSchedulerRunning()).toBe(false);
+  });
+
   it('works without schedulers option', async () => {
     const app = createApp([http({ controllers: [] })]);
     const localRuntimeApp = await app.createRuntime();

--- a/packages/core/src/features/scheduler/scheduler.service.ts
+++ b/packages/core/src/features/scheduler/scheduler.service.ts
@@ -8,27 +8,31 @@ export type { SchedulerRunner } from './scheduler-runner.lib';
 
 @Injectable()
 export class SchedulerService {
+  // Ledger of runners this service must release on shutdown; registering the
+  // lifecycle in the constructor keeps it inside the resolve→startupPending
+  // contract of AppRuntime.get, so no manual startupPending call is needed.
+  private readonly runners: SchedulerRunner[] = [];
+
   constructor(
     private readonly container: Container = inject(Container),
-    private readonly lifecycleManager: LifecycleManager = inject(LifecycleManager),
-  ) {}
+    lifecycleManager: LifecycleManager = inject(LifecycleManager),
+  ) {
+    lifecycleManager.register({
+      startup: (): void => {},
+      shutdown: async (): Promise<void> => {
+        for (const runner of this.runners) {
+          if (runner.isRunning()) await runner.shutdown();
+        }
+      },
+    });
+  }
 
-  /** @throws {ZeltReadyFailedError | ZeltLifecycleStateError} */
-  async createRunner(schedulers: readonly SchedulerClass[]): Promise<SchedulerRunner> {
+  createRunner(schedulers: readonly SchedulerClass[]): SchedulerRunner {
     const resolver = {
       get: <T extends object>(cls: new (...args: never[]) => T): T => resolve(this.container, cls),
     };
     const runner = createSchedulerRunner(schedulers, resolver);
-    this.lifecycleManager.register({
-      startup: (): void => {},
-      shutdown: async (): Promise<void> => {
-        if (runner.isRunning()) await runner.shutdown();
-      },
-    });
-    // Registration happens after LifecycleManager.startup() has already run during
-    // runtime.ready(); without startupPending() the entry stays pending and
-    // LifecycleManager.shutdown() would skip it, leaving cron timers alive.
-    await this.lifecycleManager.startupPending();
+    this.runners.push(runner);
     return runner;
   }
 }

--- a/packages/core/src/features/scheduler/scheduler.service.ts
+++ b/packages/core/src/features/scheduler/scheduler.service.ts
@@ -1,5 +1,5 @@
 import { Container } from '@needle-di/core';
-import { Injectable, inject, resolve } from '../../kernel';
+import { Injectable, inject, LifecycleManager, resolve } from '../../kernel';
 import type { SchedulerClass } from './scheduler.types';
 import type { SchedulerRunner } from './scheduler-runner.lib';
 import { createSchedulerRunner } from './scheduler-runner.lib';
@@ -8,12 +8,27 @@ export type { SchedulerRunner } from './scheduler-runner.lib';
 
 @Injectable()
 export class SchedulerService {
-  constructor(private readonly container: Container = inject(Container)) {}
+  constructor(
+    private readonly container: Container = inject(Container),
+    private readonly lifecycleManager: LifecycleManager = inject(LifecycleManager),
+  ) {}
 
-  createRunner(schedulers: readonly SchedulerClass[]): SchedulerRunner {
+  /** @throws {ZeltReadyFailedError | ZeltLifecycleStateError} */
+  async createRunner(schedulers: readonly SchedulerClass[]): Promise<SchedulerRunner> {
     const resolver = {
       get: <T extends object>(cls: new (...args: never[]) => T): T => resolve(this.container, cls),
     };
-    return createSchedulerRunner(schedulers, resolver);
+    const runner = createSchedulerRunner(schedulers, resolver);
+    this.lifecycleManager.register({
+      startup: (): void => {},
+      shutdown: async (): Promise<void> => {
+        if (runner.isRunning()) await runner.shutdown();
+      },
+    });
+    // Registration happens after LifecycleManager.startup() has already run during
+    // runtime.ready(); without startupPending() the entry stays pending and
+    // LifecycleManager.shutdown() would skip it, leaving cron timers alive.
+    await this.lifecycleManager.startupPending();
+    return runner;
   }
 }


### PR DESCRIPTION
## Summary

The scheduler runner created in `SchedulerFeature.createCapabilities` was never registered with `LifecycleManager`, so `runtime.shutdown()` (and signal-driven graceful shutdown via onNode) left running cron jobs alive. Since croner timers keep the event loop alive, the process would not exit. This is a regression from v0.8.1, where `SchedulerService` registered itself as a `Lifecycle` and stopped the runner on shutdown.

## Changes

- `SchedulerService` now registers an unconditional lifecycle in its constructor: startup is a no-op (schedulers still start only via explicit `startScheduler()`), and shutdown stops any runners created by the service that are still running.
- Registering in the constructor keeps the lifecycle inside the resolve→startupPending contract of `AppRuntime.get`, so the entry is promoted to "started" by the kernel and reached by `LifecycleManager.shutdown()` without any manual bookkeeping.

## Test

- Added regression test: a scheduler started via `startScheduler()` stops on `runtime.shutdown()` without an explicit `stopScheduler()` call (failed before the fix).
- All core tests pass (428), repo-wide `tsc -b` clean, biome clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * スケジューラーのシャットダウン処理を改善しました。

* **Tests**
  * スケジューラー停止動作のテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->