### PR TITLE
fix(docs): remove hardcoded version numbers from install commands

### DIFF
--- a/website/docs/getting-started/bun.mdx
+++ b/website/docs/getting-started/bun.mdx
@@ -14,7 +14,7 @@ This guide walks you through building a Zelt application on Bun from scratch.
 ## Installation
 
 ```bash
-bun add @zeltjs/core@0.8.1 @zeltjs/adapter-bun@0.8.1
+bun add @zeltjs/core @zeltjs/adapter-bun
 ```
 
 <FolderStructure />

--- a/website/docs/getting-started/cloudflare-workers.mdx
+++ b/website/docs/getting-started/cloudflare-workers.mdx
@@ -18,7 +18,7 @@ Additional requirements for Cloudflare Workers:
 ## Installation
 
 ```bash
-pnpm add @zeltjs/core@0.8.1 @zeltjs/adapter-cloudflare-workers@0.8.1
+pnpm add @zeltjs/core @zeltjs/adapter-cloudflare-workers
 pnpm add -D wrangler @cloudflare/workers-types
 ```
 

--- a/website/docs/getting-started/electron.mdx
+++ b/website/docs/getting-started/electron.mdx
@@ -17,7 +17,7 @@ Additional requirements for Electron:
 ## Installation
 
 ```bash
-pnpm add @zeltjs/core@0.8.1 @zeltjs/adapter-electron@0.8.1
+pnpm add @zeltjs/core @zeltjs/adapter-electron
 pnpm add -D electron
 ```
 

--- a/website/docs/getting-started/lambda.mdx
+++ b/website/docs/getting-started/lambda.mdx
@@ -18,7 +18,7 @@ Additional requirements for AWS Lambda:
 ## Installation
 
 ```bash
-pnpm add @zeltjs/core@0.8.1 @zeltjs/adapter-lambda@0.8.1
+pnpm add @zeltjs/core @zeltjs/adapter-lambda
 pnpm add -D @types/aws-lambda esbuild
 ```
 

--- a/website/docs/getting-started/node.mdx
+++ b/website/docs/getting-started/node.mdx
@@ -14,7 +14,7 @@ This guide walks you through building a Zelt application on Node.js from scratch
 ## Installation
 
 ```bash
-pnpm add @zeltjs/core@0.8.1 @zeltjs/adapter-node@0.8.1
+pnpm add @zeltjs/core @zeltjs/adapter-node
 ```
 
 <FolderStructure />

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -21,11 +21,11 @@ To achieve this, we build with these five policies:
 ## Installation
 
 ```bash
-pnpm add @zeltjs/core@0.8.1 @zeltjs/adapter-node@0.8.1
+pnpm add @zeltjs/core @zeltjs/adapter-node
 ```
 
 :::note
-This documentation covers **v0.8.x**. Zelt is in **pre-alpha** — APIs may change between minor versions.
+Zelt is in **pre-alpha** — APIs may change between minor versions.
 :::
 
 ## Quick Example


### PR DESCRIPTION
## Summary

- Remove hardcoded `@0.8.1` version pins from install commands across 6 getting-started docs
- Remove version-specific note ("This documentation covers **v0.8.x**") from index.md — the pre-alpha warning is kept

Package managers resolve to `latest` by default, so version-pinned examples go stale on every release (e.g. latest is v0.9.0 but docs still said `@0.8.1`).

## Test plan

- [ ] Verify docs site builds without errors
- [ ] Confirm install commands no longer contain version suffixes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783924422&installation_id=133048706&pr_number=269&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F269&signature=ac2582e3cc45b09ab8dc2335ba1cf2453166d5adc84d1fce5161abe6402b94ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Getting Started ガイドにおいて、パッケージのインストール手順を更新しました。複数のプラットフォーム（Bun、Cloudflare Workers、Electron、Lambda、Node）にて、常に最新バージョンのパッケージを取得するよう指示を変更しました。また、ドキュメント内の版固有の注記を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->