### PR TITLE
fix(adapter-electron): normalize trailing slash in ipc-bridge baseUrl

### DIFF
--- a/packages/adapter-electron/src/ipc-bridge.test.ts
+++ b/packages/adapter-electron/src/ipc-bridge.test.ts
@@ -66,6 +66,20 @@ describe('toRequest', () => {
     expect(request.body).toBeNull();
   });
 
+  it('normalizes trailing slash in baseUrl', () => {
+    const request = toRequest(
+      {
+        method: 'GET',
+        path: '/api/status',
+        headers: [],
+        body: { kind: 'none' },
+      },
+      'http://app/',
+    );
+
+    expect(request.url).toBe('http://app/api/status');
+  });
+
   it('preserves query string in path', () => {
     const request = toRequest(
       {

--- a/packages/adapter-electron/src/main/ipc-bridge.ts
+++ b/packages/adapter-electron/src/main/ipc-bridge.ts
@@ -26,7 +26,7 @@ const toBody = (body: IpcBody): BodyInit | null =>
 
 export const toRequest = (payload: IpcFetchRequest, baseUrl: string): Request => {
   const headers: [string, string][] = payload.headers.map(([k, v]) => [k, v]);
-  return new Request(baseUrl + payload.path, {
+  return new Request(baseUrl.replace(/\/+$/, '') + payload.path, {
     method: payload.method,
     headers,
     body: BODY_FORBIDDEN_METHODS.has(payload.method) ? null : toBody(payload.body),


### PR DESCRIPTION
## Summary

When `ipcChannel` ends with a trailing slash (e.g. `http://app/`), `toRequest` concatenates it directly with `payload.path` (which always starts with `/`), producing a double-slash URL like `http://app//api/status`. This fails to match any registered route.

## Changes

- Strip trailing slashes from `baseUrl` in `toRequest` before concatenation (1 line).
- Added test case for trailing slash normalization.

## Test

- adapter-electron: 26 tests pass, `tsc -b` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783917916&installation_id=133048706&pr_number=267&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F267&signature=8403c55bd4e4cc24639d80f4bddd84c265b5befc5bcdec1fdab8fbe24ba63d0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ベースURLの末尾スラッシュ処理を改善し、URL生成の安定性を向上しました。

* **Tests**
  * ベースURL末尾スラッシュ正規化のテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->