### PR TITLE
Refactor HTTP module base for GraphQL mounting

### DIFF
--- a/packages/core/src/features/http/app.test.ts
+++ b/packages/core/src/features/http/app.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { createApp } from '../../app';
 import { Config } from '../../built-in-service';
 import type { Lifecycle } from '../../kernel';
-import { inject, LifecycleManager } from '../../kernel';
+import { inject, LifecycleManager, runInContext } from '../../kernel';
 import { ErrorHandler } from './error/error-handler.decorator';
 import { http } from './http.feature';
 import { Middleware } from './middleware/middleware.decorator';
@@ -68,6 +68,30 @@ describe('createApp() — fetch', () => {
     const res = await readyApp.http.fetch(new Request('https://example.com/hello/zelt'));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ message: 'hello, zelt' });
+  });
+
+  it('isolates request context when called inside an existing Zelt context', async () => {
+    const readyApp = await buildApp();
+
+    const results = await runInContext(async () => {
+      const res1 = await readyApp.http.fetch(
+        new Request('https://example.com/echo/', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ seq: 1 }),
+        }),
+      );
+      const res2 = await readyApp.http.fetch(
+        new Request('https://example.com/echo/', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ seq: 2 }),
+        }),
+      );
+      return [await res1.json(), await res2.json()];
+    });
+
+    expect(results).toEqual([{ seq: 1 }, { seq: 2 }]);
   });
 
   it('parses JSON body', async () => {
@@ -202,6 +226,59 @@ describe('middleware', () => {
 
     await readyApp.http.request('/test/');
     expect(executed).toContain('global');
+  });
+
+  it('lets global middlewares read the request body before the handler', async () => {
+    const seen: unknown[] = [];
+    const captureBodyMiddleware: MiddlewareHandler = async (_c, next) => {
+      seen.push(body('json'));
+      await next();
+    };
+
+    const app = createApp([
+      http({ controllers: [EchoController], middlewares: [captureBodyMiddleware] }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    const res = await readyApp.http.fetch(
+      new Request('https://example.com/echo/', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ msg: 'from-middleware' }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ msg: 'from-middleware' });
+    expect(seen).toEqual([{ msg: 'from-middleware' }]);
+  });
+
+  it('lets parent middlewares read the body for nested child routes', async () => {
+    const seen: unknown[] = [];
+    const captureBodyMiddleware: MiddlewareHandler = async (_c, next) => {
+      seen.push(body('json'));
+      await next();
+    };
+
+    const app = createApp([
+      http({
+        middlewares: [captureBodyMiddleware],
+        children: [http({ path: '/v1', controllers: [EchoController] })],
+      }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    const res = await readyApp.http.fetch(
+      new Request('https://example.com/v1/echo/', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ msg: 'nested' }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ msg: 'nested' });
+    expect(seen).toEqual([{ msg: 'nested' }]);
   });
 
   it('executes middlewares in order: global -> controller -> method', async () => {
@@ -717,10 +794,10 @@ describe('nested children', () => {
       http({
         controllers: [],
         children: [
-          {
+          http({
             path: '/api',
             controllers: [UserController],
-          },
+          }),
         ],
       }),
     ]);
@@ -756,11 +833,11 @@ describe('nested children', () => {
         controllers: [],
         middlewares: [parentMiddleware],
         children: [
-          {
+          http({
             path: '/api',
             controllers: [ChildController],
             middlewares: [childMiddleware],
-          },
+          }),
         ],
       }),
     ]);
@@ -790,11 +867,11 @@ describe('nested children', () => {
       http({
         controllers: [],
         children: [
-          {
+          http({
             path: '/api',
             controllers: [ChildController],
             errorHandlers: [ChildErrorHandler],
-          },
+          }),
         ],
       }),
     ]);
@@ -826,10 +903,10 @@ describe('nested children', () => {
         controllers: [],
         errorHandlers: [ParentErrorHandler],
         children: [
-          {
+          http({
             path: '/api',
             controllers: [ChildController],
-          },
+          }),
         ],
       }),
     ]);
@@ -884,11 +961,11 @@ describe('nested children', () => {
         controllers: [],
         errorHandlers: [ParentHandler],
         children: [
-          {
+          http({
             path: '/api',
             controllers: [BubbleController],
             errorHandlers: [ChildHandler],
-          },
+          }),
         ],
       }),
     ]);
@@ -919,15 +996,15 @@ describe('nested children', () => {
       http({
         controllers: [],
         children: [
-          {
+          http({
             path: '/api',
             children: [
-              {
+              http({
                 path: '/v1',
                 controllers: [ItemController],
-              },
+              }),
             ],
-          },
+          }),
         ],
       }),
     ]);
@@ -959,10 +1036,10 @@ describe('nested children', () => {
       http({
         controllers: [ControllerA],
         children: [
-          {
+          http({
             path: '/child',
             controllers: [ControllerB],
-          },
+          }),
         ],
       }),
     ]);
@@ -986,10 +1063,10 @@ describe('nested children', () => {
       http({
         controllers: [],
         children: [
-          {
+          http({
             path: '/api',
             controllers: [MetaController],
-          },
+          }),
         ],
       }),
     ]);

--- a/packages/core/src/features/http/http-bootstrap.lib.test.ts
+++ b/packages/core/src/features/http/http-bootstrap.lib.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { runInContext } from '../../kernel';
+import { createRequestRootChecker } from './http-bootstrap.lib';
+
+describe('createRequestRootChecker', () => {
+  it('treats an existing non-request context without a store creator as request root', () => {
+    const isRoot = createRequestRootChecker(Symbol('router'));
+
+    runInContext(() => {
+      expect(isRoot()).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/features/http/http-bootstrap.lib.ts
+++ b/packages/core/src/features/http/http-bootstrap.lib.ts
@@ -1,0 +1,39 @@
+import type { LifecycleManager } from '../../kernel';
+import { createContextKey, getInternal, hasContext, runInContext, setInternal } from '../../kernel';
+import type { FunctionMiddleware } from './middleware/middleware.types';
+
+// Identifies which router's bootstrap created the request context store.
+// The creator is the request root: the only error-handling level that must
+// not rethrow, since no parent router exists above it.
+const STORE_CREATOR = createContextKey<symbol>('zelt:request-store-creator');
+
+// The request context store must exist before any middleware runs (setUser
+// etc. write into it). Only the outermost router actually creates the store;
+// nested routers see an existing store and stay transparent.
+/** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError | ZeltReadyFailedError} */
+export const createBootstrapMiddleware = (
+  lifecycle: LifecycleManager,
+  routerToken: symbol,
+): FunctionMiddleware => {
+  return async (_c, next) => {
+    // A Zelt context may exist (e.g. event handler, test harness) without
+    // being a request-scoped store. Only skip when STORE_CREATOR is set,
+    // meaning a parent HTTP router already bootstrapped the request.
+    if (hasContext() && getInternal(STORE_CREATOR) !== undefined) {
+      await next();
+      return;
+    }
+    await lifecycle.startupPending();
+    await runInContext(async () => {
+      setInternal(STORE_CREATOR, routerToken);
+      await next();
+    });
+  };
+};
+
+// Errors raised before the store exists can only belong to the request
+// root: every nested router runs inside its parent's store.
+/** @throws {ZeltContextNotAvailableError} */
+export const createRequestRootChecker = (routerToken: symbol): (() => boolean) => {
+  return () => !hasContext() || getInternal(STORE_CREATOR) === routerToken;
+};

--- a/packages/core/src/features/http/http-bootstrap.lib.ts
+++ b/packages/core/src/features/http/http-bootstrap.lib.ts
@@ -35,5 +35,9 @@ export const createBootstrapMiddleware = (
 // root: every nested router runs inside its parent's store.
 /** @throws {ZeltContextNotAvailableError} */
 export const createRequestRootChecker = (routerToken: symbol): (() => boolean) => {
-  return () => !hasContext() || getInternal(STORE_CREATOR) === routerToken;
+  return () => {
+    if (!hasContext()) return true;
+    const storeCreator = getInternal(STORE_CREATOR);
+    return storeCreator === undefined || storeCreator === routerToken;
+  };
 };

--- a/packages/core/src/features/http/http-children.lib.ts
+++ b/packages/core/src/features/http/http-children.lib.ts
@@ -1,44 +1,32 @@
-import type { ControllerClass, HttpChildOptions, HttpOptions } from './http.types';
+import type { ControllerClass, HttpMetadata } from './http.types';
 import type { ControllerRouteInfo } from './routing';
 import { collectControllerRouteInfo, joinPath } from './routing';
 
-export const collectAllControllers = (options: HttpOptions): readonly ControllerClass[] => {
-  const result: ControllerClass[] = [...options.controllers];
-  const collectFromChildren = (children: readonly HttpChildOptions[]): void => {
-    for (const child of children) {
-      result.push(...(child.controllers ?? []));
-      collectFromChildren(child.children ?? []);
-    }
+export const prefixControllerMetadata = (
+  info: ControllerRouteInfo,
+  prefix: string,
+): ControllerRouteInfo => {
+  if (prefix === '/' || prefix === '') return info;
+  return {
+    ...info,
+    basePath: joinPath(prefix, info.basePath),
+    routes: info.routes.map((route) => ({
+      ...route,
+      fullPath: joinPath(prefix, route.fullPath),
+    })),
   };
-  collectFromChildren(options.children ?? []);
-  return result;
 };
 
-export const collectAllControllerMetadata = (
-  options: HttpOptions,
-  prefix = '',
-): readonly ControllerRouteInfo[] => {
-  const result: ControllerRouteInfo[] = options.controllers.map((cls) => {
-    const info = collectControllerRouteInfo(cls);
-    if (!prefix) return info;
-    return {
-      ...info,
-      basePath: joinPath(prefix, info.basePath),
-      routes: info.routes.map((r) => ({
-        ...r,
-        fullPath: joinPath(prefix, r.fullPath),
-      })),
-    };
-  });
+export const prefixHttpMetadata = (metadata: HttpMetadata, prefix: string): HttpMetadata => ({
+  controllers: metadata.controllers.map((controller) =>
+    prefixControllerMetadata(controller, prefix),
+  ),
+});
 
-  for (const child of options.children ?? []) {
-    const childPrefix = joinPath(prefix, child.path);
-    const childAsOptions: HttpOptions = {
-      controllers: child.controllers ?? [],
-      ...(child.children ? { children: child.children } : {}),
-    };
-    result.push(...collectAllControllerMetadata(childAsOptions, childPrefix));
-  }
-
-  return result;
-};
+export const collectOwnControllerMetadata = (
+  controllers: readonly ControllerClass[],
+  prefix: string,
+): readonly ControllerRouteInfo[] =>
+  controllers.map((controller) =>
+    prefixControllerMetadata(collectControllerRouteInfo(controller), prefix),
+  );

--- a/packages/core/src/features/http/http-error-handlers.lib.ts
+++ b/packages/core/src/features/http/http-error-handlers.lib.ts
@@ -7,13 +7,24 @@ import type {
   RequestContext,
 } from './middleware/middleware.types';
 
-export const createErrorHandler =
-  (errorHandlers: readonly ErrorHandlerInstance[], fallback: ErrorHandlerInstance) =>
+// Bubbling falls out of Hono's composition: a rethrown error crosses into
+// the parent router's compose layer and reaches the parent's onError. Only
+// the request root (the router that created the context store) may not
+// rethrow, so it owns the default fallback.
+/** @throws {Error} */
+export const createRouterErrorHandler =
+  (
+    errorHandlers: readonly ErrorHandlerInstance[],
+    fallback: ErrorHandlerInstance,
+    isRequestRoot: () => boolean,
+  ) =>
+  /** @throws {Error} */
   async (err: Error, c: RequestContext): Promise<Response> => {
     for (const handler of errorHandlers) {
       const result = await handler.onError(err, c);
       if (result) return result;
     }
+    if (!isRequestRoot() && err instanceof Error) throw err;
     const fallbackResult = await fallback.onError(err, c);
     return (
       fallbackResult ??

--- a/packages/core/src/features/http/http.feature.test.ts
+++ b/packages/core/src/features/http/http.feature.test.ts
@@ -76,6 +76,32 @@ describe('http feature', () => {
     expect(caps.getControllers()).toEqual([TestController]);
   });
 
+  it('composes static controller metadata from nested http modules', () => {
+    @Controller('/')
+    class ApiController {
+      @Get('/health')
+      health(): Response {
+        return Response.json({ ok: true });
+      }
+    }
+
+    const app = createApp([
+      http({
+        path: '/api',
+        children: [
+          http({
+            path: '/v1',
+            controllers: [ApiController],
+          }),
+        ],
+      }),
+    ]);
+
+    expect(
+      app.http.getMetadata().controllers.map((controller) => controller.routes[0]?.fullPath),
+    ).toEqual(['/api/v1/health']);
+  });
+
   it('realize returns fetch and request', async () => {
     const feature = http({ controllers: [TestController] });
     const container = new Container();
@@ -92,5 +118,33 @@ describe('http feature', () => {
     const res = await caps.request('/');
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('mounts nested http feature modules through the same lifecycle', async () => {
+    @Controller('/')
+    class ApiController {
+      @Get('/health')
+      health(): Response {
+        return Response.json({ ok: true });
+      }
+    }
+
+    const app = createApp([
+      http({
+        path: '/api',
+        children: [
+          http({
+            path: '/v1',
+            controllers: [ApiController],
+          }),
+        ],
+      }),
+    ]);
+
+    const runtime = await app.createRuntime();
+    const response = await runtime.http.request('/api/v1/health');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
   });
 });

--- a/packages/core/src/features/http/http.feature.ts
+++ b/packages/core/src/features/http/http.feature.ts
@@ -1,52 +1,87 @@
 import type { ServiceResolver } from '../../app';
 import { Feature } from '../../app';
-import type { HttpMetadata, HttpOptions } from './http.service';
 import { HttpService } from './http.service';
-import type { ControllerClass } from './http.types';
-import { collectAllControllerMetadata, collectAllControllers } from './http-children.lib';
+import type {
+  ControllerClass,
+  HttpCapabilities,
+  HttpMetadata,
+  HttpModuleOptions,
+  HttpMountableCapabilities,
+  HttpMountableFeatureModule,
+  HttpStaticCapabilities,
+} from './http.types';
+import { collectOwnControllerMetadata, prefixHttpMetadata } from './http-children.lib';
 import { collectRoutes } from './routing';
 
 export const HTTP_FEATURE_KEY = 'http' as const;
 
-export type HttpStaticCapabilities = {
-  readonly getControllers: () => readonly ControllerClass[];
-  readonly getMetadata: () => HttpMetadata;
-};
-
-export type HttpCapabilities = {
-  readonly fetch: (request: Request) => Promise<Response>;
-  readonly request: (input: string | Request, init?: RequestInit) => Promise<Response>;
-};
-
 /** @throws {ZeltDecoratorUsageError | ZeltReadyFailedError | ZeltLifecycleStateError} */
-export class HttpFeature extends Feature<'http', HttpCapabilities, HttpStaticCapabilities> {
+export class HttpFeature
+  extends Feature<'http', HttpMountableCapabilities, HttpStaticCapabilities>
+  implements HttpMountableFeatureModule
+{
   readonly key = HTTP_FEATURE_KEY;
+  readonly path: string;
   private readonly controllers: readonly ControllerClass[];
-  private readonly metadata: HttpMetadata;
+  private readonly children: readonly HttpMountableFeatureModule[];
 
   /** @throws {ZeltDecoratorUsageError} */
-  constructor(private readonly opts: HttpOptions) {
+  constructor(private readonly opts: HttpModuleOptions) {
     super();
-    this.controllers = collectAllControllers(opts);
-    collectRoutes(this.controllers);
-    this.metadata = { controllers: collectAllControllerMetadata(opts) };
+    this.path = opts.path ?? '/';
+    this.controllers = opts.controllers ?? [];
+    this.children = opts.children ?? [];
+    collectRoutes(this.collectControllers());
   }
 
   readonly featureClasses = (): readonly ControllerClass[] => {
-    return this.controllers;
+    return [...this.controllers, ...this.children.flatMap((child) => child.featureClasses())];
   };
 
   readonly blueprint = (): HttpStaticCapabilities => {
+    const controllers = this.collectControllers();
+    const metadata = this.collectMetadata();
     return {
-      getControllers: () => this.controllers,
-      getMetadata: () => this.metadata,
+      getControllers: () => controllers,
+      getMetadata: () => metadata,
     };
   };
 
-  readonly realize = async (resolver: ServiceResolver): Promise<HttpCapabilities> => {
+  readonly realize = async (resolver: ServiceResolver): Promise<HttpMountableCapabilities> => {
     const service = await resolver.get(HttpService);
-    const router = await service.buildRouter(this.opts);
+    const local = await service.createLocalRouter(this.opts);
+
+    for (const child of this.children) {
+      const childCaps = await child.realize(resolver);
+      local.route('/', childCaps.router);
+    }
+
+    if (this.path === '/') return this.toCapabilities(local);
+
+    const rootRouter = await service.createLocalRouter({ controllers: [] });
+    rootRouter.route(this.path, local);
+    return this.toCapabilities(rootRouter);
+  };
+
+  private collectMetadata(): HttpMetadata {
+    const ownControllers = collectOwnControllerMetadata(this.controllers, this.path);
+    const childControllers = this.children.flatMap((child) => {
+      const metadata = child.blueprint().getMetadata();
+      return prefixHttpMetadata(metadata, this.path).controllers;
+    });
+    return { controllers: [...ownControllers, ...childControllers] };
+  }
+
+  private collectControllers(): readonly ControllerClass[] {
+    return [
+      ...this.controllers,
+      ...this.children.flatMap((child) => child.blueprint().getControllers()),
+    ];
+  }
+
+  private toCapabilities(router: HttpMountableCapabilities['router']): HttpMountableCapabilities {
     return {
+      router,
       fetch: async (req) => router.fetch(req),
       request: async (input, init) => {
         const req =
@@ -54,7 +89,13 @@ export class HttpFeature extends Feature<'http', HttpCapabilities, HttpStaticCap
         return router.fetch(req);
       },
     };
-  };
+  }
 }
 
-export const http = (opts: HttpOptions): HttpFeature => new HttpFeature(opts);
+export const http = (opts: HttpModuleOptions): HttpFeature => new HttpFeature(opts);
+export type {
+  HttpCapabilities,
+  HttpMountableCapabilities,
+  HttpMountableFeatureModule,
+  HttpStaticCapabilities,
+};

--- a/packages/core/src/features/http/http.feature.ts
+++ b/packages/core/src/features/http/http.feature.ts
@@ -53,13 +53,13 @@ export class HttpFeature
 
     for (const child of this.children) {
       const childCaps = await child.realize(resolver);
-      local.route('/', childCaps.router);
+      Reflect.apply(local.route, local, ['/', childCaps.router]);
     }
 
     if (this.path === '/') return this.toCapabilities(local);
 
     const rootRouter = await service.createLocalRouter({ controllers: [] });
-    rootRouter.route(this.path, local);
+    Reflect.apply(rootRouter.route, rootRouter, [this.path, local]);
     return this.toCapabilities(rootRouter);
   };
 

--- a/packages/core/src/features/http/http.service.ts
+++ b/packages/core/src/features/http/http.service.ts
@@ -2,23 +2,26 @@ import { Container } from '@needle-di/core';
 import type { Hono } from 'hono';
 import { Injectable, inject, LifecycleManager, resolve } from '../../kernel';
 import { DefaultErrorHandler } from './error/default.error-handler';
-import type { ControllerClass, HttpChildOptions, HttpOptions } from './http.types';
-import { createErrorHandler, resolveErrorHandlers } from './http-error-handlers.lib';
+import type { HttpOptions } from './http.types';
+import { createBootstrapMiddleware, createRequestRootChecker } from './http-bootstrap.lib';
+import { createRouterErrorHandler, resolveErrorHandlers } from './http-error-handlers.lib';
+import {
+  guardMiddleware,
+  middlewareIdentity,
+  oncePerRequest,
+  resolveMiddleware,
+} from './middleware';
 import { CorsMiddleware } from './middleware/cors/cors.middleware';
 import type {
-  ErrorHandlerClass,
+  FunctionMiddleware,
   MiddlewareInput,
   RequestContext,
 } from './middleware/middleware.types';
 import { SecureHeadersMiddleware } from './middleware/secure-headers/secure-headers.middleware';
-import type { ControllerRouteInfo } from './routing';
+import { createRequestInjectionMiddleware } from './request-injection.lib';
 import { buildRoutes } from './routing';
 
-export type { HttpChildOptions, HttpOptions } from './http.types';
-
-export type HttpMetadata = {
-  readonly controllers: readonly ControllerRouteInfo[];
-};
+export type { HttpChildOptions, HttpMetadata, HttpModuleOptions, HttpOptions } from './http.types';
 
 export type HttpRouter = Hono;
 
@@ -40,6 +43,7 @@ type _HonoInstanceCheck = HonoInstance extends {
   readonly put: (path: string, handler: RouteHandler) => unknown;
   readonly patch: (path: string, handler: RouteHandler) => unknown;
   readonly delete: (path: string, handler: RouteHandler) => unknown;
+  readonly use: (handler: FunctionMiddleware) => unknown;
   readonly onError: (handler: (err: Error, c: RequestContext) => Promise<Response>) => unknown;
   readonly route: (path: string, app: Hono) => unknown;
   readonly fetch: (request: Request) => Response | Promise<Response>;
@@ -55,15 +59,17 @@ export class HttpService {
   ) {}
 
   /** @throws {Error} */
-  async buildRouter(options: HttpOptions): Promise<HttpRouter> {
+  async createLocalRouter(options: HttpOptions): Promise<HttpRouter> {
     try {
       return await this.initializeHono(options);
     } catch (cause) {
-      throw new Error('HttpService buildRouter failed', { cause });
+      throw new Error('HttpService createLocalRouter failed', { cause });
     }
   }
 
-  /** @throws {ZeltNotImplementedError | ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
+  /** @throws {Error | ZeltNotImplementedError | ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError | ZeltReadyFailedError | BadRequestException}
+   * @throws {unknown} from http-error-handlers.lib.ts:createRouterErrorHandler
+   */
   private async initializeHono(options: HttpOptions): Promise<HonoInstance> {
     const Hono = await this.loadHonoConstructor();
     const fallbackHandler = resolve(this.container, DefaultErrorHandler);
@@ -71,67 +77,48 @@ export class HttpService {
       get: <T extends object>(cls: new (...args: never[]) => T): T => resolve(this.container, cls),
     };
 
+    const routerToken = Symbol('zelt:http-router');
+    const hono = new Hono({ strict: false });
+    hono.use(createBootstrapMiddleware(this.lifecycleManager, routerToken));
+    // Request helpers (body() etc.) must work inside the security and user
+    // middlewares below, so injection happens before they run.
+    hono.use(createRequestInjectionMiddleware());
+
+    const errorHandlers = resolveErrorHandlers(options.errorHandlers ?? [], this.container);
+    hono.onError(
+      createRouterErrorHandler(
+        errorHandlers,
+        fallbackHandler,
+        createRequestRootChecker(routerToken),
+      ),
+    );
+
     const securityMiddlewares: readonly MiddlewareInput[] = [
       CorsMiddleware,
       SecureHeadersMiddleware,
     ];
-    const rootMiddlewares = [...securityMiddlewares, ...(options.middlewares ?? [])];
+    for (const input of securityMiddlewares) {
+      const identity = middlewareIdentity(input);
+      hono.use(
+        guardMiddleware(identity, oncePerRequest(identity, resolveMiddleware(input, resolver))),
+      );
+    }
+    for (const input of options.middlewares ?? []) {
+      hono.use(guardMiddleware(middlewareIdentity(input), resolveMiddleware(input, resolver)));
+    }
 
-    const hono = this.buildHonoInstance(
-      options.controllers,
-      rootMiddlewares,
-      options.errorHandlers ?? [],
-      options.children ?? [],
-      fallbackHandler,
+    buildRoutes({
+      hono,
+      controllers: options.controllers ?? [],
       resolver,
-      Hono,
-    );
+      lifecycle: this.lifecycleManager,
+    });
+
     return hono;
   }
 
   private async loadHonoConstructor(): Promise<HonoConstructor> {
     const honoModule = await import('hono');
     return honoModule.Hono;
-  }
-
-  /** @throws {ZeltContextNotAvailableError | ZeltDecoratorUsageError} */
-  private buildHonoInstance(
-    controllers: readonly ControllerClass[],
-    middlewares: readonly MiddlewareInput[],
-    errorHandlerClasses: readonly ErrorHandlerClass[],
-    children: readonly HttpChildOptions[],
-    fallbackHandler: InstanceType<typeof DefaultErrorHandler>,
-    resolver: { get: <T extends object>(cls: new (...args: never[]) => T) => T },
-    Hono: HonoConstructor,
-  ): HonoInstance {
-    const hono = new Hono({ strict: false });
-
-    const errorHandlers = resolveErrorHandlers(errorHandlerClasses, this.container);
-    hono.onError(createErrorHandler(errorHandlers, fallbackHandler));
-
-    buildRoutes({
-      hono,
-      controllers,
-      resolver,
-      lifecycle: this.lifecycleManager,
-      globalMiddlewares: middlewares,
-    });
-
-    for (const child of children) {
-      const childMiddlewares = [...middlewares, ...(child.middlewares ?? [])];
-      const childErrorHandlers = [...(child.errorHandlers ?? []), ...errorHandlerClasses];
-      const childHono = this.buildHonoInstance(
-        child.controllers ?? [],
-        childMiddlewares,
-        childErrorHandlers,
-        child.children ?? [],
-        fallbackHandler,
-        resolver,
-        Hono,
-      );
-      hono.route(child.path, childHono);
-    }
-
-    return hono;
   }
 }

--- a/packages/core/src/features/http/http.types.ts
+++ b/packages/core/src/features/http/http.types.ts
@@ -1,18 +1,45 @@
+import type { Hono } from 'hono';
+
+import type { ServiceResolver } from '../../app';
 import type { ErrorHandlerClass, MiddlewareInput } from './middleware/middleware.types';
+import type { ControllerClass, ControllerRouteInfo } from './routing';
 
-export type ControllerClass = new (...args: never[]) => object;
+export type { ControllerClass } from './routing';
 
-export type HttpChildOptions = {
+export type HttpMetadata = {
+  readonly controllers: readonly ControllerRouteInfo[];
+};
+
+export type HttpStaticCapabilities = {
+  readonly getControllers: () => readonly ControllerClass[];
+  readonly getMetadata: () => HttpMetadata;
+};
+
+export type HttpMountableCapabilities = {
+  readonly router: Hono;
+  readonly fetch: (request: Request) => Promise<Response>;
+  readonly request: (input: string | Request, init?: RequestInit) => Promise<Response>;
+};
+
+// Same shape as the generic Feature contract: a module returns a
+// self-contained router (own path already applied) and parents merge it
+// without passing anything down.
+export type HttpMountableFeatureModule = {
   readonly path: string;
+  readonly featureClasses: () => readonly ControllerClass[];
+  readonly blueprint: () => HttpStaticCapabilities;
+  readonly realize: (resolver: ServiceResolver) => Promise<HttpMountableCapabilities>;
+};
+
+export type HttpModuleOptions = {
+  readonly path?: string;
   readonly controllers?: readonly ControllerClass[];
   readonly middlewares?: readonly MiddlewareInput[];
   readonly errorHandlers?: readonly ErrorHandlerClass[];
-  readonly children?: readonly HttpChildOptions[];
+  readonly children?: readonly HttpMountableFeatureModule[];
 };
 
-export type HttpOptions = {
-  readonly controllers: readonly ControllerClass[];
-  readonly middlewares?: readonly MiddlewareInput[];
-  readonly errorHandlers?: readonly ErrorHandlerClass[];
-  readonly children?: readonly HttpChildOptions[];
-};
+export type HttpCapabilities = Pick<HttpMountableCapabilities, 'fetch' | 'request'>;
+
+export type HttpChildOptions = HttpModuleOptions;
+export type HttpOptions = HttpModuleOptions;

--- a/packages/core/src/features/http/http.types.ts
+++ b/packages/core/src/features/http/http.types.ts
@@ -1,5 +1,3 @@
-import type { Hono } from 'hono';
-
 import type { ServiceResolver } from '../../app';
 import type { ErrorHandlerClass, MiddlewareInput } from './middleware/middleware.types';
 import type { ControllerClass, ControllerRouteInfo } from './routing';
@@ -15,8 +13,12 @@ export type HttpStaticCapabilities = {
   readonly getMetadata: () => HttpMetadata;
 };
 
+export type HttpMountableRouter = {
+  readonly fetch: (request: Request) => Response | Promise<Response>;
+};
+
 export type HttpMountableCapabilities = {
-  readonly router: Hono;
+  readonly router: HttpMountableRouter;
   readonly fetch: (request: Request) => Promise<Response>;
   readonly request: (input: string | Request, init?: RequestInit) => Promise<Response>;
 };

--- a/packages/core/src/features/http/middleware/index.ts
+++ b/packages/core/src/features/http/middleware/index.ts
@@ -1,0 +1,7 @@
+export {
+  attachSkippedMiddlewares,
+  guardMiddleware,
+  middlewareIdentity,
+  oncePerRequest,
+  resolveMiddleware,
+} from './middleware-guard.lib';

--- a/packages/core/src/features/http/middleware/middleware-guard.lib.ts
+++ b/packages/core/src/features/http/middleware/middleware-guard.lib.ts
@@ -1,0 +1,126 @@
+import type { Context } from 'hono';
+import { matchedRoutes } from 'hono/route';
+import { findTargetHandler } from 'hono/utils/handler';
+
+import type { ResolverHandle } from '../../../kernel';
+import { createContextKey, getInternal, setInternal } from '../../../kernel';
+import type {
+  FunctionMiddleware,
+  MiddlewareClass,
+  MiddlewareIdentifier,
+  MiddlewareInput,
+  MiddlewareInputWithOptions,
+} from './middleware.types';
+
+const SKIPPED_MIDDLEWARES = Symbol('zelt:skipped-middlewares');
+
+const hasUseMethod = (proto: unknown): boolean => {
+  if (proto === null || proto === undefined) return false;
+  if (typeof proto !== 'object') return false;
+  return typeof Reflect.get(proto, 'use') === 'function';
+};
+
+const checkMiddlewareClass = (input: MiddlewareInput): boolean =>
+  typeof input === 'function' && input.prototype !== undefined && hasUseMethod(input.prototype);
+
+const checkMiddlewareWithOptions = (input: MiddlewareInput): boolean => {
+  if (!Array.isArray(input)) return false;
+  const tuple: MiddlewareInputWithOptions = input;
+  return checkMiddlewareClass(tuple[0]);
+};
+
+function narrowToWithOptions(middleware: MiddlewareInput): MiddlewareInputWithOptions;
+function narrowToWithOptions(middleware: MiddlewareInput): MiddlewareInput {
+  return middleware;
+}
+
+function narrowToClass(middleware: MiddlewareInput): MiddlewareClass;
+function narrowToClass(middleware: MiddlewareInput): MiddlewareInput {
+  return middleware;
+}
+
+function narrowToFunction(middleware: MiddlewareInput): FunctionMiddleware;
+function narrowToFunction(middleware: MiddlewareInput): MiddlewareInput {
+  return middleware;
+}
+
+// Skip declarations reference the class (or function) itself, so a
+// [class, options] tuple must collapse to the class for identity checks.
+export const middlewareIdentity = (input: MiddlewareInput): MiddlewareIdentifier => {
+  if (checkMiddlewareWithOptions(input)) return narrowToWithOptions(input)[0];
+  if (checkMiddlewareClass(input)) return narrowToClass(input);
+  return narrowToFunction(input);
+};
+
+/** @throws {ZeltLifecycleStateError} */
+export const resolveMiddleware = (
+  middleware: MiddlewareInput,
+  resolver: ResolverHandle,
+): FunctionMiddleware => {
+  if (checkMiddlewareWithOptions(middleware)) {
+    const [mwClass, options] = narrowToWithOptions(middleware);
+    const instance = resolver.get(mwClass);
+    return (c, next) => instance.use(c, next, options);
+  }
+  if (checkMiddlewareClass(middleware)) {
+    const mwClass = narrowToClass(middleware);
+    const instance = resolver.get(mwClass);
+    return (c, next) => instance.use(c, next, undefined);
+  }
+  return narrowToFunction(middleware);
+};
+
+export const attachSkippedMiddlewares = (
+  handler: object,
+  skipped: ReadonlySet<MiddlewareIdentifier>,
+): void => {
+  Reflect.set(handler, SKIPPED_MIDDLEWARES, skipped);
+};
+
+const findSkippedMiddlewares = (c: Context): ReadonlySet<unknown> | undefined => {
+  for (const route of matchedRoutes(c)) {
+    // route() mounting may wrap handlers for error-handler scoping;
+    // findTargetHandler unwraps to the function the skip set was attached to.
+    const skipped: unknown = Reflect.get(findTargetHandler(route.handler), SKIPPED_MIDDLEWARES);
+    if (skipped instanceof Set) return skipped;
+  }
+  return undefined;
+};
+
+// Skip is decided here, at execution time, against the matched endpoint's
+// declaration — registration never filters middlewares, so inherited (use)
+// and route-chained middlewares share a single skip semantics.
+export const guardMiddleware = (
+  identifier: MiddlewareIdentifier,
+  middleware: FunctionMiddleware,
+): FunctionMiddleware => {
+  return async (c, next) => {
+    const skipped = findSkippedMiddlewares(c);
+    if (skipped?.has(identifier)) return next();
+    const result = await middleware(c, next);
+    if (result instanceof Response) {
+      c.res = result;
+    }
+  };
+};
+
+const APPLIED_MIDDLEWARES = createContextKey<Set<MiddlewareIdentifier>>('zelt:applied-middlewares');
+
+// Every router level registers the built-in security middlewares; this guard
+// keeps one identity to one run per request regardless of nesting depth.
+/** @throws {ZeltContextNotAvailableError} */
+export const oncePerRequest = (
+  identifier: MiddlewareIdentifier,
+  middleware: FunctionMiddleware,
+): FunctionMiddleware => {
+  return (c, next) => {
+    const existing = getInternal(APPLIED_MIDDLEWARES);
+    if (existing) {
+      if (existing.has(identifier)) return next();
+      existing.add(identifier);
+    } else {
+      setInternal(APPLIED_MIDDLEWARES, new Set([identifier]));
+    }
+    return middleware(c, next);
+  };
+};

--- a/packages/core/src/features/http/request-injection.lib.ts
+++ b/packages/core/src/features/http/request-injection.lib.ts
@@ -1,0 +1,26 @@
+import { createContextKey, getInternal, setInternal } from '../../kernel';
+import type { FunctionMiddleware } from './middleware/middleware.types';
+import { setHonoContext } from './request';
+import { parseRequestBody, setBody, setPathParams } from './request/injection';
+
+const REQUEST_INJECTED = createContextKey<true>('zelt:request-injected');
+
+// Runs right after the bootstrap middleware, ahead of the router-level
+// (security and user) middlewares, so request helpers like body() / header()
+// / pathParam() work inside them. Only the outermost router performs the
+// injection; nested routers stay transparent. Path params are re-applied per
+// matched route by the route-level injection for accuracy under nesting.
+/** @throws {ZeltContextNotAvailableError | BadRequestException} */
+export const createRequestInjectionMiddleware = (): FunctionMiddleware => {
+  return async (c, next) => {
+    if (getInternal(REQUEST_INJECTED)) {
+      await next();
+      return;
+    }
+    setInternal(REQUEST_INJECTED, true);
+    setHonoContext(c);
+    setBody(await parseRequestBody(c));
+    setPathParams(c.req.param());
+    await next();
+  };
+};

--- a/packages/core/src/features/http/request/injection/body.lib.ts
+++ b/packages/core/src/features/http/request/injection/body.lib.ts
@@ -1,14 +1,16 @@
+import type { Context } from 'hono';
+
 import {
   createContextKey,
   getInternal,
   setInternal,
   ZeltContextNotAvailableError,
 } from '../../../../kernel';
-import { UnsupportedMediaTypeException } from '../../http.exceptions';
+import { BadRequestException, UnsupportedMediaTypeException } from '../../http.exceptions';
 
 type FormBody = Record<string, string | File | (string | File)[]>;
 
-type ParsedBody =
+export type ParsedBody =
   | { type: 'json'; val: unknown }
   | { type: 'form'; val: FormBody }
   | { type: 'text'; val: string }
@@ -19,6 +21,42 @@ const BODY_CONTEXT = createContextKey<ParsedBody>('zelt:body');
 /** @throws {ZeltContextNotAvailableError} */
 export const setBody = (body: ParsedBody): void => {
   setInternal(BODY_CONTEXT, body);
+};
+
+// Lets injection middlewares at different router levels avoid re-reading the
+// request stream: only the first injection per request parses the body.
+/** @throws {ZeltContextNotAvailableError} */
+export const hasParsedBody = (): boolean => getInternal(BODY_CONTEXT) !== undefined;
+
+/** @throws {BadRequestException} */
+export const parseRequestBody = async (c: Pick<Context, 'req'>): Promise<ParsedBody> => {
+  const contentType = c.req.header('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    const val = await c.req.json<unknown>().catch((e: Error) => {
+      throw new BadRequestException({ reason: `Invalid JSON: ${e.message}` });
+    });
+    return { type: 'json', val };
+  }
+
+  if (
+    contentType.includes('multipart/form-data') ||
+    contentType.includes('application/x-www-form-urlencoded')
+  ) {
+    const val: FormBody = await c.req.parseBody({ all: true }).catch((e: Error) => {
+      throw new BadRequestException({ reason: `Invalid form data: ${e.message}` });
+    });
+    return { type: 'form', val };
+  }
+
+  if (contentType.startsWith('text/')) {
+    const val = await c.req.text().catch((e: Error) => {
+      throw new BadRequestException({ reason: `Invalid text body: ${e.message}` });
+    });
+    return { type: 'text', val };
+  }
+
+  return { type: 'none', val: undefined };
 };
 
 /** @throws {ZeltContextNotAvailableError} */

--- a/packages/core/src/features/http/request/injection/index.ts
+++ b/packages/core/src/features/http/request/injection/index.ts
@@ -1,4 +1,5 @@
-export { body, setBody } from './body.lib';
+export type { ParsedBody } from './body.lib';
+export { body, hasParsedBody, parseRequestBody, setBody } from './body.lib';
 export { cookie } from './cookie.lib';
 export type { RequestContextSchema } from './get-context.lib';
 export { getContext, setContext } from './get-context.lib';

--- a/packages/core/src/features/http/routing/index.ts
+++ b/packages/core/src/features/http/routing/index.ts
@@ -1,6 +1,11 @@
 export { joinPath } from './path-utils.lib';
 export { buildRoutes, collectRoutes } from './route-builder.lib';
-export type { ControllerRouteInfo, HttpMethod, RouteInfo } from './routing-metadata.lib';
+export type {
+  ControllerClass,
+  ControllerRouteInfo,
+  HttpMethod,
+  RouteInfo,
+} from './routing-metadata.lib';
 export {
   collectControllerRouteInfo,
   getAuthorizedMetadata,

--- a/packages/core/src/features/http/routing/route-builder.lib.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.ts
@@ -1,23 +1,27 @@
 import type { Context, Env, Input } from 'hono';
 import type { LifecycleManager, ResolverHandle } from '../../../kernel';
 import {
+  hasContext,
   runInContext,
   ZeltDecoratorUsageError,
-  ZeltMiddlewareExecutionError,
   ZeltRouteConfigurationError,
 } from '../../../kernel';
-import { BadRequestException } from '../http.exceptions';
+import {
+  attachSkippedMiddlewares,
+  guardMiddleware,
+  middlewareIdentity,
+  resolveMiddleware,
+} from '../middleware';
 import { currentRoles, currentUser } from '../middleware/auth';
 import type {
   FunctionMiddleware,
-  MiddlewareClass,
+  MiddlewareIdentifier,
   MiddlewareInput,
-  MiddlewareInputWithOptions,
 } from '../middleware/middleware.types';
 import { setHonoContext } from '../request';
-import { setBody, setPathParams } from '../request/injection';
+import { hasParsedBody, parseRequestBody, setBody, setPathParams } from '../request/injection';
 import { joinPath } from './path-utils.lib';
-import type { HttpMethod } from './routing-metadata.lib';
+import type { ControllerClass, HttpMethod } from './routing-metadata.lib';
 import {
   getAuthorizedMetadata,
   getControllerMetadata,
@@ -32,14 +36,12 @@ export { joinPath };
 type MiddlewareContext = Context<Env, string, Input>;
 type RouteHandler = (c: MiddlewareContext) => Promise<Response>;
 type HonoRouter = {
-  readonly get: (path: string, handler: RouteHandler) => unknown;
-  readonly post: (path: string, handler: RouteHandler) => unknown;
-  readonly put: (path: string, handler: RouteHandler) => unknown;
-  readonly patch: (path: string, handler: RouteHandler) => unknown;
-  readonly delete: (path: string, handler: RouteHandler) => unknown;
+  readonly get: (path: string, ...handlers: (FunctionMiddleware | RouteHandler)[]) => unknown;
+  readonly post: (path: string, ...handlers: (FunctionMiddleware | RouteHandler)[]) => unknown;
+  readonly put: (path: string, ...handlers: (FunctionMiddleware | RouteHandler)[]) => unknown;
+  readonly patch: (path: string, ...handlers: (FunctionMiddleware | RouteHandler)[]) => unknown;
+  readonly delete: (path: string, ...handlers: (FunctionMiddleware | RouteHandler)[]) => unknown;
 };
-
-import type { ControllerClass } from '../http.types';
 
 type Route = {
   readonly method: HttpMethod;
@@ -86,96 +88,6 @@ const resolveHandler = (instance: object, methodName: string | symbol): (() => u
   };
 };
 
-type FormBody = Record<string, string | File | (string | File)[]>;
-
-type ParsedBody =
-  | { type: 'json'; val: unknown }
-  | { type: 'form'; val: FormBody }
-  | { type: 'text'; val: string }
-  | { type: 'none'; val: undefined };
-
-/** @throws {BadRequestException} */
-const parseRequestBody = async (c: MiddlewareContext): Promise<ParsedBody> => {
-  const contentType = c.req.header('content-type') ?? '';
-
-  if (contentType.includes('application/json')) {
-    const val = await c.req.json<unknown>().catch((e: Error) => {
-      throw new BadRequestException({ reason: `Invalid JSON: ${e.message}` });
-    });
-    return { type: 'json', val };
-  }
-
-  if (
-    contentType.includes('multipart/form-data') ||
-    contentType.includes('application/x-www-form-urlencoded')
-  ) {
-    const val: FormBody = await c.req.parseBody({ all: true }).catch((e: Error) => {
-      throw new BadRequestException({ reason: `Invalid form data: ${e.message}` });
-    });
-    return { type: 'form', val };
-  }
-
-  if (contentType.startsWith('text/')) {
-    const val = await c.req.text().catch((e: Error) => {
-      throw new BadRequestException({ reason: `Invalid text body: ${e.message}` });
-    });
-    return { type: 'text', val };
-  }
-
-  return { type: 'none', val: undefined };
-};
-
-/** @throws {ZeltLifecycleStateError} */
-const hasUseMethod = (proto: unknown): boolean => {
-  if (proto === null || proto === undefined) return false;
-  if (typeof proto !== 'object') return false;
-  return typeof Reflect.get(proto, 'use') === 'function';
-};
-
-/** @throws {ZeltLifecycleStateError} */
-const checkMiddlewareClass = (input: MiddlewareInput): boolean =>
-  typeof input === 'function' && input.prototype !== undefined && hasUseMethod(input.prototype);
-
-/** @throws {ZeltLifecycleStateError} */
-const checkMiddlewareWithOptions = (input: MiddlewareInput): boolean => {
-  if (!Array.isArray(input)) return false;
-  const tuple: MiddlewareInputWithOptions = input;
-  return checkMiddlewareClass(tuple[0]);
-};
-
-function narrowToWithOptions(middleware: MiddlewareInput): MiddlewareInputWithOptions;
-function narrowToWithOptions(middleware: MiddlewareInput): MiddlewareInput {
-  return middleware;
-}
-
-function narrowToClass(middleware: MiddlewareInput): MiddlewareClass;
-function narrowToClass(middleware: MiddlewareInput): MiddlewareInput {
-  return middleware;
-}
-
-function narrowToFunction(middleware: MiddlewareInput): FunctionMiddleware;
-function narrowToFunction(middleware: MiddlewareInput): MiddlewareInput {
-  return middleware;
-}
-
-/** @throws {ZeltLifecycleStateError} */
-const resolveMiddleware = (
-  middleware: MiddlewareInput,
-  resolver: ResolverHandle,
-): FunctionMiddleware => {
-  if (checkMiddlewareWithOptions(middleware)) {
-    const [mwClass, options] = narrowToWithOptions(middleware);
-    const instance = resolver.get(mwClass);
-    return (c, next) => instance.use(c, next, options);
-  }
-  if (checkMiddlewareClass(middleware)) {
-    const mwClass = narrowToClass(middleware);
-    const instance = resolver.get(mwClass);
-    return (c, next) => instance.use(c, next, undefined);
-  }
-  return narrowToFunction(middleware);
-};
-
 /** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError} */
 const createAuthorizationMiddleware = (requiredRoles: readonly string[]): FunctionMiddleware => {
   return async (_c, next) => {
@@ -205,7 +117,6 @@ const createAuthorizationMiddleware = (requiredRoles: readonly string[]): Functi
 
 /** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError} */
 const collectRouteMiddlewares = (
-  globalMiddlewares: readonly MiddlewareInput[],
   controllerClass: ControllerClass,
   methodName: string | symbol,
   resolver: ResolverHandle,
@@ -214,67 +125,56 @@ const collectRouteMiddlewares = (
   const methodMetas = getMethodMiddlewareMetadata(controllerClass).filter(
     (m) => m.methodName === methodName,
   );
-  const skipMetas = getSkipMiddlewareMetadata(controllerClass).filter(
-    (m) => m.methodName === methodName,
-  );
   const authorizedMeta = getAuthorizedMetadata(controllerClass, methodName);
 
-  const skippedSet = new Set<MiddlewareInput>(skipMetas.flatMap((m) => m.skipped));
-
-  const allMiddlewares: MiddlewareInput[] = [
-    ...globalMiddlewares.filter((m) => !skippedSet.has(m)),
-    ...(controllerMeta?.flatMap((set) => set.filter((m) => !skippedSet.has(m))) ?? []),
-    ...methodMetas.flatMap((m) => m.middlewares.filter((mw) => !skippedSet.has(mw))),
+  const inputs: MiddlewareInput[] = [
+    ...(controllerMeta?.flat() ?? []),
+    ...methodMetas.flatMap((m) => m.middlewares),
   ];
 
-  const resolvedMiddlewares = allMiddlewares.map((m) => resolveMiddleware(m, resolver));
+  const guarded = inputs.map((input) =>
+    guardMiddleware(middlewareIdentity(input), resolveMiddleware(input, resolver)),
+  );
 
   if (authorizedMeta) {
-    resolvedMiddlewares.push(createAuthorizationMiddleware(authorizedMeta.roles));
+    guarded.push(createAuthorizationMiddleware(authorizedMeta.roles));
   }
 
-  return resolvedMiddlewares;
+  return guarded;
 };
 
-/** @throws {ZeltMiddlewareExecutionError} */
-const composeHandler = (
-  middlewares: readonly FunctionMiddleware[],
-  finalHandler: (c: MiddlewareContext) => Promise<Response>,
-): ((c: MiddlewareContext) => Promise<Response>) => {
-  if (middlewares.length === 0) {
-    return finalHandler;
-  }
+const collectSkippedMiddlewares = (
+  controllerClass: ControllerClass,
+  methodName: string | symbol,
+): ReadonlySet<MiddlewareIdentifier> =>
+  new Set(
+    getSkipMiddlewareMetadata(controllerClass)
+      .filter((m) => m.methodName === methodName)
+      .flatMap((m) => m.skipped),
+  );
 
-  return async (c: MiddlewareContext): Promise<Response> => {
-    let index = -1;
-    let response: Response | undefined;
-
-    /** @throws {ZeltMiddlewareExecutionError} */
-    const dispatch = async (i: number): Promise<void> => {
-      if (i <= index) {
-        throw new ZeltMiddlewareExecutionError({
-          reason: 'next_called_multiple_times',
-          middlewareName: middlewares[index]?.name || '<anonymous>',
-        });
+// Populates the request context store before route-chained middlewares and
+// the controller run. The router-level request injection normally ran
+// earlier; this re-applies path params for the matched route (parent routers
+// only see their mount-level params) and keeps bare buildRoutes() usage
+// working by parsing the body when nothing parsed it yet.
+/** @throws {ZeltContextNotAvailableError | BadRequestException} */
+const createInjectionMiddleware = (): FunctionMiddleware => {
+  return async (c, next) => {
+    /** @throws {ZeltContextNotAvailableError | BadRequestException} */
+    const run = async (): Promise<void> => {
+      setHonoContext(c);
+      if (!hasParsedBody()) {
+        setBody(await parseRequestBody(c));
       }
-      index = i;
-      if (i < middlewares.length) {
-        const mw = middlewares[i];
-        if (mw) {
-          const result = await mw(c, () => dispatch(i + 1));
-          if (result instanceof Response) {
-            response = result;
-            c.res = result;
-          }
-        }
-      } else {
-        response = await finalHandler(c);
-        c.res = response;
-      }
+      setPathParams(c.req.param());
+      await next();
     };
-
-    await dispatch(0);
-    return response ?? c.res;
+    if (hasContext()) {
+      await run();
+      return;
+    }
+    await runInContext(run);
   };
 };
 
@@ -296,51 +196,37 @@ const getOrCreateInstance = (
   return instance;
 };
 
-/** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError} */
-const registerRoute = (
-  hono: HonoRouter,
-  ctx: RouteBuilderContext,
-  route: Route,
-  globalMiddlewares: readonly MiddlewareInput[],
-): void => {
+/** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError | BadRequestException} */
+const registerRoute = (hono: HonoRouter, ctx: RouteBuilderContext, route: Route): void => {
   const middlewares = collectRouteMiddlewares(
-    globalMiddlewares,
     route.controllerClass,
     route.methodName,
     ctx.resolver,
   );
 
-  /** @throws {BadRequestException | ZeltContextNotAvailableError | ZeltReadyFailedError | ZeltLifecycleStateError | ZeltMiddlewareExecutionError | ZeltRouteConfigurationError} */
+  /** @throws {ZeltContextNotAvailableError | ZeltReadyFailedError | ZeltLifecycleStateError | ZeltRouteConfigurationError} */
   const handler = async (c: MiddlewareContext): Promise<Response> => {
     const instance = getOrCreateInstance(ctx, route.controllerClass);
     await ctx.lifecycle.startupPending();
 
     const invoke = resolveHandler(instance, route.methodName);
-
-    const finalHandler = async (ctx: MiddlewareContext): Promise<Response> => {
-      const result = await invoke();
-      if (result instanceof Response) return result;
-      return ctx.json(result);
-    };
-
-    const composedHandler = composeHandler(middlewares, finalHandler);
-
-    const body = await parseRequestBody(c);
-    const pathParams: Readonly<Record<string, string>> = c.req.param();
-    return runInContext(() => {
-      setHonoContext(c);
-      setBody(body);
-      setPathParams(pathParams);
-      return composedHandler(c);
-    });
+    const result = await invoke();
+    if (result instanceof Response) return result;
+    return c.json(result);
   };
 
+  attachSkippedMiddlewares(
+    handler,
+    collectSkippedMiddlewares(route.controllerClass, route.methodName),
+  );
+
+  const chain = [createInjectionMiddleware(), ...middlewares];
   const methods = {
-    GET: () => hono.get(route.fullPath, handler),
-    POST: () => hono.post(route.fullPath, handler),
-    PUT: () => hono.put(route.fullPath, handler),
-    PATCH: () => hono.patch(route.fullPath, handler),
-    DELETE: () => hono.delete(route.fullPath, handler),
+    GET: () => hono.get(route.fullPath, ...chain, handler),
+    POST: () => hono.post(route.fullPath, ...chain, handler),
+    PUT: () => hono.put(route.fullPath, ...chain, handler),
+    PATCH: () => hono.patch(route.fullPath, ...chain, handler),
+    DELETE: () => hono.delete(route.fullPath, ...chain, handler),
   } as const;
 
   methods[route.method]();
@@ -351,10 +237,9 @@ export type BuildRoutesOptions = {
   readonly controllers: readonly ControllerClass[];
   readonly resolver: ResolverHandle;
   readonly lifecycle: LifecycleManager;
-  readonly globalMiddlewares?: readonly MiddlewareInput[];
 };
 
-/** @throws {ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError} */
+/** @throws {ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError | BadRequestException} */
 export const buildRoutes = (options: BuildRoutesOptions): void => {
   const ctx: RouteBuilderContext = {
     resolver: options.resolver,
@@ -363,6 +248,6 @@ export const buildRoutes = (options: BuildRoutesOptions): void => {
   };
 
   for (const route of collectRoutes(options.controllers)) {
-    registerRoute(options.hono, ctx, route, options.globalMiddlewares ?? []);
+    registerRoute(options.hono, ctx, route);
   }
 };

--- a/packages/core/src/features/http/routing/routing-metadata.lib.ts
+++ b/packages/core/src/features/http/routing/routing-metadata.lib.ts
@@ -6,6 +6,8 @@ import { joinPath } from './path-utils.lib';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
+export type ControllerClass = new (...args: never[]) => object;
+
 type ControllerMetadata = {
   readonly basePath: string;
 };
@@ -203,9 +205,7 @@ export const getAuthorizedMetadata = (
   return undefined;
 };
 
-export const collectControllerRouteInfo = (
-  cls: new (...args: never[]) => object,
-): ControllerRouteInfo => {
+export const collectControllerRouteInfo = (cls: ControllerClass): ControllerRouteInfo => {
   const controllerMeta = getControllerMetadata(cls);
   const basePath = controllerMeta?.basePath ?? '/';
   const routeMeta = getRouteMetadata(cls);

--- a/packages/core/src/features/index.ts
+++ b/packages/core/src/features/index.ts
@@ -11,7 +11,12 @@ export type {
 export { Feature } from '../app';
 export type { CommandCapabilities } from './command/command.feature';
 export { CommandFeature, command } from './command/command.feature';
-export type { HttpCapabilities, HttpStaticCapabilities } from './http/http.feature';
+export type {
+  HttpCapabilities,
+  HttpMountableCapabilities,
+  HttpMountableFeatureModule,
+  HttpStaticCapabilities,
+} from './http/http.feature';
 export { HTTP_FEATURE_KEY, HttpFeature, http } from './http/http.feature';
 export type { SchedulerCapabilities } from './scheduler/scheduler.feature';
 export { SchedulerFeature, scheduler } from './scheduler/scheduler.feature';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,8 @@ export type {
   FeatureManagedClass,
   FeatureReadyCapabilities,
   HttpCapabilities,
+  HttpMountableCapabilities,
+  HttpMountableFeatureModule,
   HttpStaticCapabilities,
   NamespacedCaps,
   SchedulerCapabilities,
@@ -89,7 +91,11 @@ export type {
 } from './features/http/error/error.types';
 export { ErrorHandler } from './features/http/error/error-handler.decorator';
 export type { HttpMetadata } from './features/http/http.service';
-export type { ControllerClass } from './features/http/http.types';
+export type {
+  ControllerClass,
+  HttpChildOptions,
+  HttpModuleOptions,
+} from './features/http/http.types';
 // HTTP primitives
 export { currentRoles, currentUser, setUser } from './features/http/middleware/auth';
 // HTTP decorators

--- a/packages/core/src/kernel/index.ts
+++ b/packages/core/src/kernel/index.ts
@@ -22,6 +22,7 @@ export {
   createReadyValue,
   disposeReadyValue,
   getInternal,
+  hasContext,
   type InjectableClassDecoratorHooks,
   type ReadyValue,
   runInContext,

--- a/packages/core/src/kernel/internal/context-key.lib.ts
+++ b/packages/core/src/kernel/internal/context-key.lib.ts
@@ -21,6 +21,8 @@ export const runInContext = <T>(fn: () => T): T => {
   return storage.run({ ...parent }, fn);
 };
 
+export const hasContext = (): boolean => storage.getStore() !== undefined;
+
 /** @throws {ZeltContextNotAvailableError} */
 export const getInternal = <T>(key: ContextKey<T>): T | undefined => {
   const store = storage.getStore();

--- a/packages/core/src/kernel/internal/index.ts
+++ b/packages/core/src/kernel/internal/index.ts
@@ -2,6 +2,7 @@ export type { ContextKey } from './context-key.lib';
 export {
   createContextKey,
   getInternal,
+  hasContext,
   runInContext,
   setInternal,
 } from './context-key.lib';


### PR DESCRIPTION
## Summary

- Refactor core HTTP feature modules so nested/mountable HTTP capabilities can be composed cleanly.
- Add request bootstrap and middleware guards needed by downstream GraphQL mounting.
- Keep this PR scoped to `@zeltjs/core`; GraphQL package, dogfooding integration, docs, CI, and lockfile changes are intentionally excluded.

## Verification

- `pnpm run precommit`
- `git commit` passed pre-commit hooks with `precommit-verify: verified`
- `git push` passed pre-push hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783987124&installation_id=133048706&pr_number=272&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F272&signature=16fbe9faa9df330ddfd85ae69e0749ba4cd853fdbf850e94d8d04d3b3f703a3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ネストされたHTTPモジュールの複数レベルマウントに対応しました
  * リクエストコンテキストの分離とキャッシング機構を追加しました
  * ミドルウェア実行を細粒度で制御する機能を実装しました
  * リクエストボディの自動解析機能を強化しました

* **改善**
  * エラーハンドリングのスコープ管理を改善しました
  * ルータネスト時のミドルウェア重複実行を抑制しました

* **テスト**
  * ネストされたルートとミドルウェアの統合テストを拡充しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->