### PR TITLE
refactor(core): rename Feature API for clarity

### DIFF
--- a/integration/hooks/src/app.ts
+++ b/integration/hooks/src/app.ts
@@ -11,8 +11,8 @@ type NoCapabilities = Record<never, never>;
 const warmupProbe = (): ConfiguredFeature<'warmupProbe', NoCapabilities> => ({
   key: 'warmupProbe',
   featureClasses: () => [WarmupSpy],
-  staticCapabilities: () => ({}),
-  createCapabilities: () => ({}),
+  blueprint: () => ({}),
+  realize: () => ({}),
 });
 
 // Factory because each spec needs an isolated app instance for clean lifecycle counting.

--- a/packages/adapter-bun/src/on-bun.test.ts
+++ b/packages/adapter-bun/src/on-bun.test.ts
@@ -60,8 +60,8 @@ class FakeHttpLikeFeature extends Feature<
   readonly key = 'http' as const;
 
   featureClasses = () => [];
-  staticCapabilities = () => ({});
-  createCapabilities = () => ({
+  blueprint = () => ({});
+  realize = () => ({
     fetch: async () => new Response('fake'),
     request: async () => new Response('fake'),
   });

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -54,8 +54,8 @@ class FakeHttpLikeFeature extends Feature<
   readonly key = 'http' as const;
 
   featureClasses = () => [];
-  staticCapabilities = () => ({});
-  createCapabilities = () => ({
+  blueprint = () => ({});
+  realize = () => ({
     fetch: async () => new Response('fake'),
     request: async () => new Response('fake'),
   });

--- a/packages/core/src/app/app-bootstrap.lib.test.ts
+++ b/packages/core/src/app/app-bootstrap.lib.test.ts
@@ -1,12 +1,12 @@
 import { Container } from '@needle-di/core';
 import { describe, expect, it, vi } from 'vitest';
 import { LifecycleManager, ZeltLifecycleStateError } from '../kernel';
-import { AppRuntime } from './app-runtime.lib';
+import { AppBootstrap } from './app-bootstrap.lib';
 
-describe('AppRuntime', () => {
+describe('AppBootstrap', () => {
   it('should call lifecycle startup on ready', async () => {
     const container = new Container();
-    const runtime = container.get(AppRuntime);
+    const runtime = container.get(AppBootstrap);
 
     const result = await runtime.ready();
 
@@ -16,7 +16,7 @@ describe('AppRuntime', () => {
 
   it('should return cached result on second ready call', async () => {
     const container = new Container();
-    const runtime = container.get(AppRuntime);
+    const runtime = container.get(AppBootstrap);
 
     const result1 = await runtime.ready();
     const result2 = await runtime.ready();
@@ -26,7 +26,7 @@ describe('AppRuntime', () => {
 
   it('should throw on ready after disposed', async () => {
     const container = new Container();
-    const runtime = container.get(AppRuntime);
+    const runtime = container.get(AppBootstrap);
 
     await runtime.shutdown();
 
@@ -35,7 +35,7 @@ describe('AppRuntime', () => {
 
   it('should be idempotent on shutdown', async () => {
     const container = new Container();
-    const runtime = container.get(AppRuntime);
+    const runtime = container.get(AppBootstrap);
 
     await runtime.ready();
     await runtime.shutdown();
@@ -46,7 +46,7 @@ describe('AppRuntime', () => {
     const container = new Container();
     const lifecycle = container.get(LifecycleManager);
     const shutdownSpy = vi.spyOn(lifecycle, 'shutdown');
-    const runtime = container.get(AppRuntime);
+    const runtime = container.get(AppBootstrap);
 
     await runtime.ready();
     await runtime.shutdown();

--- a/packages/core/src/app/app-bootstrap.lib.ts
+++ b/packages/core/src/app/app-bootstrap.lib.ts
@@ -8,11 +8,11 @@ export type ReadyResult = {
   readonly get: <T extends object>(cls: new (...args: never[]) => T) => Promise<T>;
 };
 
-type AppRuntimeState = 'idle' | 'starting' | 'ready' | 'disposed';
+type AppBootstrapState = 'idle' | 'starting' | 'ready' | 'disposed';
 
 @injectable()
-export class AppRuntime {
-  private state: AppRuntimeState = 'idle';
+export class AppBootstrap {
+  private state: AppBootstrapState = 'idle';
   private readyPromise: Promise<ReadyResult> | undefined;
   private cachedResult: ReadyResult | undefined;
 

--- a/packages/core/src/app/create-app.lib.test.ts
+++ b/packages/core/src/app/create-app.lib.test.ts
@@ -12,39 +12,39 @@ const createStubFeature = <TKey extends string, TCaps extends object>(
 ): ConfiguredFeature<TKey, TCaps> => ({
   key,
   featureClasses: () => [],
-  staticCapabilities: () => ({}),
-  createCapabilities: () => caps,
+  blueprint: () => ({}),
+  realize: () => caps,
 });
 
 const createEmptyFeature = (key: string): ConfiguredFeature<string, object> => ({
   key,
   featureClasses: () => [],
-  staticCapabilities: () => ({}),
-  createCapabilities: () => ({}),
+  blueprint: () => ({}),
+  realize: () => ({}),
 });
 
 class TypedFeature extends Feature<'typed', { readonly value: () => string }> {
   readonly key = 'typed' as const;
 
   featureClasses = () => [];
-  staticCapabilities = () => ({});
-  createCapabilities = () => ({ value: () => 'ok' });
+  blueprint = () => ({});
+  realize = () => ({ value: () => 'ok' });
 }
 
 class UserFeature extends Feature<'userFeature', { readonly run: () => number }> {
   readonly key = 'userFeature' as const;
 
   featureClasses = () => [];
-  staticCapabilities = () => ({});
-  createCapabilities = () => ({ run: () => 123 });
+  blueprint = () => ({});
+  realize = () => ({ run: () => 123 });
 }
 
 class OtherFeature extends Feature<'otherFeature', { readonly other: () => string }> {
   readonly key = 'otherFeature' as const;
 
   featureClasses = () => [];
-  staticCapabilities = () => ({});
-  createCapabilities = () => ({ other: () => 'no' });
+  blueprint = () => ({});
+  realize = () => ({ other: () => 'no' });
 }
 
 const duplicateStaticCapabilities = vi.fn(() => ({}));
@@ -52,15 +52,15 @@ const duplicateStaticCapabilities = vi.fn(() => ({}));
 class DuplicateA extends Feature<'dup', { readonly a: () => string }> {
   readonly key = 'dup' as const;
   featureClasses = () => [];
-  staticCapabilities = duplicateStaticCapabilities;
-  createCapabilities = () => ({ a: () => 'a' });
+  blueprint = duplicateStaticCapabilities;
+  realize = () => ({ a: () => 'a' });
 }
 
 class DuplicateB extends Feature<'dup', { readonly b: () => string }> {
   readonly key = 'dup' as const;
   featureClasses = () => [];
-  staticCapabilities = () => ({});
-  createCapabilities = () => ({ b: () => 'b' });
+  blueprint = () => ({});
+  realize = () => ({ b: () => 'b' });
 }
 
 const reservedStaticCapabilities = vi.fn(() => ({}));
@@ -68,8 +68,8 @@ const reservedStaticCapabilities = vi.fn(() => ({}));
 class ReservedCreateRuntimeFeature extends Feature<'createRuntime', { readonly run: () => void }> {
   readonly key = 'createRuntime' as const;
   featureClasses = () => [];
-  staticCapabilities = reservedStaticCapabilities;
-  createCapabilities = () => ({ run: () => {} });
+  blueprint = reservedStaticCapabilities;
+  realize = () => ({ run: () => {} });
 }
 
 @Injectable()
@@ -136,8 +136,8 @@ describe('createApp', () => {
       {
         key: 'warmupTarget',
         featureClasses: () => [WarmupTarget],
-        staticCapabilities: () => ({}),
-        createCapabilities: () => ({}),
+        blueprint: () => ({}),
+        realize: () => ({}),
       },
     ]);
 

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -14,8 +14,8 @@ import type {
   ConfiguredFeature,
   FeatureClass,
   FeatureReadyCapabilities,
-  FeatureRuntime,
   NamespacedCaps,
+  ServiceResolver,
   StaticNamespacedCaps,
 } from './feature.types';
 import { attachContainer } from './override.lib';
@@ -83,26 +83,26 @@ const assertUniqueFeatureKeys = (features: readonly ConfiguredFeature[]): void =
   }
 };
 
-const createNamespacedCapabilities = async <const F extends readonly ConfiguredFeature[]>(
-  runtime: FeatureRuntime,
+const realizeNamespacedCapabilities = async <const F extends readonly ConfiguredFeature[]>(
+  resolver: ServiceResolver,
   features: F,
-): Promise<KeyedValues<F, 'createCapabilities'>> => {
-  return unsafeKeyedValues(features, 'createCapabilities', runtime);
+): Promise<KeyedValues<F, 'realize'>> => {
+  return unsafeKeyedValues(features, 'realize', resolver);
 };
 
-const createStaticCapabilities = <const F extends readonly ConfiguredFeature[]>(
+const collectBlueprints = <const F extends readonly ConfiguredFeature[]>(
   features: F,
 ): StaticNamespacedCaps<F> => {
-  return unsafeObjectFromNonEmptyKeyedValuesSync(features, 'staticCapabilities');
+  return unsafeObjectFromNonEmptyKeyedValuesSync(features, 'blueprint');
 };
 
 const warmupFeatureClasses = async (
-  runtime: FeatureRuntime,
+  resolver: ServiceResolver,
   features: readonly ConfiguredFeature[],
 ): Promise<void> => {
   for (const feature of features) {
     for (const cls of feature.featureClasses()) {
-      await runtime.get(cls);
+      await resolver.get(cls);
     }
   }
 };
@@ -135,7 +135,7 @@ export const createApp = <const F extends readonly ConfiguredFeature[]>(
   assertUniqueFeatureKeys(features);
 
   const baseConfigs = options?.configs;
-  const staticCaps = createStaticCapabilities(features);
+  const staticCaps = collectBlueprints(features);
 
   const app = {
     ...staticCaps,
@@ -151,7 +151,7 @@ export const createApp = <const F extends readonly ConfiguredFeature[]>(
 
       const readyResult = await runtime.ready();
 
-      const caps = await createNamespacedCapabilities(readyResult, features);
+      const caps = await realizeNamespacedCapabilities(readyResult, features);
 
       if (runtimeOptions?.warmup) {
         await warmupFeatureClasses(readyResult, features);

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -8,7 +8,7 @@ import {
 
 import type { ConfigClass } from '../built-in-service';
 import { ZeltAppConfigurationError } from '../kernel';
-import { AppRuntime } from './app-runtime.lib';
+import { AppBootstrap } from './app-bootstrap.lib';
 import { ConfigRegistry } from './config-registry.lib';
 import type {
   ConfiguredFeature,
@@ -142,7 +142,7 @@ export const createApp = <const F extends readonly ConfiguredFeature[]>(
     createRuntime: async (runtimeOptions?: CreateRuntimeOptions): Promise<RuntimeApp<F>> => {
       const container = new Container();
 
-      const runtime = container.get(AppRuntime);
+      const runtime = container.get(AppBootstrap);
       const configRegistry = container.get(ConfigRegistry);
 
       registerConfigs(configRegistry, baseConfigs, undefined);

--- a/packages/core/src/app/feature.types.test.ts
+++ b/packages/core/src/app/feature.types.test.ts
@@ -38,7 +38,7 @@ describe('Feature type utilities', () => {
     expectTypeOf<Result>().toEqualTypeOf<{ readonly http: MockHttpStaticCaps }>();
   });
 
-  it('StaticNamespacedCaps omits features without staticCapabilities', () => {
+  it('StaticNamespacedCaps omits features without blueprint', () => {
     type MockSchedulerCaps = { readonly start: () => void };
     type MockSchedulerFeature = ConfiguredFeature<'scheduler', MockSchedulerCaps>;
     type Result = StaticNamespacedCaps<readonly [MockHttpFeature, MockSchedulerFeature]>;

--- a/packages/core/src/app/feature.types.ts
+++ b/packages/core/src/app/feature.types.ts
@@ -4,7 +4,7 @@ import type {
   ObjectFromNonEmptyKeyedValues,
 } from '@zeltjs/unsafe-type-lib';
 
-export type FeatureRuntime = {
+export type ServiceResolver = {
   readonly get: <T extends object>(cls: new (...args: never[]) => T) => Promise<T>;
 };
 
@@ -19,8 +19,8 @@ export abstract class Feature<
 > {
   abstract readonly key: TKey;
   abstract featureClasses(): readonly FeatureManagedClass[];
-  abstract staticCapabilities(): TStaticCaps;
-  abstract createCapabilities(runtime: FeatureRuntime): TReadyCaps | Promise<TReadyCaps>;
+  abstract blueprint(): TStaticCaps;
+  abstract realize(resolver: ServiceResolver): TReadyCaps | Promise<TReadyCaps>;
 }
 
 export type ConfiguredFeature<
@@ -35,7 +35,7 @@ export type FeatureClass<TFeature extends ConfiguredFeature = ConfiguredFeature>
 
 export type FeatureReadyCapabilities<TFeature extends ConfiguredFeature> = KeyedMethodValue<
   TFeature,
-  'createCapabilities'
+  'realize'
 >;
 
 export type FeatureCaps<TFeature extends ConfiguredFeature> = {
@@ -50,8 +50,8 @@ export type FeatureCaps<TFeature extends ConfiguredFeature> = {
 
 export type NamespacedCaps<F extends readonly ConfiguredFeature[]> = ObjectFromKeyedValues<
   F,
-  'createCapabilities'
+  'realize'
 >;
 
 export type StaticNamespacedCaps<F extends readonly ConfiguredFeature[]> =
-  ObjectFromNonEmptyKeyedValues<F, 'staticCapabilities'>;
+  ObjectFromNonEmptyKeyedValues<F, 'blueprint'>;

--- a/packages/core/src/app/index.ts
+++ b/packages/core/src/app/index.ts
@@ -1,5 +1,5 @@
-export type { ReadyResult } from './app-runtime.lib';
-export { AppRuntime } from './app-runtime.lib';
+export type { ReadyResult } from './app-bootstrap.lib';
+export { AppBootstrap } from './app-bootstrap.lib';
 export { ConfigRegistry } from './config-registry.lib';
 export {
   type App,

--- a/packages/core/src/app/index.ts
+++ b/packages/core/src/app/index.ts
@@ -14,8 +14,8 @@ export type {
   FeatureClass,
   FeatureManagedClass,
   FeatureReadyCapabilities,
-  FeatureRuntime,
   NamespacedCaps,
+  ServiceResolver,
   StaticNamespacedCaps,
 } from './feature.types';
 export { Feature } from './feature.types';

--- a/packages/core/src/features/command/command.feature.test.ts
+++ b/packages/core/src/features/command/command.feature.test.ts
@@ -29,22 +29,22 @@ describe('command feature', () => {
 
   it('keeps feature methods callable when destructured', () => {
     const feature = command([GreetCommand]);
-    const { staticCapabilities } = feature;
+    const { blueprint } = feature;
 
-    expect(() => staticCapabilities()).not.toThrow();
+    expect(() => blueprint()).not.toThrow();
   });
 
   it('returns a ConfiguredFeature with key "commands"', () => {
     const feature = command([GreetCommand]);
     expect(feature.key).toBe('commands');
     expect(feature.featureClasses()).toEqual([GreetCommand]);
-    expect(typeof feature.createCapabilities).toBe('function');
+    expect(typeof feature.realize).toBe('function');
   });
 
-  it('createCapabilities returns CommandCapabilities', async () => {
+  it('realize returns CommandCapabilities', async () => {
     const feature = command([GreetCommand]);
     const container = new Container();
-    const caps = await feature.createCapabilities(createRuntime(container));
+    const caps = await feature.realize(createRuntime(container));
     expect(typeof caps.hasCommand).toBe('function');
     expect(typeof caps.getCommands).toBe('function');
     expect(typeof caps.execCommand).toBe('function');
@@ -53,7 +53,7 @@ describe('command feature', () => {
   it('caps.hasCommand detects registered commands', async () => {
     const feature = command([GreetCommand]);
     const container = new Container();
-    const caps = await feature.createCapabilities(createRuntime(container));
+    const caps = await feature.realize(createRuntime(container));
 
     expect(caps.hasCommand('greet')).toBe(true);
     expect(caps.hasCommand('unknown')).toBe(false);
@@ -62,7 +62,7 @@ describe('command feature', () => {
   it('caps.execCommand runs a registered command', async () => {
     const feature = command([GreetCommand]);
     const container = new Container();
-    const caps = await feature.createCapabilities(createRuntime(container));
+    const caps = await feature.realize(createRuntime(container));
 
     const result = await caps.execCommand(['greet']);
     expect(result.exitCode).toBe(0);

--- a/packages/core/src/features/command/command.feature.ts
+++ b/packages/core/src/features/command/command.feature.ts
@@ -1,4 +1,4 @@
-import type { FeatureRuntime } from '../../app';
+import type { ServiceResolver } from '../../app';
 import { Feature } from '../../app';
 import { CommandService } from './command.service';
 import type { CommandClass } from './command.types';
@@ -21,12 +21,12 @@ export class CommandFeature extends Feature<'commands', CommandCapabilities> {
     return this.commands;
   };
 
-  readonly staticCapabilities = (): Record<never, never> => {
+  readonly blueprint = (): Record<never, never> => {
     return {};
   };
 
-  readonly createCapabilities = async (runtime: FeatureRuntime): Promise<CommandCapabilities> => {
-    const service = await runtime.get(CommandService);
+  readonly realize = async (resolver: ServiceResolver): Promise<CommandCapabilities> => {
+    const service = await resolver.get(CommandService);
     const registry = service.buildRegistry(this.commands);
     return {
       hasCommand: (name) => registry.has(name),

--- a/packages/core/src/features/http/http.feature.test.ts
+++ b/packages/core/src/features/http/http.feature.test.ts
@@ -32,9 +32,9 @@ describe('http feature', () => {
 
   it('keeps feature methods callable when destructured', () => {
     const feature = http({ controllers: [TestController] });
-    const { staticCapabilities } = feature;
+    const { blueprint } = feature;
 
-    expect(staticCapabilities().getControllers()).toEqual([TestController]);
+    expect(blueprint().getControllers()).toEqual([TestController]);
   });
 
   it('createApp([http(...)]) exposes http capabilities in types', async () => {
@@ -64,22 +64,22 @@ describe('http feature', () => {
     const feature = http({ controllers: [TestController] });
     expect(feature.key).toBe('http');
     expect(feature.featureClasses()).toEqual([TestController]);
-    expect(typeof feature.createCapabilities).toBe('function');
-    expect(typeof feature.staticCapabilities).toBe('function');
+    expect(typeof feature.realize).toBe('function');
+    expect(typeof feature.blueprint).toBe('function');
   });
 
-  it('staticCapabilities returns getControllers and getMetadata', () => {
+  it('blueprint returns getControllers and getMetadata', () => {
     const feature = http({ controllers: [TestController] });
-    const caps = feature.staticCapabilities();
+    const caps = feature.blueprint();
     expect(typeof caps.getControllers).toBe('function');
     expect(typeof caps.getMetadata).toBe('function');
     expect(caps.getControllers()).toEqual([TestController]);
   });
 
-  it('createCapabilities returns fetch and request', async () => {
+  it('realize returns fetch and request', async () => {
     const feature = http({ controllers: [TestController] });
     const container = new Container();
-    const caps = await feature.createCapabilities(createRuntime(container));
+    const caps = await feature.realize(createRuntime(container));
     expect(typeof caps.fetch).toBe('function');
     expect(typeof caps.request).toBe('function');
   });
@@ -87,7 +87,7 @@ describe('http feature', () => {
   it('caps.request handles HTTP requests', async () => {
     const feature = http({ controllers: [TestController] });
     const container = new Container();
-    const caps = await feature.createCapabilities(createRuntime(container));
+    const caps = await feature.realize(createRuntime(container));
 
     const res = await caps.request('/');
     expect(res.status).toBe(200);

--- a/packages/core/src/features/http/http.feature.ts
+++ b/packages/core/src/features/http/http.feature.ts
@@ -1,4 +1,4 @@
-import type { FeatureRuntime } from '../../app';
+import type { ServiceResolver } from '../../app';
 import { Feature } from '../../app';
 import type { HttpMetadata, HttpOptions } from './http.service';
 import { HttpService } from './http.service';
@@ -36,15 +36,15 @@ export class HttpFeature extends Feature<'http', HttpCapabilities, HttpStaticCap
     return this.controllers;
   };
 
-  readonly staticCapabilities = (): HttpStaticCapabilities => {
+  readonly blueprint = (): HttpStaticCapabilities => {
     return {
       getControllers: () => this.controllers,
       getMetadata: () => this.metadata,
     };
   };
 
-  readonly createCapabilities = async (runtime: FeatureRuntime): Promise<HttpCapabilities> => {
-    const service = await runtime.get(HttpService);
+  readonly realize = async (resolver: ServiceResolver): Promise<HttpCapabilities> => {
+    const service = await resolver.get(HttpService);
     const router = await service.buildRouter(this.opts);
     return {
       fetch: async (req) => router.fetch(req),

--- a/packages/core/src/features/index.ts
+++ b/packages/core/src/features/index.ts
@@ -4,8 +4,8 @@ export type {
   FeatureClass,
   FeatureManagedClass,
   FeatureReadyCapabilities,
-  FeatureRuntime,
   NamespacedCaps,
+  ServiceResolver,
   StaticNamespacedCaps,
 } from '../app';
 export { Feature } from '../app';

--- a/packages/core/src/features/scheduler/scheduler.feature.test.ts
+++ b/packages/core/src/features/scheduler/scheduler.feature.test.ts
@@ -29,22 +29,22 @@ describe('scheduler feature', () => {
 
   it('keeps feature methods callable when destructured', () => {
     const feature = scheduler([TestScheduler]);
-    const { staticCapabilities } = feature;
+    const { blueprint } = feature;
 
-    expect(() => staticCapabilities()).not.toThrow();
+    expect(() => blueprint()).not.toThrow();
   });
 
   it('returns a ConfiguredFeature with key "schedulers"', () => {
     const feature = scheduler([TestScheduler]);
     expect(feature.key).toBe('schedulers');
     expect(feature.featureClasses()).toEqual([TestScheduler]);
-    expect(typeof feature.createCapabilities).toBe('function');
+    expect(typeof feature.realize).toBe('function');
   });
 
-  it('createCapabilities returns SchedulerCapabilities', async () => {
+  it('realize returns SchedulerCapabilities', async () => {
     const feature = scheduler([TestScheduler]);
     const container = new Container();
-    const caps = await feature.createCapabilities(createRuntime(container));
+    const caps = await feature.realize(createRuntime(container));
 
     expect(typeof caps.startScheduler).toBe('function');
     expect(typeof caps.stopScheduler).toBe('function');
@@ -55,7 +55,7 @@ describe('scheduler feature', () => {
   it('scheduler is not running by default', async () => {
     const feature = scheduler([TestScheduler]);
     const container = new Container();
-    const caps = await feature.createCapabilities(createRuntime(container));
+    const caps = await feature.realize(createRuntime(container));
 
     expect(caps.isSchedulerRunning()).toBe(false);
   });

--- a/packages/core/src/features/scheduler/scheduler.feature.ts
+++ b/packages/core/src/features/scheduler/scheduler.feature.ts
@@ -1,4 +1,4 @@
-import type { FeatureRuntime } from '../../app';
+import type { ServiceResolver } from '../../app';
 import { Feature } from '../../app';
 import { SchedulerService } from './scheduler.service';
 import type { SchedulerClass } from './scheduler.types';
@@ -22,12 +22,12 @@ export class SchedulerFeature extends Feature<'schedulers', SchedulerCapabilitie
     return this.schedulers;
   };
 
-  readonly staticCapabilities = (): Record<never, never> => {
+  readonly blueprint = (): Record<never, never> => {
     return {};
   };
 
-  readonly createCapabilities = async (runtime: FeatureRuntime): Promise<SchedulerCapabilities> => {
-    const service = await runtime.get(SchedulerService);
+  readonly realize = async (resolver: ServiceResolver): Promise<SchedulerCapabilities> => {
+    const service = await resolver.get(SchedulerService);
     const runner = service.createRunner(this.schedulers);
     return {
       startScheduler: async () => {

--- a/packages/core/src/features/scheduler/scheduler.service.ts
+++ b/packages/core/src/features/scheduler/scheduler.service.ts
@@ -10,7 +10,7 @@ export type { SchedulerRunner } from './scheduler-runner.lib';
 export class SchedulerService {
   // Ledger of runners this service must release on shutdown; registering the
   // lifecycle in the constructor keeps it inside the resolve→startupPending
-  // contract of AppRuntime.get, so no manual startupPending call is needed.
+  // contract of AppBootstrap.get, so no manual startupPending call is needed.
   private readonly runners: SchedulerRunner[] = [];
 
   constructor(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,11 +39,11 @@ export type {
   FeatureClass,
   FeatureManagedClass,
   FeatureReadyCapabilities,
-  FeatureRuntime,
   HttpCapabilities,
   HttpStaticCapabilities,
   NamespacedCaps,
   SchedulerCapabilities,
+  ServiceResolver,
   StaticNamespacedCaps,
 } from './features';
 // Feature factories

--- a/packages/eventbus/src/eventbus.feature.test.ts
+++ b/packages/eventbus/src/eventbus.feature.test.ts
@@ -73,7 +73,7 @@ describe('eventbus feature', () => {
     const feature = eventbus({ adaptor: MemoryEventBusAdaptor });
     expect(feature.key).toBe('eventbus');
     expect(feature.featureClasses()).toEqual([MemoryEventBusAdaptor]);
-    expect(typeof feature.createCapabilities).toBe('function');
+    expect(typeof feature.realize).toBe('function');
   });
 
   it('returns adaptor and handlers as feature classes', () => {

--- a/packages/eventbus/src/eventbus.feature.ts
+++ b/packages/eventbus/src/eventbus.feature.ts
@@ -29,13 +29,13 @@ export const eventbus = (
 ): ConfiguredFeature<'eventbus', EventBusCapabilities> => ({
   key: 'eventbus',
   featureClasses: () => [opts.adaptor, ...(opts.handlers ?? [])],
-  staticCapabilities: () => ({}),
-  createCapabilities: async (runtime) => {
+  blueprint: () => ({}),
+  realize: async (resolver) => {
     for (const handler of opts.handlers ?? []) {
-      await runtime.get(handler);
+      await resolver.get(handler);
     }
 
-    const adaptor = await runtime.get(opts.adaptor);
+    const adaptor = await resolver.get(opts.adaptor);
     return {
       emit: (event, data) => adaptor.emit(event, data),
       on: (event, handler) => adaptor.on(event, handler),


### PR DESCRIPTION
## Summary

- `staticCapabilities()` → `blueprint()` — 静的な設計情報を返すメソッド名を、概念に即した名前に変更
- `createCapabilities(runtime)` → `realize(resolver)` — DI起動後の能力構築メソッドを、blueprintとの対関係が明確な名前に変更
- `FeatureRuntime` → `ServiceResolver` — 実態（`{ get }` のみ）に即した型名に変更

## Motivation

Feature の核心的なAPIメソッド名が、実際の概念と乖離していた:
- `staticCapabilities` は「能力」というより「設計情報の公開」
- `createCapabilities` は何かをnewする印象だが、実際はサービス解決+APIバインド
- `FeatureRuntime` は `{ get }` しかないのに大きすぎる名前で、`AppRuntime` / `RuntimeApp` と3つ被り

`blueprint` / `realize` の対は「設計図を描いて、それを実現する」というzeltのFeatureライフサイクルを直接表現する。

## Test plan

- [x] `pnpm run precommit` 全パス（typecheck, lint, build, test）
- [x] core: 70 test files, 428 tests passed
- [x] eventbus: 3 tests passed
- [x] adapter-node: 26 tests passed
- [x] adapter-bun: 4 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783918552&installation_id=133048706&pr_number=268&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F268&signature=9105b17192e6bc801b312e116a31deef6deaa99b971fdba6c6dff775c5bc29e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->