### PR TITLE
Add schema-first GraphQL codegen DX

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,7 +105,14 @@ export default tseslint.config(
       'zelt/double-dot-naming': [
         'error',
         {
-          allowedFiles: ['main.ts', 'cli.ts', 'ipc-bridge.ts', 'ipc-fetch.ts', 'expose-ipc.ts'],
+          allowedFiles: [
+            'main.ts',
+            'cli.ts',
+            'codegen.ts',
+            'ipc-bridge.ts',
+            'ipc-fetch.ts',
+            'expose-ipc.ts',
+          ],
           allowedPatterns: ['on-*.ts'],
         },
       ],
@@ -226,6 +233,7 @@ export default tseslint.config(
   {
     // Env module needs process.env access
     files: [
+      'packages/cli/src/cli-runtime.lib.ts',
       // EnvAdaptor implementations in adapters read process.env directly
       'packages/adapter-node/src/process-env.adaptor.ts',
       'packages/adapter-electron/src/main/electron-env.adaptor.ts',
@@ -312,6 +320,7 @@ export default tseslint.config(
       'packages/cli/src/run.command.ts',
       'packages/cli/src/dev.command.ts',
       'packages/cli/src/build.command.ts',
+      'packages/cli/src/graphql.command.ts',
     ],
     rules: {
       '@9wick/strict-type-rules/no-type-predicate': 'off',
@@ -324,6 +333,7 @@ export default tseslint.config(
       'packages/cli/src/build.command.ts',
       'packages/cli/src/dev.command.ts',
       'packages/cli/src/run.command.ts',
+      'packages/cli/src/graphql.command.ts',
     ],
     rules: {
       '@9wick/strict-type-rules/nestjs-like-di-for-needle-di': 'off',

--- a/integration/graphql-schema-first/e2e/graphql.spec.ts
+++ b/integration/graphql-schema-first/e2e/graphql.spec.ts
@@ -12,6 +12,10 @@ const schema = resolve(__dirname, '../src/graphql/schema.graphql');
 const runtimeModulePath = resolve(__dirname, '..', graphqlRuntimeModule);
 const generatedDir = dirname(runtimeModulePath);
 
+type AppRuntime = Awaited<
+  ReturnType<ReturnType<typeof createGraphqlSchemaFirstApp>['createRuntime']>
+>;
+
 const prepareGeneratedRuntime = async (): Promise<void> => {
   await rm(runtimeModulePath, { force: true });
   await mkdir(generatedDir, { recursive: true });
@@ -26,10 +30,7 @@ const prepareGeneratedRuntime = async (): Promise<void> => {
   });
 };
 
-const postGraphql = (
-  runtime: Awaited<ReturnType<ReturnType<typeof createGraphqlSchemaFirstApp>['createRuntime']>>,
-  query: string,
-): Promise<Response> =>
+const postGraphql = (runtime: AppRuntime, query: string): Promise<Response> =>
   runtime.http.request('/graphql', {
     method: 'POST',
     body: JSON.stringify({ query }),
@@ -37,7 +38,7 @@ const postGraphql = (
   });
 
 describe('GraphQL schema-first app', () => {
-  let runtime: Awaited<ReturnType<ReturnType<typeof createGraphqlSchemaFirstApp>['createRuntime']>>;
+  let runtime: AppRuntime;
 
   beforeAll(async () => {
     await prepareGeneratedRuntime();

--- a/integration/graphql-schema-first/e2e/graphql.spec.ts
+++ b/integration/graphql-schema-first/e2e/graphql.spec.ts
@@ -1,0 +1,68 @@
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { generateGraphqlSdl } from '@zeltjs/graphql';
+import { onTest, shutdownAll } from '@zeltjs/testing';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createGraphqlSchemaFirstApp, graphqlRuntimeModule } from '../src/app';
+
+const tsconfig = resolve(__dirname, '../tsconfig.json');
+const schema = resolve(__dirname, '../src/graphql/schema.graphql');
+const runtimeModulePath = resolve(__dirname, '..', graphqlRuntimeModule);
+const generatedDir = dirname(runtimeModulePath);
+
+const prepareGeneratedRuntime = async (): Promise<void> => {
+  await rm(runtimeModulePath, { force: true });
+  await mkdir(generatedDir, { recursive: true });
+
+  const app = createGraphqlSchemaFirstApp();
+  await generateGraphqlSdl(app.http, {
+    mode: 'schema-first',
+    schema,
+    runtimeModule: runtimeModulePath,
+    distDir: generatedDir,
+    tsconfig,
+  });
+};
+
+const postGraphql = (
+  runtime: Awaited<ReturnType<ReturnType<typeof createGraphqlSchemaFirstApp>['createRuntime']>>,
+  query: string,
+): Promise<Response> =>
+  runtime.http.request('/graphql', {
+    method: 'POST',
+    body: JSON.stringify({ query }),
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('GraphQL schema-first app', () => {
+  let runtime: Awaited<ReturnType<ReturnType<typeof createGraphqlSchemaFirstApp>['createRuntime']>>;
+
+  beforeAll(async () => {
+    await prepareGeneratedRuntime();
+    runtime = await onTest(createGraphqlSchemaFirstApp());
+  });
+
+  afterAll(async () => {
+    await shutdownAll();
+  });
+
+  it('runs a schema-first resolver through the generated GraphQL runtime over HTTP', async () => {
+    await expect(readFile(runtimeModulePath, 'utf8')).resolves.toContain(
+      'export const graphqlRuntime',
+    );
+
+    const response = await postGraphql(runtime, '{ product(id: "p_lamp") { id name } }');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        product: {
+          id: 'p_lamp',
+          name: 'Desk Lamp',
+        },
+      },
+    });
+  });
+});

--- a/integration/graphql-schema-first/package.extra.json
+++ b/integration/graphql-schema-first/package.extra.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "prepare:integration": "zelt graphql codegen --schema src/graphql/schema.graphql --out src/generated/graphql.ts"
+  }
+}

--- a/integration/graphql-schema-first/src/app.ts
+++ b/integration/graphql-schema-first/src/app.ts
@@ -1,0 +1,21 @@
+import { createApp, http } from '@zeltjs/core';
+import { graphql } from '@zeltjs/graphql';
+
+import { StorefrontResolver } from './graphql/storefront.resolver';
+
+export const graphqlRuntimeModule = 'src/generated/graphql-runtime.js';
+
+export const createGraphqlSchemaFirstApp = () =>
+  createApp([
+    http({
+      children: [
+        graphql({
+          path: '/graphql',
+          resolvers: [StorefrontResolver],
+          runtimeModule: graphqlRuntimeModule,
+        }),
+      ],
+    }),
+  ]);
+
+export const app = createGraphqlSchemaFirstApp();

--- a/integration/graphql-schema-first/src/catalog/catalog.service.ts
+++ b/integration/graphql-schema-first/src/catalog/catalog.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@zeltjs/core';
+
+import type { Gql } from '../generated/graphql';
+
+@Injectable()
+export class CatalogService {
+  findProduct(id: string): Gql.Product | undefined {
+    if (id !== 'p_lamp') return undefined;
+    return { id, name: 'Desk Lamp' };
+  }
+}

--- a/integration/graphql-schema-first/src/graphql/schema.graphql
+++ b/integration/graphql-schema-first/src/graphql/schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  product(id: ID!): Product
+}
+
+type Product {
+  id: ID!
+  name: String!
+}

--- a/integration/graphql-schema-first/src/graphql/storefront.resolver.ts
+++ b/integration/graphql-schema-first/src/graphql/storefront.resolver.ts
@@ -9,7 +9,7 @@ export class StorefrontResolver {
   constructor(private readonly catalog = inject(CatalogService)) {}
 
   @Query()
-  product(input = Gql.Query.product.args()) {
+  product(input = Gql.Query.product.args()): Gql.Query.product.Result {
     return this.catalog.findProduct(input.id) ?? null;
   }
 }

--- a/integration/graphql-schema-first/src/graphql/storefront.resolver.ts
+++ b/integration/graphql-schema-first/src/graphql/storefront.resolver.ts
@@ -6,7 +6,7 @@ import { Gql } from '../generated/graphql';
 
 @Resolver()
 export class StorefrontResolver {
-  constructor(private readonly catalog = inject(CatalogService) as CatalogService) {}
+  constructor(private readonly catalog = inject(CatalogService)) {}
 
   @Query()
   product(input = Gql.Query.product.args()) {

--- a/integration/graphql-schema-first/src/graphql/storefront.resolver.ts
+++ b/integration/graphql-schema-first/src/graphql/storefront.resolver.ts
@@ -1,0 +1,15 @@
+import { inject } from '@zeltjs/core';
+import { Query, Resolver } from '@zeltjs/graphql';
+
+import { CatalogService } from '../catalog/catalog.service';
+import { Gql } from '../generated/graphql';
+
+@Resolver()
+export class StorefrontResolver {
+  constructor(private readonly catalog = inject(CatalogService) as CatalogService) {}
+
+  @Query()
+  product(input = Gql.Query.product.args()) {
+    return this.catalog.findProduct(input.id) ?? null;
+  }
+}

--- a/integration/graphql-schema-first/tsconfig.json
+++ b/integration/graphql-schema-first/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "e2e/**/*"]
+}

--- a/integration/graphql-schema-first/vitest.config.ts
+++ b/integration/graphql-schema-first/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['e2e/**/*.spec.ts'],
+  },
+});

--- a/integration/scripts/run-tests.sh
+++ b/integration/scripts/run-tests.sh
@@ -47,6 +47,13 @@ run_tests() {
     echo "Running tests: $name"
     echo "=========================================="
 
+    if (cd "$dir" && pnpm --if-present run prepare:integration); then
+      echo "✓ $name: prepare:integration passed"
+    else
+      echo "✗ $name: prepare:integration FAILED"
+      exit_code=1
+    fi
+
     if (cd "$dir" && npx tsc --noEmit); then
       echo "✓ $name: tsc --noEmit passed"
     else

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,10 @@
   },
   "dependencies": {
     "chokidar": "5.0.0",
-    "jiti": "2.6.1"
+    "citty": "0.1.6",
+    "consola": "3.4.2",
+    "jiti": "2.6.1",
+    "ts-pattern": "5.7.1"
   },
   "peerDependencies": {
     "typescript": "catalog:peer"
@@ -55,9 +58,6 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "c12": "3.0.4",
-    "citty": "0.1.6",
-    "consola": "3.4.2",
-    "ts-pattern": "5.7.1",
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "valibot": "catalog:"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,8 +46,6 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
-    "@zeltjs/adapter-node": "workspace:*",
-    "@zeltjs/core": "workspace:*",
     "chokidar": "5.0.0",
     "jiti": "2.6.1"
   },

--- a/packages/cli/src/build.command.ts
+++ b/packages/cli/src/build.command.ts
@@ -14,6 +14,7 @@ import {
   isZeltNoEntryError,
   ZeltNoEntryError,
 } from './cli.errors';
+import { nodeCliRuntime } from './cli-runtime.lib';
 import type { BuildConfig } from './config/config.types';
 import { loadZeltConfig } from './config/index';
 import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './plugin-runner.lib';
@@ -114,7 +115,7 @@ export const buildCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cwd = process.cwd();
+    const cwd = nodeCliRuntime.cwd();
     const typedArgs: BuildArgs = args;
 
     try {

--- a/packages/cli/src/build.command.ts
+++ b/packages/cli/src/build.command.ts
@@ -1,4 +1,3 @@
-import { NodeCliConfig } from '@zeltjs/adapter-node';
 import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
@@ -19,8 +18,6 @@ import type { BuildConfig } from './config/config.types';
 import { loadZeltConfig } from './config/index';
 import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './plugin-runner.lib';
 import { runTsdownBuild } from './tsdown.lib';
-
-const cliConfig = new NodeCliConfig();
 
 type BuildArgs = {
   readonly config?: string;
@@ -117,7 +114,7 @@ export const buildCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cwd = cliConfig.cwd();
+    const cwd = process.cwd();
     const typedArgs: BuildArgs = args;
 
     try {

--- a/packages/cli/src/cli-runtime.lib.ts
+++ b/packages/cli/src/cli-runtime.lib.ts
@@ -1,0 +1,22 @@
+export type CliSignal = 'SIGINT' | 'SIGTERM';
+export type CliSignalHandler = () => void;
+
+export type CliRuntime = {
+  readonly cwd: () => string;
+  readonly setExitCode: (code: number) => void;
+  readonly onSignal: (signal: CliSignal, handler: CliSignalHandler) => void;
+  readonly offSignal: (signal: CliSignal, handler: CliSignalHandler) => void;
+};
+
+export const nodeCliRuntime: CliRuntime = {
+  cwd: () => process.cwd(),
+  setExitCode: (code) => {
+    process.exitCode = code;
+  },
+  onSignal: (signal, handler) => {
+    process.on(signal, handler);
+  },
+  offSignal: (signal, handler) => {
+    process.off(signal, handler);
+  },
+};

--- a/packages/cli/src/cli.errors.ts
+++ b/packages/cli/src/cli.errors.ts
@@ -2,11 +2,14 @@ const defineError = <Context extends object>(
   name: string,
   createMessage: (ctx: Context) => string,
 ) => {
+  const toErrorOptions = (cause: unknown): ErrorOptions | undefined =>
+    cause === undefined ? undefined : { cause };
+
   return class ZeltCliError extends Error {
     readonly context: Context;
 
     constructor(context: Context, cause?: unknown) {
-      super(createMessage(context), cause === undefined ? undefined : { cause });
+      super(createMessage(context), toErrorOptions(cause));
       this.name = name;
       this.context = context;
     }

--- a/packages/cli/src/cli.errors.ts
+++ b/packages/cli/src/cli.errors.ts
@@ -1,4 +1,17 @@
-import { defineError } from '@zeltjs/core/internal-bridge/errors';
+const defineError = <Context extends object>(
+  name: string,
+  createMessage: (ctx: Context) => string,
+) => {
+  return class ZeltCliError extends Error {
+    readonly context: Context;
+
+    constructor(context: Context, cause?: unknown) {
+      super(createMessage(context), cause === undefined ? undefined : { cause });
+      this.name = name;
+      this.context = context;
+    }
+  };
+};
 
 export const ZeltConfigLoadError = defineError(
   'ZeltConfigLoadError',

--- a/packages/cli/src/dev-server.lib.ts
+++ b/packages/cli/src/dev-server.lib.ts
@@ -19,6 +19,7 @@ export type DevServerOptions = {
 type DevServerState = {
   childProcess: ChildProcess | undefined;
   watcher: WatcherHandle | undefined;
+  unregisterSignals: (() => void) | undefined;
   isShuttingDown: boolean;
 };
 
@@ -104,6 +105,9 @@ const createShutdownHandler = (state: DevServerState) => {
     state.isShuttingDown = true;
     consola.info('Shutting down dev server...');
 
+    state.unregisterSignals?.();
+    state.unregisterSignals = undefined;
+
     if (state.watcher !== undefined) {
       await state.watcher.close();
     }
@@ -166,6 +170,7 @@ export const startDevServer = async (options: DevServerOptions): Promise<void> =
   const state: DevServerState = {
     childProcess: undefined,
     watcher: undefined,
+    unregisterSignals: undefined,
     isShuttingDown: false,
   };
 
@@ -176,7 +181,7 @@ export const startDevServer = async (options: DevServerOptions): Promise<void> =
   const shutdown = createShutdownHandler(state);
   const restart = createRestartHandler(state, cwd, devConfig.entry, config);
 
-  registerSignalHandlers(cliRuntime, shutdown);
+  state.unregisterSignals = registerSignalHandlers(cliRuntime, shutdown);
 
   state.watcher = createWatcher({
     cwd,

--- a/packages/cli/src/dev-server.lib.ts
+++ b/packages/cli/src/dev-server.lib.ts
@@ -1,16 +1,12 @@
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 
-import { NodeCliConfig } from '@zeltjs/adapter-node';
-import type { SignalHandler } from '@zeltjs/core';
 import consola from 'consola';
 
 import type { DevConfig, ZeltConfig } from './config/config.types';
 import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './plugin-runner.lib';
 import type { WatcherHandle } from './watcher.lib';
 import { createWatcher } from './watcher.lib';
-
-const cliConfig = new NodeCliConfig();
 
 export type DevServerOptions = {
   readonly cwd: string;
@@ -144,17 +140,17 @@ const createRestartHandler = (
   };
 };
 
-const registerSignalHandlers = (onSignal: () => Promise<void>): SignalHandler => {
+const registerSignalHandlers = (onSignal: () => Promise<void>): (() => void) => {
   const handler = (): void => {
     void onSignal();
   };
 
-  cliConfig.onSignal('SIGINT', handler);
-  cliConfig.onSignal('SIGTERM', handler);
+  process.on('SIGINT', handler);
+  process.on('SIGTERM', handler);
 
   return () => {
-    cliConfig.offSignal('SIGINT', handler);
-    cliConfig.offSignal('SIGTERM', handler);
+    process.off('SIGINT', handler);
+    process.off('SIGTERM', handler);
   };
 };
 

--- a/packages/cli/src/dev-server.lib.ts
+++ b/packages/cli/src/dev-server.lib.ts
@@ -3,6 +3,7 @@ import { spawn } from 'node:child_process';
 
 import consola from 'consola';
 
+import type { CliRuntime } from './cli-runtime.lib';
 import type { DevConfig, ZeltConfig } from './config/config.types';
 import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './plugin-runner.lib';
 import type { WatcherHandle } from './watcher.lib';
@@ -12,6 +13,7 @@ export type DevServerOptions = {
   readonly cwd: string;
   readonly config: ZeltConfig;
   readonly devConfig: DevConfig & { entry: string };
+  readonly cliRuntime: Pick<CliRuntime, 'onSignal' | 'offSignal'>;
 };
 
 type DevServerState = {
@@ -140,23 +142,26 @@ const createRestartHandler = (
   };
 };
 
-const registerSignalHandlers = (onSignal: () => Promise<void>): (() => void) => {
+const registerSignalHandlers = (
+  runtime: Pick<CliRuntime, 'onSignal' | 'offSignal'>,
+  onSignal: () => Promise<void>,
+): (() => void) => {
   const handler = (): void => {
     void onSignal();
   };
 
-  process.on('SIGINT', handler);
-  process.on('SIGTERM', handler);
+  runtime.onSignal('SIGINT', handler);
+  runtime.onSignal('SIGTERM', handler);
 
   return () => {
-    process.off('SIGINT', handler);
-    process.off('SIGTERM', handler);
+    runtime.offSignal('SIGINT', handler);
+    runtime.offSignal('SIGTERM', handler);
   };
 };
 
 /** @throws {ZeltMultipleBuildHooksError} */
 export const startDevServer = async (options: DevServerOptions): Promise<void> => {
-  const { cwd, config, devConfig } = options;
+  const { cwd, config, devConfig, cliRuntime } = options;
 
   const state: DevServerState = {
     childProcess: undefined,
@@ -171,7 +176,7 @@ export const startDevServer = async (options: DevServerOptions): Promise<void> =
   const shutdown = createShutdownHandler(state);
   const restart = createRestartHandler(state, cwd, devConfig.entry, config);
 
-  registerSignalHandlers(shutdown);
+  registerSignalHandlers(cliRuntime, shutdown);
 
   state.watcher = createWatcher({
     cwd,

--- a/packages/cli/src/dev.command.ts
+++ b/packages/cli/src/dev.command.ts
@@ -1,4 +1,3 @@
-import { NodeCliConfig } from '@zeltjs/adapter-node';
 import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
@@ -7,9 +6,6 @@ import type { ZeltConfigLoadError } from './cli.errors';
 import { isZeltConfigLoadError, isZeltNoEntryError, ZeltNoEntryError } from './cli.errors';
 import type { DevConfig } from './config/config.types';
 import { loadZeltConfig } from './config/index';
-import { startDevServer } from './dev-server.lib';
-
-const cliConfig = new NodeCliConfig();
 
 type DevArgs = {
   readonly config?: string;
@@ -40,7 +36,12 @@ const runDev = async (cwd: string, typedArgs: DevArgs): Promise<void> => {
     throw new ZeltNoEntryError({});
   }
 
-  await startDevServer({ cwd, config, devConfig: { ...devConfig, entry: devConfig.entry } });
+  const devServer = await import('./dev-server.lib');
+  await devServer.startDevServer({
+    cwd,
+    config,
+    devConfig: { ...devConfig, entry: devConfig.entry },
+  });
 };
 
 const handleError = (error: DevError): void => {
@@ -77,7 +78,7 @@ export const devCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cwd = cliConfig.cwd();
+    const cwd = process.cwd();
     const typedArgs: DevArgs = args;
 
     try {

--- a/packages/cli/src/dev.command.ts
+++ b/packages/cli/src/dev.command.ts
@@ -4,6 +4,7 @@ import { match } from 'ts-pattern';
 
 import type { ZeltConfigLoadError } from './cli.errors';
 import { isZeltConfigLoadError, isZeltNoEntryError, ZeltNoEntryError } from './cli.errors';
+import { nodeCliRuntime } from './cli-runtime.lib';
 import type { DevConfig } from './config/config.types';
 import { loadZeltConfig } from './config/index';
 
@@ -35,12 +36,14 @@ const runDev = async (cwd: string, typedArgs: DevArgs): Promise<void> => {
   if (devConfig.entry === undefined) {
     throw new ZeltNoEntryError({});
   }
+  const entry = devConfig.entry;
 
   const devServer = await import('./dev-server.lib');
   await devServer.startDevServer({
     cwd,
     config,
-    devConfig: { ...devConfig, entry: devConfig.entry },
+    devConfig: { ...devConfig, entry },
+    cliRuntime: nodeCliRuntime,
   });
 };
 
@@ -78,7 +81,7 @@ export const devCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const cwd = process.cwd();
+    const cwd = nodeCliRuntime.cwd();
     const typedArgs: DevArgs = args;
 
     try {

--- a/packages/cli/src/graphql.command.test.ts
+++ b/packages/cli/src/graphql.command.test.ts
@@ -1,0 +1,30 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { runGraphqlCodegen } from './graphql.command';
+
+describe('zelt graphql codegen', () => {
+  it('passes schema and out paths to schema-first codegen without loading an app', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zelt-graphql-codegen-'));
+    const schema = join(dir, 'schema.graphql');
+    const out = join(dir, 'generated.ts');
+    await writeFile(schema, 'type Query { viewer: String }', 'utf8');
+    const calls: unknown[] = [];
+
+    await runGraphqlCodegen(
+      dir,
+      { schema: 'schema.graphql', out: 'generated.ts' },
+      async (options) => {
+        calls.push(options);
+        await writeFile(options.out, '// generated\n', 'utf8');
+        return { changed: true };
+      },
+    );
+
+    expect(calls).toEqual([{ schema, out }]);
+    await expect(readFile(out, 'utf8')).resolves.toBe('// generated\n');
+  });
+});

--- a/packages/cli/src/graphql.command.ts
+++ b/packages/cli/src/graphql.command.ts
@@ -4,6 +4,9 @@ import { pathToFileURL } from 'node:url';
 
 import { defineCommand } from 'citty';
 import consola from 'consola';
+import { match, P } from 'ts-pattern';
+
+import { nodeCliRuntime } from './cli-runtime.lib';
 
 type GraphqlCodegenArgs = {
   readonly schema?: string;
@@ -21,21 +24,50 @@ type GraphqlCodegenResult = {
 
 type GraphqlCodegenRunner = (options: GraphqlCodegenOptions) => Promise<GraphqlCodegenResult>;
 
-const toRecord = (value: unknown): Readonly<Record<string, unknown>> | undefined =>
-  typeof value === 'object' && value !== null
-    ? (value as Readonly<Record<string, unknown>>)
-    : undefined;
+type GraphqlCodegenModule = {
+  readonly generateSchemaFirstCodegen: unknown;
+};
+
+const isCodegenResult = (result: unknown): result is GraphqlCodegenResult =>
+  match(result)
+    .with({ changed: P.boolean }, () => true)
+    .otherwise(() => false);
+
+/** @throws {Error} */
+const readCodegenResult = (result: unknown): GraphqlCodegenResult => {
+  if (!isCodegenResult(result)) {
+    throw new Error('generateSchemaFirstCodegen result must include changed.');
+  }
+  return result;
+};
+
+/** @throws {Error} */
+const toCodegenRunner = (runner: unknown): GraphqlCodegenRunner => {
+  if (typeof runner !== 'function') {
+    throw new Error('@zeltjs/graphql/codegen must export generateSchemaFirstCodegen.');
+  }
+  return async (options) => readCodegenResult(await Reflect.apply(runner, undefined, [options]));
+};
+
+const isCodegenModule = (mod: unknown): mod is GraphqlCodegenModule =>
+  match(mod)
+    .with({ generateSchemaFirstCodegen: P._ }, () => true)
+    .otherwise(() => false);
+
+/** @throws {Error} */
+const readCodegenRunner = (mod: unknown): GraphqlCodegenRunner => {
+  if (!isCodegenModule(mod)) {
+    throw new Error('@zeltjs/graphql/codegen must export a module object.');
+  }
+  return toCodegenRunner(mod.generateSchemaFirstCodegen);
+};
 
 /** @throws {Error} */
 const loadGraphqlCodegen = async (cwd: string): Promise<GraphqlCodegenRunner> => {
   const requireFromCwd = createRequire(resolve(cwd, 'package.json'));
   const codegenModule = requireFromCwd.resolve('@zeltjs/graphql/codegen');
-  const mod = toRecord(await import(pathToFileURL(codegenModule).href));
-  const runner = mod?.['generateSchemaFirstCodegen'];
-  if (typeof runner !== 'function') {
-    throw new Error('@zeltjs/graphql/codegen must export generateSchemaFirstCodegen.');
-  }
-  return (options) => runner(options) as Promise<GraphqlCodegenResult>;
+  const mod: unknown = await import(pathToFileURL(codegenModule).href);
+  return readCodegenRunner(mod);
 };
 
 /** @throws {Error} */
@@ -73,7 +105,7 @@ const codegenCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const result = await runGraphqlCodegen(process.cwd(), args);
+    const result = await runGraphqlCodegen(nodeCliRuntime.cwd(), args);
     consola.success(result.changed ? 'GraphQL codegen completed' : 'GraphQL codegen unchanged');
   },
 });

--- a/packages/cli/src/graphql.command.ts
+++ b/packages/cli/src/graphql.command.ts
@@ -1,0 +1,89 @@
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { defineCommand } from 'citty';
+import consola from 'consola';
+
+type GraphqlCodegenArgs = {
+  readonly schema?: string;
+  readonly out?: string;
+};
+
+type GraphqlCodegenOptions = {
+  readonly schema: string;
+  readonly out: string;
+};
+
+type GraphqlCodegenResult = {
+  readonly changed: boolean;
+};
+
+type GraphqlCodegenRunner = (options: GraphqlCodegenOptions) => Promise<GraphqlCodegenResult>;
+
+const toRecord = (value: unknown): Readonly<Record<string, unknown>> | undefined =>
+  typeof value === 'object' && value !== null
+    ? (value as Readonly<Record<string, unknown>>)
+    : undefined;
+
+/** @throws {Error} */
+const loadGraphqlCodegen = async (cwd: string): Promise<GraphqlCodegenRunner> => {
+  const requireFromCwd = createRequire(resolve(cwd, 'package.json'));
+  const codegenModule = requireFromCwd.resolve('@zeltjs/graphql/codegen');
+  const mod = toRecord(await import(pathToFileURL(codegenModule).href));
+  const runner = mod?.['generateSchemaFirstCodegen'];
+  if (typeof runner !== 'function') {
+    throw new Error('@zeltjs/graphql/codegen must export generateSchemaFirstCodegen.');
+  }
+  return (options) => runner(options) as Promise<GraphqlCodegenResult>;
+};
+
+/** @throws {Error} */
+export const runGraphqlCodegen = async (
+  cwd: string,
+  args: GraphqlCodegenArgs,
+  runner?: GraphqlCodegenRunner,
+): Promise<GraphqlCodegenResult> => {
+  if (!args.schema) {
+    throw new Error('zelt graphql codegen requires --schema.');
+  }
+  if (!args.out) {
+    throw new Error('zelt graphql codegen requires --out.');
+  }
+  const codegen = runner ?? (await loadGraphqlCodegen(cwd));
+  return codegen({
+    schema: resolve(cwd, args.schema),
+    out: resolve(cwd, args.out),
+  });
+};
+
+const codegenCommand = defineCommand({
+  meta: {
+    name: 'codegen',
+    description: 'Generate schema-first GraphQL TypeScript helpers from SDL',
+  },
+  args: {
+    schema: {
+      type: 'string',
+      description: 'Path to schema.graphql',
+    },
+    out: {
+      type: 'string',
+      description: 'Generated TypeScript output path',
+    },
+  },
+  async run({ args }) {
+    const result = await runGraphqlCodegen(process.cwd(), args);
+    consola.success(result.changed ? 'GraphQL codegen completed' : 'GraphQL codegen unchanged');
+  },
+});
+
+export const graphqlCommand = defineCommand({
+  meta: {
+    name: 'graphql',
+    description: 'GraphQL development commands',
+  },
+  subCommands: {
+    codegen: codegenCommand,
+  },
+});

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty';
 
 import { buildCommand } from './build.command';
 import { devCommand } from './dev.command';
+import { graphqlCommand } from './graphql.command';
 import { runCommandDef } from './run.command';
 
 export const mainCommand = defineCommand({
@@ -13,6 +14,7 @@ export const mainCommand = defineCommand({
   subCommands: {
     build: buildCommand,
     dev: devCommand,
+    graphql: graphqlCommand,
     run: runCommandDef,
   },
 });

--- a/packages/cli/src/run.command.ts
+++ b/packages/cli/src/run.command.ts
@@ -12,6 +12,7 @@ import {
   ZeltCliExecutionError,
   ZeltNoCliEntryError,
 } from './cli.errors';
+import { nodeCliRuntime } from './cli-runtime.lib';
 import type { CliConfig } from './config/config.types';
 import { loadZeltConfig } from './config/index';
 
@@ -91,7 +92,7 @@ export const runCommandDef = defineCommand({
     },
   },
   async run({ args, rawArgs }) {
-    const cwd = process.cwd();
+    const cwd = nodeCliRuntime.cwd();
     // citty types config as `string` but it's actually `string | undefined` at runtime when omitted
     const configFile = args.config || undefined;
     const cliArgs = rawArgs.filter(
@@ -103,7 +104,7 @@ export const runCommandDef = defineCommand({
     } catch (error) {
       if (isRunError(error)) {
         handleError(error, (code) => {
-          process.exitCode = code;
+          nodeCliRuntime.setExitCode(code);
         });
       } else {
         throw error;

--- a/packages/cli/src/run.command.ts
+++ b/packages/cli/src/run.command.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'node:child_process';
 
-import { NodeCliConfig } from '@zeltjs/adapter-node';
 import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
@@ -15,8 +14,6 @@ import {
 } from './cli.errors';
 import type { CliConfig } from './config/config.types';
 import { loadZeltConfig } from './config/index';
-
-const cliConfig = new NodeCliConfig();
 
 type RunError =
   | InstanceType<typeof ZeltConfigLoadError>
@@ -94,7 +91,7 @@ export const runCommandDef = defineCommand({
     },
   },
   async run({ args, rawArgs }) {
-    const cwd = cliConfig.cwd();
+    const cwd = process.cwd();
     // citty types config as `string` but it's actually `string | undefined` at runtime when omitted
     const configFile = args.config || undefined;
     const cliArgs = rawArgs.filter(
@@ -105,7 +102,9 @@ export const runCommandDef = defineCommand({
       await runCli(cwd, configFile, cliArgs);
     } catch (error) {
       if (isRunError(error)) {
-        handleError(error, (code) => cliConfig.setExitCode(code));
+        handleError(error, (code) => {
+          process.exitCode = code;
+        });
       } else {
         throw error;
       }

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -22,6 +22,8 @@ export default mergeConfig(
           '../core/src/internal-bridge/errors.ts',
         ),
         '@zeltjs/core': path.resolve(__dirname, '../core/src/index.ts'),
+        '@zeltjs/adapter-node': path.resolve(__dirname, '../adapter-node/src/index.ts'),
+        '@zeltjs/unsafe-type-lib': path.resolve(__dirname, '../unsafe-type-lib/src/index.ts'),
       },
     },
   }),

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -22,8 +22,6 @@ export default mergeConfig(
           '../core/src/internal-bridge/errors.ts',
         ),
         '@zeltjs/core': path.resolve(__dirname, '../core/src/index.ts'),
-        '@zeltjs/adapter-node': path.resolve(__dirname, '../adapter-node/src/index.ts'),
-        '@zeltjs/unsafe-type-lib': path.resolve(__dirname, '../unsafe-type-lib/src/index.ts'),
       },
     },
   }),

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -21,6 +21,16 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
+    },
+    "./codegen": {
+      "import": {
+        "types": "./dist/codegen.d.ts",
+        "default": "./dist/codegen.js"
+      },
+      "require": {
+        "types": "./dist/codegen.d.cts",
+        "default": "./dist/codegen.cjs"
+      }
     }
   },
   "files": [

--- a/packages/graphql/src/args.lib.ts
+++ b/packages/graphql/src/args.lib.ts
@@ -23,16 +23,29 @@ const isThenable = (value: unknown): boolean => {
 export const runWithGraphqlArgs = <T>(args: Readonly<Record<string, unknown>>, fn: () => T): T =>
   graphqlArgsStorage.run(args, fn);
 
-/** @throws {GraphqlArgsValidationError | Error} */
-export const args = <Schema extends StandardSchemaV1>(
-  schema: Schema,
-): StandardSchemaV1.InferOutput<Schema> => {
+/** @throws {Error} */
+const getGraphqlArgsContext = (): Readonly<Record<string, unknown>> => {
   const rawArgs = graphqlArgsStorage.getStore();
   if (rawArgs === undefined) {
     throw new Error(
       'args() requires a GraphQL args context; call it only as a resolver method default parameter.',
     );
   }
+  return rawArgs;
+};
+
+/**
+ * @internal Used by generated schema-first field helpers.
+ * @throws {Error}
+ */
+export const readGraphqlArgs = <Output extends Readonly<Record<string, unknown>>>(): Output =>
+  getGraphqlArgsContext() as Output;
+
+/** @throws {GraphqlArgsValidationError | Error} */
+export const validateGraphqlArgs = <Schema extends StandardSchemaV1>(
+  schema: Schema,
+): StandardSchemaV1.InferOutput<Schema> => {
+  const rawArgs = getGraphqlArgsContext();
 
   const result = schema['~standard'].validate(rawArgs);
   if (result instanceof Promise || isThenable(result)) {
@@ -43,3 +56,8 @@ export const args = <Schema extends StandardSchemaV1>(
   }
   return result.value;
 };
+
+/** @throws {GraphqlArgsValidationError | Error} */
+export const args = <Schema extends StandardSchemaV1>(
+  schema: Schema,
+): StandardSchemaV1.InferOutput<Schema> => validateGraphqlArgs(schema);

--- a/packages/graphql/src/args.lib.ts
+++ b/packages/graphql/src/args.lib.ts
@@ -39,7 +39,12 @@ const getGraphqlArgsContext = (): Readonly<Record<string, unknown>> => {
  * @throws {Error}
  */
 export const readGraphqlArgs = <Output extends Readonly<Record<string, unknown>>>(): Output =>
-  getGraphqlArgsContext() as Output;
+  narrowGraphqlArgs<Output>(getGraphqlArgsContext());
+
+function narrowGraphqlArgs<Output>(args: Readonly<Record<string, unknown>>): Output;
+function narrowGraphqlArgs(args: Readonly<Record<string, unknown>>): unknown {
+  return args;
+}
 
 /** @throws {GraphqlArgsValidationError | Error} */
 export const validateGraphqlArgs = <Schema extends StandardSchemaV1>(

--- a/packages/graphql/src/args.test.ts
+++ b/packages/graphql/src/args.test.ts
@@ -1,7 +1,7 @@
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 
-import { args, runWithGraphqlArgs } from './args.lib';
+import { args, readGraphqlArgs, runWithGraphqlArgs, validateGraphqlArgs } from './args.lib';
 import type { GeneratedGraphqlRuntime } from './graphql-runtime.lib';
 import { createGraphqlExecutor, executeGraphqlRequest } from './graphql-runtime.lib';
 import { Query, Resolver } from './index';
@@ -41,6 +41,20 @@ describe('args', () => {
     expect(() => runWithGraphqlArgs({ id: 'user-1' }, () => args(AsyncInput))).toThrow(
       'args() does not support async validation schemas.',
     );
+  });
+
+  it('lets generated helpers read raw GraphQL args from the current context', () => {
+    const output = runWithGraphqlArgs({ id: 'product-1' }, () =>
+      readGraphqlArgs<{ readonly id: string }>(),
+    );
+
+    expect(output.id).toBe('product-1');
+  });
+
+  it('lets generated helpers validate GraphQL args with Standard Schema', () => {
+    const output = runWithGraphqlArgs({ id: 'product-1' }, () => validateGraphqlArgs(GetUserInput));
+
+    expect(output).toEqual({ id: 'product-1' });
   });
 });
 

--- a/packages/graphql/src/codegen.ts
+++ b/packages/graphql/src/codegen.ts
@@ -1,0 +1,5 @@
+export type {
+  SchemaFirstCodegenOptions,
+  SchemaFirstCodegenResult,
+} from './schema-first-codegen.lib';
+export { generateSchemaFirstCodegen, renderSchemaFirstCodegen } from './schema-first-codegen.lib';

--- a/packages/graphql/src/graphql-metadata.lib.ts
+++ b/packages/graphql/src/graphql-metadata.lib.ts
@@ -8,6 +8,7 @@ export type GraphqlOperationKind = 'query' | 'mutation' | 'resolveField';
 
 export type GraphqlOperationMetadata = {
   readonly kind: GraphqlOperationKind;
+  readonly fieldName?: string;
 };
 
 export type GraphqlControllerMetadata = {

--- a/packages/graphql/src/graphql-plugin.lib.ts
+++ b/packages/graphql/src/graphql-plugin.lib.ts
@@ -188,15 +188,29 @@ export const generateGraphqlSdl = async (
   return { changed: standaloneChanged || runtimeChanged };
 };
 
-const buildGenerateOptions = (options: GraphqlPluginOptions): GenerateGraphqlSdlOptions => ({
-  distDir: options.outDir ?? './dist',
-  ...(options.mode !== undefined && { mode: options.mode }),
-  ...(options.schema !== undefined && { schema: options.schema }),
-  ...(options.runtimeModule !== undefined && { runtimeModule: options.runtimeModule }),
-  ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
-  ...(options.schemaAdapter !== undefined && { schemaAdapter: options.schemaAdapter }),
-  ...(options.schemaResolver !== undefined && { schemaResolver: options.schemaResolver }),
-});
+type WritableGenerateGraphqlSdlOptions = {
+  -readonly [Key in keyof GenerateGraphqlSdlOptions]: GenerateGraphqlSdlOptions[Key];
+};
+
+const addGenerateOptions = (
+  generateOptions: WritableGenerateGraphqlSdlOptions,
+  options: GraphqlPluginOptions,
+): void => {
+  if (options.mode !== undefined) generateOptions.mode = options.mode;
+  if (options.schema !== undefined) generateOptions.schema = options.schema;
+  if (options.runtimeModule !== undefined) generateOptions.runtimeModule = options.runtimeModule;
+  if (options.tsconfig !== undefined) generateOptions.tsconfig = options.tsconfig;
+  if (options.schemaAdapter !== undefined) generateOptions.schemaAdapter = options.schemaAdapter;
+  if (options.schemaResolver !== undefined) generateOptions.schemaResolver = options.schemaResolver;
+};
+
+const buildGenerateOptions = (options: GraphqlPluginOptions): GenerateGraphqlSdlOptions => {
+  const generateOptions: WritableGenerateGraphqlSdlOptions = {
+    distDir: options.outDir ?? './dist',
+  };
+  addGenerateOptions(generateOptions, options);
+  return generateOptions;
+};
 
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
 export const graphqlPlugin = (options: GraphqlPluginOptions = {}): ZeltPlugin<HttpStaticApp> => ({

--- a/packages/graphql/src/graphql-plugin.lib.ts
+++ b/packages/graphql/src/graphql-plugin.lib.ts
@@ -5,15 +5,20 @@ import { dirname, resolve } from 'node:path';
 import type { ZeltPlugin } from '@zeltjs/cli';
 import type { ControllerClass, HttpStaticCapabilities } from '@zeltjs/core';
 import { getGraphqlControllerMetadata } from './graphql-metadata.lib';
+import type { GraphqlRuntimeManifest } from './graphql-runtime.lib';
 import type { GenerateSdlOptions } from './graphql-sdl-generator.lib';
 import { generateGraphqlRuntimeForResolvers } from './graphql-sdl-generator.lib';
+import { generateSchemaFirstGraphqlRuntimeForResolvers } from './schema-first-runtime.lib';
 
 type HttpStaticApp = {
   readonly http: Pick<HttpStaticCapabilities, 'getControllers'>;
 };
 
 export type GraphqlPluginOptions = {
+  readonly mode?: 'code-first' | 'schema-first';
   readonly outDir?: string;
+  readonly schema?: string;
+  readonly runtimeModule?: string;
   readonly tsconfig?: string;
   readonly schemaAdapter?: GenerateSdlOptions['schemaAdapter'];
   readonly schemaResolver?: GenerateSdlOptions['schemaResolver'];
@@ -21,6 +26,9 @@ export type GraphqlPluginOptions = {
 
 export type GenerateGraphqlSdlOptions = GenerateSdlOptions & {
   readonly distDir: string;
+  readonly mode?: 'code-first' | 'schema-first';
+  readonly schema?: string;
+  readonly runtimeModule?: string;
 };
 
 export type GenerateGraphqlSdlResult = {
@@ -58,13 +66,12 @@ const collectGraphqlEndpoints = (
   return endpoints;
 };
 
-const buildRuntimeModule = (
-  runtime: Awaited<ReturnType<typeof generateGraphqlRuntimeForResolvers>>,
-): string => `export const graphqlRuntime = ${JSON.stringify(runtime, null, 2)};\n`;
+const buildRuntimeModule = (runtime: GraphqlRuntimeManifest): string =>
+  `export const graphqlRuntime = ${JSON.stringify(runtime, null, 2)};\n`;
 
 const writeRuntimeModule = async (
   runtimeModule: string,
-  runtime: Awaited<ReturnType<typeof generateGraphqlRuntimeForResolvers>>,
+  runtime: GraphqlRuntimeManifest,
 ): Promise<boolean> => {
   const runtimePath = resolve(runtimeModule);
   await mkdir(dirname(runtimePath), { recursive: true });
@@ -121,6 +128,49 @@ const generateRuntimeModules = async (
   return changed;
 };
 
+/** @throws {Error} */
+const resolveSchemaFirstRuntimeModule = (
+  endpoints: readonly GraphqlEndpoint[],
+  options: GenerateGraphqlSdlOptions,
+): string => {
+  if (options.runtimeModule) return options.runtimeModule;
+  const runtimeModules = endpoints.flatMap((endpoint) =>
+    endpoint.runtimeModule ? [endpoint.runtimeModule] : [],
+  );
+  const first = runtimeModules[0];
+  if (!first) {
+    throw new Error('schema-first graphqlPlugin requires runtimeModule.');
+  }
+  if (runtimeModules.length > 1) {
+    throw new Error(
+      'schema-first graphqlPlugin requires runtimeModule when multiple endpoints exist.',
+    );
+  }
+  return first;
+};
+
+/** @throws {Error | UnsupportedTypeScriptVersionError} */
+const generateSchemaFirstRuntimeModule = async (
+  endpoints: readonly GraphqlEndpoint[],
+  options: GenerateGraphqlSdlOptions,
+): Promise<boolean> => {
+  if (!options.schema) {
+    throw new Error('schema-first graphqlPlugin requires schema.');
+  }
+  const runtimeModule = resolveSchemaFirstRuntimeModule(endpoints, options);
+  const schemaSdl = await readFile(resolve(options.schema), 'utf8');
+  const runtime = await generateSchemaFirstGraphqlRuntimeForResolvers(
+    endpoints.flatMap((endpoint) => endpoint.resolvers),
+    {
+      schemaSdl,
+      ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
+    },
+  );
+  const runtimeChanged = await writeRuntimeModule(runtimeModule, runtime);
+  const schemaChanged = await writeIfChanged(toRuntimeSchemaPath(runtimeModule), schemaSdl);
+  return runtimeChanged || schemaChanged;
+};
+
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
 export const generateGraphqlSdl = async (
   app: Pick<HttpStaticCapabilities, 'getControllers'>,
@@ -130,6 +180,9 @@ export const generateGraphqlSdl = async (
   await mkdir(distDir, { recursive: true });
 
   const endpoints = collectGraphqlEndpoints(app.getControllers());
+  if (options.mode === 'schema-first' || options.schema !== undefined) {
+    return { changed: await generateSchemaFirstRuntimeModule(endpoints, options) };
+  }
   const standaloneChanged = await generateStandaloneSchema(endpoints, distDir, options);
   const runtimeChanged = await generateRuntimeModules(endpoints, options);
   return { changed: standaloneChanged || runtimeChanged };
@@ -137,6 +190,9 @@ export const generateGraphqlSdl = async (
 
 const buildGenerateOptions = (options: GraphqlPluginOptions): GenerateGraphqlSdlOptions => ({
   distDir: options.outDir ?? './dist',
+  ...(options.mode !== undefined && { mode: options.mode }),
+  ...(options.schema !== undefined && { schema: options.schema }),
+  ...(options.runtimeModule !== undefined && { runtimeModule: options.runtimeModule }),
   ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
   ...(options.schemaAdapter !== undefined && { schemaAdapter: options.schemaAdapter }),
   ...(options.schemaResolver !== undefined && { schemaResolver: options.schemaResolver }),

--- a/packages/graphql/src/graphql-runtime.lib.ts
+++ b/packages/graphql/src/graphql-runtime.lib.ts
@@ -20,11 +20,16 @@ export type GeneratedGraphqlBinding = {
   readonly method: string;
 };
 
+// GeneratedGraphqlRuntime is the runtime manifest consumed by the executor.
+// Code-first generation is one producer. Schema-first generation can produce
+// the same shape from SDL + resolver bindings.
 export type GeneratedGraphqlRuntime = {
   readonly schemaSdl: string;
   readonly bindings: Record<string, Record<string, GeneratedGraphqlBinding>>;
   readonly enumFields?: Record<string, Record<string, Readonly<Record<string, string>>>>;
 };
+
+export type GraphqlRuntimeManifest = GeneratedGraphqlRuntime;
 
 export type GraphqlRequestPayload = {
   readonly query: string;

--- a/packages/graphql/src/graphql-sdl-generator.lib.ts
+++ b/packages/graphql/src/graphql-sdl-generator.lib.ts
@@ -5,7 +5,7 @@ import { getOrCreateProgram, getTypeMetadata } from '@zeltjs/decorator-metadata/
 
 import type { GqlSchemaResolver, GraphqlArgsSchemaRef } from './analyze-gql-args.lib';
 import { extractGraphqlArgsRef, resolveGraphqlArgs } from './analyze-gql-args.lib';
-import type { GraphqlResolverClass } from './graphql-metadata.lib';
+import type { GraphqlOperationMetadata, GraphqlResolverClass } from './graphql-metadata.lib';
 import type { GeneratedGraphqlRuntime } from './graphql-runtime.lib';
 import type { GraphqlSchemaAdapter } from './json-schema-to-graphql-args.lib';
 import { renderGraphqlArgs } from './json-schema-to-graphql-args.lib';
@@ -67,10 +67,16 @@ function narrowToTypeReference(type: TSType): TSType {
   return type;
 }
 
-const getOperationKind = (method: MethodInfo): OperationKind | undefined => {
+const getOperationMetadata = (method: MethodInfo): GraphqlOperationMetadata | undefined => {
   for (const prop of method.props) {
     const kind: unknown = Reflect.get(prop, 'kind');
-    if (kind === 'query' || kind === 'mutation' || kind === 'resolveField') return kind;
+    if (kind === 'query' || kind === 'mutation' || kind === 'resolveField') {
+      const fieldName: unknown = Reflect.get(prop, 'fieldName');
+      return {
+        kind,
+        ...(typeof fieldName === 'string' ? { fieldName } : {}),
+      };
+    }
   }
   return undefined;
 };
@@ -310,6 +316,7 @@ const registerRootMethod = (
   state: AnalysisState,
   resolverName: string,
   methodName: string,
+  fieldName: string,
   returnType: TypeInfo,
   kind: 'query' | 'mutation',
   names: MethodTypeNames | undefined,
@@ -317,9 +324,9 @@ const registerRootMethod = (
 ): void => {
   const fields = kind === 'query' ? state.roots.query : state.roots.mutation;
   const rootTypeName = kind === 'query' ? 'Query' : 'Mutation';
-  addRootField(fields, methodName, returnType, names?.returnTypeName, argsRendered, state.typeCtx);
-  addEnumFieldMappingForType(state.typeCtx, rootTypeName, methodName, returnType);
-  addRuntimeBinding(state.bindings, rootTypeName, methodName, resolverName, methodName);
+  addRootField(fields, fieldName, returnType, names?.returnTypeName, argsRendered, state.typeCtx);
+  addEnumFieldMappingForType(state.typeCtx, rootTypeName, fieldName, returnType);
+  addRuntimeBinding(state.bindings, rootTypeName, fieldName, resolverName, methodName);
 };
 
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
@@ -327,20 +334,15 @@ const registerFieldMethod = (
   state: AnalysisState,
   resolverName: string,
   methodName: string,
+  fieldName: string,
   returnType: TypeInfo,
   names: MethodTypeNames | undefined,
 ): void => {
   if (!names?.parentTypeName) {
     throw new Error(`@ResolveField() ${resolverName}.${methodName} requires named parent type`);
   }
-  addGraphqlField(
-    state.typeCtx,
-    names.parentTypeName,
-    methodName,
-    returnType,
-    names.returnTypeName,
-  );
-  addRuntimeBinding(state.bindings, names.parentTypeName, methodName, resolverName, methodName);
+  addGraphqlField(state.typeCtx, names.parentTypeName, fieldName, returnType, names.returnTypeName);
+  addRuntimeBinding(state.bindings, names.parentTypeName, fieldName, resolverName, methodName);
 };
 
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
@@ -348,6 +350,7 @@ const registerResolverMethod = (
   state: AnalysisState,
   resolverName: string,
   methodName: string,
+  fieldName: string,
   returnType: TypeInfo,
   kind: OperationKind,
   names: MethodTypeNames | undefined,
@@ -359,10 +362,19 @@ const registerResolverMethod = (
         `args() on @ResolveField() is not supported yet: ${resolverName}.${methodName}`,
       );
     }
-    registerFieldMethod(state, resolverName, methodName, returnType, names);
+    registerFieldMethod(state, resolverName, methodName, fieldName, returnType, names);
     return;
   }
-  registerRootMethod(state, resolverName, methodName, returnType, kind, names, argsRendered);
+  registerRootMethod(
+    state,
+    resolverName,
+    methodName,
+    fieldName,
+    returnType,
+    kind,
+    names,
+    argsRendered,
+  );
 };
 
 /** @throws {Error} */
@@ -401,8 +413,8 @@ const analyzeResolver = async (
 
   for (const method of metadata.methods) {
     if (typeof method.name !== 'string') continue;
-    const operationKind = getOperationKind(method);
-    if (!operationKind) continue;
+    const operation = getOperationMetadata(method);
+    if (!operation) continue;
 
     const names = methodTypeNames.get(method.name);
     const argsRendered = await renderMethodArgs(names, resolver.name, method.name, options);
@@ -410,8 +422,9 @@ const analyzeResolver = async (
       state,
       resolver.name,
       method.name,
+      operation.fieldName ?? method.name,
       method.returnType,
-      operationKind,
+      operation.kind,
       names,
       argsRendered,
     );

--- a/packages/graphql/src/graphql.decorator.ts
+++ b/packages/graphql/src/graphql.decorator.ts
@@ -26,8 +26,13 @@ export const Resolver = (): ClassDecoratorFn =>
   });
 
 /** @throws {E} */
-const createGraphqlOperationDecorator = (kind: GraphqlOperationKind) => (): MethodDecoratorFn =>
-  createMethodDecorator<GraphqlOperationMetadata>({ kind });
+const createGraphqlOperationDecorator =
+  (kind: GraphqlOperationKind) =>
+  (fieldName?: string): MethodDecoratorFn =>
+    createMethodDecorator<GraphqlOperationMetadata>({
+      kind,
+      ...(fieldName !== undefined ? { fieldName } : {}),
+    });
 
 export const Query = createGraphqlOperationDecorator('query');
 export const Mutation = createGraphqlOperationDecorator('mutation');

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,7 +1,13 @@
 export type { StandardSchemaV1 } from '@standard-schema/spec';
 export type { GqlSchemaResolver, GraphqlArgsSchemaRef } from './analyze-gql-args.lib';
 export type { StandardSchemaIssue } from './args.lib';
-export { args, GraphqlArgsValidationError, runWithGraphqlArgs } from './args.lib';
+export {
+  args,
+  GraphqlArgsValidationError,
+  readGraphqlArgs,
+  runWithGraphqlArgs,
+  validateGraphqlArgs,
+} from './args.lib';
 export { Mutation, Query, ResolveField, Resolver } from './graphql.decorator';
 export type { GraphqlChildOptions, GraphqlOptions } from './graphql-child.lib';
 export { graphql } from './graphql-child.lib';
@@ -29,6 +35,7 @@ export type {
   GeneratedGraphqlRuntime,
   GraphqlExecutor,
   GraphqlRequestPayload,
+  GraphqlRuntimeManifest,
 } from './graphql-runtime.lib';
 export {
   createGraphqlExecutor,
@@ -41,5 +48,11 @@ export {
   generateSdlForResolvers,
 } from './graphql-sdl-generator.lib';
 export type { GraphqlArg, GraphqlSchemaAdapter } from './json-schema-to-graphql-args.lib';
+export type {
+  SchemaFirstCodegenOptions,
+  SchemaFirstCodegenResult,
+} from './schema-first-codegen.lib';
+export { generateSchemaFirstCodegen, renderSchemaFirstCodegen } from './schema-first-codegen.lib';
+export { generateSchemaFirstGraphqlRuntimeForResolvers } from './schema-first-runtime.lib';
 export type { GraphqlTypeContext, GraphqlTypeResult } from './type-to-graphql.lib';
 export { typeInfoToGraphqlType } from './type-to-graphql.lib';

--- a/packages/graphql/src/plugin.test.ts
+++ b/packages/graphql/src/plugin.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -70,5 +70,48 @@ describe('graphqlPlugin', () => {
     expect(generated).toContain('"schemaSdl"');
     expect(generated).toContain('"ViewerResolver"');
     expect(generated).toContain('"viewer"');
+  });
+
+  it('generates a schema-first runtime helper from SDL and resolver bindings', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'zelt-graphql-schema-first-'));
+    const schema = join(outDir, 'schema.graphql');
+    const runtimeModule = join(outDir, 'schema-first-runtime.js');
+    await writeFile(
+      schema,
+      `type Query {
+  viewer: ViewerPublic
+}
+
+type ViewerPublic {
+  id: String!
+}
+`,
+      'utf8',
+    );
+    const child = graphql({ path: '/graphql', resolvers: [ViewerResolver], runtimeModule });
+    const plugin = graphqlPlugin({
+      mode: 'schema-first',
+      schema,
+      runtimeModule,
+      tsconfig: resolve(__dirname, '../tsconfig.json'),
+    });
+
+    await plugin.preBuild?.({
+      cwd: process.cwd(),
+      build: {},
+      loadStaticApp: async () => ({
+        http: { getControllers: () => child.blueprint().getControllers() },
+      }),
+    });
+
+    const generated = await readFile(runtimeModule, 'utf8');
+    expect(generated).toContain('export const graphqlRuntime');
+    expect(generated).toContain('"schemaSdl"');
+    expect(generated).toContain('viewer: ViewerPublic\\n');
+    expect(generated).toContain('"ViewerResolver"');
+    expect(generated).toContain('"viewer"');
+    await expect(readFile(runtimeModule.replace(/\.js$/, '.graphql'), 'utf8')).resolves.toContain(
+      'type Query',
+    );
   });
 });

--- a/packages/graphql/src/schema-first-codegen.lib.ts
+++ b/packages/graphql/src/schema-first-codegen.lib.ts
@@ -1,0 +1,211 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import type {
+  FieldDefinitionNode,
+  InputValueDefinitionNode,
+  ObjectTypeDefinitionNode,
+  TypeNode,
+} from 'graphql';
+import { Kind, parse } from 'graphql';
+
+const BUILTIN_SCALARS = new Map<string, string>([
+  ['ID', 'string'],
+  ['String', 'string'],
+  ['Int', 'number'],
+  ['Float', 'number'],
+  ['Boolean', 'boolean'],
+]);
+
+export type SchemaFirstCodegenOptions = {
+  readonly schema: string;
+  readonly out: string;
+};
+
+export type SchemaFirstCodegenResult = {
+  readonly changed: boolean;
+};
+
+type SchemaIndex = {
+  readonly objectTypes: ReadonlyMap<string, ObjectTypeDefinitionNode>;
+  readonly customScalars: ReadonlySet<string>;
+  readonly unsupportedTypes: ReadonlyMap<string, string>;
+};
+
+type TypeRenderOptions = {
+  readonly nullable: boolean;
+  readonly optional: boolean;
+};
+
+const writeIfChanged = async (path: string, content: string): Promise<boolean> => {
+  if (existsSync(path)) {
+    const existing = await readFile(path, 'utf8');
+    if (existing === content) return false;
+  }
+  await writeFile(path, content, 'utf8');
+  return true;
+};
+
+const buildSchemaIndex = (schemaSdl: string): SchemaIndex => {
+  const document = parse(schemaSdl);
+  const objectTypes = new Map<string, ObjectTypeDefinitionNode>();
+  const customScalars = new Set<string>();
+  const unsupportedTypes = new Map<string, string>();
+
+  for (const definition of document.definitions) {
+    if (definition.kind === Kind.OBJECT_TYPE_DEFINITION) {
+      objectTypes.set(definition.name.value, definition);
+      continue;
+    }
+    if (definition.kind === Kind.SCALAR_TYPE_DEFINITION) {
+      customScalars.add(definition.name.value);
+      continue;
+    }
+    if (
+      definition.kind === Kind.UNION_TYPE_DEFINITION ||
+      definition.kind === Kind.INTERFACE_TYPE_DEFINITION ||
+      definition.kind === Kind.ENUM_TYPE_DEFINITION ||
+      definition.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION
+    ) {
+      unsupportedTypes.set(definition.name.value, definition.kind);
+    }
+  }
+
+  return { objectTypes, customScalars, unsupportedTypes };
+};
+
+/** @throws {Error} */
+const renderNamedType = (name: string, index: SchemaIndex): string => {
+  const scalar = BUILTIN_SCALARS.get(name);
+  if (scalar) return scalar;
+  if (index.objectTypes.has(name)) return `Gql.${name}`;
+  if (index.customScalars.has(name)) {
+    throw new Error(`Schema-first codegen does not support custom scalar "${name}" yet.`);
+  }
+  if (index.unsupportedTypes.has(name)) {
+    throw new Error(`Schema-first codegen does not support GraphQL type "${name}" yet.`);
+  }
+  throw new Error(`Schema-first codegen does not support GraphQL type "${name}" yet.`);
+};
+
+const parenthesizeArrayElement = (type: string): string =>
+  type.includes(' | ') ? `(${type})` : type;
+
+/** @throws {Error} */
+const renderType = (type: TypeNode, index: SchemaIndex, options: TypeRenderOptions): string => {
+  if (type.kind === Kind.NON_NULL_TYPE) {
+    return renderType(type.type, index, { ...options, nullable: false, optional: false });
+  }
+
+  const nullable = options.nullable;
+  const rendered =
+    type.kind === Kind.LIST_TYPE
+      ? `readonly ${parenthesizeArrayElement(
+          renderType(type.type, index, { nullable: true, optional: false }),
+        )}[]`
+      : renderNamedType(type.name.value, index);
+
+  return nullable ? `${rendered} | null` : rendered;
+};
+
+/** @throws {Error} */
+const renderInputField = (field: InputValueDefinitionNode, index: SchemaIndex): string => {
+  const isOptional = field.type.kind !== Kind.NON_NULL_TYPE;
+  const optional = isOptional ? '?' : '';
+  return `    readonly ${field.name.value}${optional}: ${renderType(field.type, index, {
+    nullable: true,
+    optional: isOptional,
+  })};`;
+};
+
+/** @throws {Error} */
+const renderArgsType = (field: FieldDefinitionNode, index: SchemaIndex): string => {
+  const args = field.arguments ?? [];
+  if (args.length === 0) return 'Record<string, never>';
+  return ['{', ...args.map((arg) => renderInputField(arg, index)), '  }'].join('\n');
+};
+
+/** @throws {Error} */
+const renderObjectField = (field: FieldDefinitionNode, index: SchemaIndex): string => {
+  const isOptional = field.type.kind !== Kind.NON_NULL_TYPE;
+  const optional = isOptional ? '?' : '';
+  return `    readonly ${field.name.value}${optional}: ${renderType(field.type, index, {
+    nullable: true,
+    optional: isOptional,
+  })};`;
+};
+
+/** @throws {Error} */
+const renderObjectType = (type: ObjectTypeDefinitionNode, index: SchemaIndex): string => {
+  const fields = type.fields ?? [];
+  return [
+    `  export type ${type.name.value} = {`,
+    ...fields.map((field) => renderObjectField(field, index)),
+    '  };',
+  ].join('\n');
+};
+
+/** @throws {Error} */
+const renderOperationField = (field: FieldDefinitionNode, index: SchemaIndex): string =>
+  [
+    `    export namespace ${field.name.value} {`,
+    `      export type Args = ${renderArgsType(field, index)};`,
+    `      export type Result = ${renderType(field.type, index, { nullable: true, optional: false })};`,
+    '      export function args(): Args;',
+    '      export function args<Schema extends StandardSchemaV1<unknown, Args>>(',
+    '        schema: Schema,',
+    '      ): StandardSchemaV1.InferOutput<Schema>;',
+    '      export function args(schema?: StandardSchemaV1): Args {',
+    '        return schema ? (validateGraphqlArgs(schema) as Args) : readGraphqlArgs<Args>();',
+    '      }',
+    '    }',
+  ].join('\n');
+
+/** @throws {Error} */
+const renderOperationNamespace = (
+  name: 'Query' | 'Mutation',
+  type: ObjectTypeDefinitionNode | undefined,
+  index: SchemaIndex,
+): string | undefined => {
+  if (!type) return undefined;
+  return [
+    `  export namespace ${name} {`,
+    ...(type.fields ?? []).map((field) => renderOperationField(field, index)),
+    '  }',
+  ].join('\n');
+};
+
+/** @throws {Error} */
+export const renderSchemaFirstCodegen = (schemaSdl: string): string => {
+  const index = buildSchemaIndex(schemaSdl);
+  const objectTypes = [...index.objectTypes.values()].filter(
+    (type) => type.name.value !== 'Query' && type.name.value !== 'Mutation',
+  );
+  const query = index.objectTypes.get('Query');
+  const mutation = index.objectTypes.get('Mutation');
+  const parts = [
+    "import type { StandardSchemaV1 } from '@zeltjs/graphql';",
+    "import { readGraphqlArgs, validateGraphqlArgs } from '@zeltjs/graphql';",
+    '',
+    'export namespace Gql {',
+    renderOperationNamespace('Query', query, index),
+    renderOperationNamespace('Mutation', mutation, index),
+    ...objectTypes.map((type) => renderObjectType(type, index)),
+    '}',
+    '',
+  ].flatMap((part) => (part === undefined ? [] : [part]));
+
+  return parts.join('\n');
+};
+
+/** @throws {Error} */
+export const generateSchemaFirstCodegen = async (
+  options: SchemaFirstCodegenOptions,
+): Promise<SchemaFirstCodegenResult> => {
+  const schemaPath = resolve(options.schema);
+  const outPath = resolve(options.out);
+  const schemaSdl = await readFile(schemaPath, 'utf8');
+  const generated = renderSchemaFirstCodegen(schemaSdl);
+  await mkdir(dirname(outPath), { recursive: true });
+  return { changed: await writeIfChanged(outPath, generated) };
+};

--- a/packages/graphql/src/schema-first-codegen.lib.ts
+++ b/packages/graphql/src/schema-first-codegen.lib.ts
@@ -27,14 +27,13 @@ export type SchemaFirstCodegenResult = {
 };
 
 type SchemaIndex = {
-  readonly objectTypes: ReadonlyMap<string, ObjectTypeDefinitionNode>;
-  readonly customScalars: ReadonlySet<string>;
-  readonly unsupportedTypes: ReadonlyMap<string, string>;
+  readonly objectTypes: Map<string, ObjectTypeDefinitionNode>;
+  readonly customScalars: Set<string>;
+  readonly unsupportedTypes: Map<string, string>;
 };
 
 type TypeRenderOptions = {
   readonly nullable: boolean;
-  readonly optional: boolean;
 };
 
 const writeIfChanged = async (path: string, content: string): Promise<boolean> => {
@@ -46,32 +45,38 @@ const writeIfChanged = async (path: string, content: string): Promise<boolean> =
   return true;
 };
 
-const buildSchemaIndex = (schemaSdl: string): SchemaIndex => {
-  const document = parse(schemaSdl);
-  const objectTypes = new Map<string, ObjectTypeDefinitionNode>();
-  const customScalars = new Set<string>();
-  const unsupportedTypes = new Map<string, string>();
-
-  for (const definition of document.definitions) {
-    if (definition.kind === Kind.OBJECT_TYPE_DEFINITION) {
-      objectTypes.set(definition.name.value, definition);
-      continue;
-    }
-    if (definition.kind === Kind.SCALAR_TYPE_DEFINITION) {
-      customScalars.add(definition.name.value);
-      continue;
-    }
-    if (
-      definition.kind === Kind.UNION_TYPE_DEFINITION ||
-      definition.kind === Kind.INTERFACE_TYPE_DEFINITION ||
-      definition.kind === Kind.ENUM_TYPE_DEFINITION ||
-      definition.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION
-    ) {
-      unsupportedTypes.set(definition.name.value, definition.kind);
-    }
+const registerSchemaDefinition = (
+  index: SchemaIndex,
+  definition: ReturnType<typeof parse>['definitions'][number],
+): void => {
+  if (definition.kind === Kind.OBJECT_TYPE_DEFINITION) {
+    index.objectTypes.set(definition.name.value, definition);
+    return;
   }
+  if (definition.kind === Kind.SCALAR_TYPE_DEFINITION) {
+    index.customScalars.add(definition.name.value);
+    return;
+  }
+  if (
+    definition.kind === Kind.UNION_TYPE_DEFINITION ||
+    definition.kind === Kind.INTERFACE_TYPE_DEFINITION ||
+    definition.kind === Kind.ENUM_TYPE_DEFINITION ||
+    definition.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION
+  ) {
+    index.unsupportedTypes.set(definition.name.value, definition.kind);
+  }
+};
 
-  return { objectTypes, customScalars, unsupportedTypes };
+const buildSchemaIndex = (schemaSdl: string): SchemaIndex => {
+  const index = {
+    objectTypes: new Map<string, ObjectTypeDefinitionNode>(),
+    customScalars: new Set<string>(),
+    unsupportedTypes: new Map<string, string>(),
+  };
+  for (const definition of parse(schemaSdl).definitions) {
+    registerSchemaDefinition(index, definition);
+  }
+  return index;
 };
 
 /** @throws {Error} */
@@ -94,15 +99,13 @@ const parenthesizeArrayElement = (type: string): string =>
 /** @throws {Error} */
 const renderType = (type: TypeNode, index: SchemaIndex, options: TypeRenderOptions): string => {
   if (type.kind === Kind.NON_NULL_TYPE) {
-    return renderType(type.type, index, { ...options, nullable: false, optional: false });
+    return renderType(type.type, index, { nullable: false });
   }
 
   const nullable = options.nullable;
   const rendered =
     type.kind === Kind.LIST_TYPE
-      ? `readonly ${parenthesizeArrayElement(
-          renderType(type.type, index, { nullable: true, optional: false }),
-        )}[]`
+      ? `readonly ${parenthesizeArrayElement(renderType(type.type, index, { nullable: true }))}[]`
       : renderNamedType(type.name.value, index);
 
   return nullable ? `${rendered} | null` : rendered;
@@ -114,7 +117,6 @@ const renderInputField = (field: InputValueDefinitionNode, index: SchemaIndex): 
   const optional = isOptional ? '?' : '';
   return `    readonly ${field.name.value}${optional}: ${renderType(field.type, index, {
     nullable: true,
-    optional: isOptional,
   })};`;
 };
 
@@ -127,11 +129,8 @@ const renderArgsType = (field: FieldDefinitionNode, index: SchemaIndex): string 
 
 /** @throws {Error} */
 const renderObjectField = (field: FieldDefinitionNode, index: SchemaIndex): string => {
-  const isOptional = field.type.kind !== Kind.NON_NULL_TYPE;
-  const optional = isOptional ? '?' : '';
-  return `    readonly ${field.name.value}${optional}: ${renderType(field.type, index, {
+  return `    readonly ${field.name.value}: ${renderType(field.type, index, {
     nullable: true,
-    optional: isOptional,
   })};`;
 };
 
@@ -150,7 +149,7 @@ const renderOperationField = (field: FieldDefinitionNode, index: SchemaIndex): s
   [
     `    export namespace ${field.name.value} {`,
     `      export type Args = ${renderArgsType(field, index)};`,
-    `      export type Result = ${renderType(field.type, index, { nullable: true, optional: false })};`,
+    `      export type Result = ${renderType(field.type, index, { nullable: true })};`,
     '      export function args(): Args;',
     '      export function args<Schema extends StandardSchemaV1<unknown, Args>>(',
     '        schema: Schema,',

--- a/packages/graphql/src/schema-first-codegen.test.ts
+++ b/packages/graphql/src/schema-first-codegen.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderSchemaFirstCodegen } from './schema-first-codegen.lib';
+
+describe('schema-first GraphQL codegen', () => {
+  it('generates typed field helpers for Query fields', () => {
+    const generated = renderSchemaFirstCodegen(`type Query {
+  product(id: ID!): Product
+}
+
+type Product {
+  id: ID!
+  name: String!
+}
+`);
+
+    expect(generated).toContain('export namespace Gql');
+    expect(generated).toContain('export namespace Query');
+    expect(generated).toContain('export namespace product');
+    expect(generated).toContain('export type Args = {');
+    expect(generated).toContain('readonly id: string;');
+    expect(generated).toContain('export type Result = Gql.Product | null;');
+    expect(generated).toContain('export function args(): Args;');
+    expect(generated).toContain('readGraphqlArgs<Args>()');
+  });
+
+  it('generates typed field helpers for Mutation fields', () => {
+    const generated = renderSchemaFirstCodegen(`type Mutation {
+  renameProduct(id: ID!, name: String!): Product!
+}
+
+type Query {
+  product(id: ID!): Product
+}
+
+type Product {
+  id: ID!
+  name: String!
+}
+`);
+
+    expect(generated).toContain('export namespace Mutation');
+    expect(generated).toContain('export namespace renameProduct');
+    expect(generated).toContain('readonly id: string;');
+    expect(generated).toContain('readonly name: string;');
+    expect(generated).toContain('export type Result = Gql.Product;');
+  });
+
+  it('maps nullable, non-null and list GraphQL types to TypeScript types', () => {
+    const generated = renderSchemaFirstCodegen(`type Query {
+  product(id: ID!): Product
+  products(ids: [ID!]!): [Product!]!
+}
+
+type Product {
+  id: ID!
+  tags: [String]
+}
+`);
+
+    expect(generated).toContain('readonly ids: readonly string[];');
+    expect(generated).toContain('export type Result = readonly Gql.Product[];');
+    expect(generated).toContain('readonly tags?: readonly (string | null)[] | null;');
+  });
+
+  it('fails clearly for unsupported custom scalars', () => {
+    expect(() =>
+      renderSchemaFirstCodegen(`scalar DateTime
+
+type Query {
+  now: DateTime!
+}
+`),
+    ).toThrow('Schema-first codegen does not support custom scalar "DateTime" yet.');
+  });
+});

--- a/packages/graphql/src/schema-first-codegen.test.ts
+++ b/packages/graphql/src/schema-first-codegen.test.ts
@@ -60,7 +60,7 @@ type Product {
 
     expect(generated).toContain('readonly ids: readonly string[];');
     expect(generated).toContain('export type Result = readonly Gql.Product[];');
-    expect(generated).toContain('readonly tags?: readonly (string | null)[] | null;');
+    expect(generated).toContain('readonly tags: readonly (string | null)[] | null;');
   });
 
   it('fails clearly for unsupported custom scalars', () => {

--- a/packages/graphql/src/schema-first-runtime.lib.ts
+++ b/packages/graphql/src/schema-first-runtime.lib.ts
@@ -128,6 +128,19 @@ const registerOperation = (
   addRuntimeBinding(bindings, findResolveFieldOwner(index, fieldName), fieldName, binding);
 };
 
+/** @throws {Error} */
+const requireRootBindings = (
+  fields: ReadonlySet<string>,
+  bindings: RuntimeBindings,
+  typeName: 'Query' | 'Mutation',
+): void => {
+  const typeBindings = bindings[typeName] ?? {};
+  for (const fieldName of fields) {
+    if (typeBindings[fieldName] !== undefined) continue;
+    throw new Error(`Schema-first resolver binding missing for ${typeName}.${fieldName}`);
+  }
+};
+
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
 const registerResolver = async (
   bindings: RuntimeBindings,
@@ -164,6 +177,8 @@ export const generateSchemaFirstGraphqlRuntimeForResolvers = async (
   for (const resolver of resolvers) {
     await registerResolver(bindings, index, resolver, options);
   }
+  requireRootBindings(index.queryFields, bindings, 'Query');
+  requireRootBindings(index.mutationFields, bindings, 'Mutation');
   return {
     schemaSdl: options.schemaSdl,
     bindings,

--- a/packages/graphql/src/schema-first-runtime.lib.ts
+++ b/packages/graphql/src/schema-first-runtime.lib.ts
@@ -1,0 +1,171 @@
+import type { ClassMetadata, MethodInfo } from '@zeltjs/decorator-metadata/inspect';
+import { getTypeMetadata } from '@zeltjs/decorator-metadata/inspect';
+import type { ObjectTypeDefinitionNode } from 'graphql';
+import { Kind, parse } from 'graphql';
+
+import type { GraphqlOperationMetadata, GraphqlResolverClass } from './graphql-metadata.lib';
+import type { GeneratedGraphqlBinding, GraphqlRuntimeManifest } from './graphql-runtime.lib';
+
+type SchemaFirstRuntimeOptions = {
+  readonly schemaSdl: string;
+  readonly tsconfig?: string;
+};
+
+type SchemaFirstSdlIndex = {
+  readonly queryFields: ReadonlySet<string>;
+  readonly mutationFields: ReadonlySet<string>;
+  readonly objectFields: ReadonlyMap<string, ReadonlySet<string>>;
+};
+
+type RuntimeBindings = GraphqlRuntimeManifest['bindings'];
+
+function toInspectableClass(cls: GraphqlResolverClass): new (...args: unknown[]) => object;
+function toInspectableClass(cls: GraphqlResolverClass): unknown {
+  return cls;
+}
+
+const collectFieldNames = (type: ObjectTypeDefinitionNode | undefined): ReadonlySet<string> =>
+  new Set((type?.fields ?? []).map((field) => field.name.value));
+
+const buildSdlIndex = (schemaSdl: string): SchemaFirstSdlIndex => {
+  const document = parse(schemaSdl);
+  const objectTypes = new Map<string, ObjectTypeDefinitionNode>();
+
+  for (const definition of document.definitions) {
+    if (definition.kind === Kind.OBJECT_TYPE_DEFINITION) {
+      objectTypes.set(definition.name.value, definition);
+    }
+  }
+
+  const objectFields = new Map<string, ReadonlySet<string>>();
+  for (const [typeName, type] of objectTypes.entries()) {
+    if (typeName === 'Query' || typeName === 'Mutation') continue;
+    objectFields.set(typeName, collectFieldNames(type));
+  }
+
+  return {
+    queryFields: collectFieldNames(objectTypes.get('Query')),
+    mutationFields: collectFieldNames(objectTypes.get('Mutation')),
+    objectFields,
+  };
+};
+
+const getOperationMetadata = (method: MethodInfo): GraphqlOperationMetadata | undefined => {
+  for (const prop of method.props) {
+    const kind: unknown = Reflect.get(prop, 'kind');
+    if (kind === 'query' || kind === 'mutation' || kind === 'resolveField') {
+      const fieldName: unknown = Reflect.get(prop, 'fieldName');
+      return {
+        kind,
+        ...(typeof fieldName === 'string' ? { fieldName } : {}),
+      };
+    }
+  }
+  return undefined;
+};
+
+/** @throws {Error} */
+const addRuntimeBinding = (
+  bindings: RuntimeBindings,
+  typeName: string,
+  fieldName: string,
+  binding: GeneratedGraphqlBinding,
+): void => {
+  const typeBindings = bindings[typeName] ?? {};
+  const existing = typeBindings[fieldName];
+  if (existing && (existing.resolver !== binding.resolver || existing.method !== binding.method)) {
+    throw new Error(`Duplicate GraphQL runtime binding: ${typeName}.${fieldName}`);
+  }
+  bindings[typeName] = { ...typeBindings, [fieldName]: binding };
+};
+
+/** @throws {Error} */
+const requireRootField = (
+  fields: ReadonlySet<string>,
+  typeName: 'Query' | 'Mutation',
+  fieldName: string,
+): void => {
+  if (fields.has(fieldName)) return;
+  throw new Error(
+    `Schema-first binding currently requires method name to match field name: ${typeName}.${fieldName}`,
+  );
+};
+
+/** @throws {Error} */
+const findResolveFieldOwner = (index: SchemaFirstSdlIndex, fieldName: string): string => {
+  const owners = [...index.objectFields.entries()].flatMap(([typeName, fields]) =>
+    fields.has(fieldName) ? [typeName] : [],
+  );
+  if (owners.length === 1) return owners[0] ?? '';
+  if (owners.length === 0) {
+    throw new Error(
+      `Schema-first binding could not find schema field for @ResolveField(): ${fieldName}`,
+    );
+  }
+  throw new Error(`Schema-first binding is ambiguous for @ResolveField(): ${fieldName}`);
+};
+
+/** @throws {Error} */
+const registerOperation = (
+  bindings: RuntimeBindings,
+  index: SchemaFirstSdlIndex,
+  resolverName: string,
+  methodName: string,
+  operation: GraphqlOperationMetadata,
+): void => {
+  const fieldName = operation.fieldName ?? methodName;
+  const binding = { resolver: resolverName, method: methodName };
+  if (operation.kind === 'query') {
+    requireRootField(index.queryFields, 'Query', fieldName);
+    addRuntimeBinding(bindings, 'Query', fieldName, binding);
+    return;
+  }
+  if (operation.kind === 'mutation') {
+    requireRootField(index.mutationFields, 'Mutation', fieldName);
+    addRuntimeBinding(bindings, 'Mutation', fieldName, binding);
+    return;
+  }
+  addRuntimeBinding(bindings, findResolveFieldOwner(index, fieldName), fieldName, binding);
+};
+
+/** @throws {Error | UnsupportedTypeScriptVersionError} */
+const registerResolver = async (
+  bindings: RuntimeBindings,
+  index: SchemaFirstSdlIndex,
+  resolver: GraphqlResolverClass,
+  options: SchemaFirstRuntimeOptions,
+): Promise<void> => {
+  const metadataResult = await getTypeMetadata(toInspectableClass(resolver), {
+    expandStrategy: 'always',
+    ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
+  });
+  if (metadataResult.isErr()) {
+    throw new Error(
+      `Failed to inspect GraphQL resolver ${resolver.name}: ${metadataResult.error.message}`,
+    );
+  }
+
+  const metadata: ClassMetadata = metadataResult.value;
+  for (const method of metadata.methods) {
+    if (typeof method.name !== 'string') continue;
+    const operation = getOperationMetadata(method);
+    if (!operation) continue;
+    registerOperation(bindings, index, resolver.name, method.name, operation);
+  }
+};
+
+/** @throws {Error | UnsupportedTypeScriptVersionError} */
+export const generateSchemaFirstGraphqlRuntimeForResolvers = async (
+  resolvers: readonly GraphqlResolverClass[],
+  options: SchemaFirstRuntimeOptions,
+): Promise<GraphqlRuntimeManifest> => {
+  const index = buildSdlIndex(options.schemaSdl);
+  const bindings: RuntimeBindings = {};
+  for (const resolver of resolvers) {
+    await registerResolver(bindings, index, resolver, options);
+  }
+  return {
+    schemaSdl: options.schemaSdl,
+    bindings,
+  };
+};

--- a/packages/graphql/src/schema-first-runtime.test.ts
+++ b/packages/graphql/src/schema-first-runtime.test.ts
@@ -1,0 +1,98 @@
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { readGraphqlArgs } from './args.lib';
+import { executeGraphqlRequest } from './graphql-runtime.lib';
+import { Query, Resolver } from './index';
+import { generateSchemaFirstGraphqlRuntimeForResolvers } from './schema-first-runtime.lib';
+
+type Product = {
+  readonly id: string;
+  readonly name: string;
+};
+
+@Resolver()
+class SchemaFirstStorefrontResolver {
+  @Query()
+  product(input = readGraphqlArgs<{ readonly id: string }>()): Product {
+    return { id: input.id, name: 'Desk Lamp' };
+  }
+}
+
+@Resolver()
+class SchemaFirstNamedStorefrontResolver {
+  @Query('product')
+  findProduct(input = readGraphqlArgs<{ readonly id: string }>()): Product {
+    return { id: input.id, name: 'Desk Lamp' };
+  }
+}
+
+describe('schema-first GraphQL runtime generation', () => {
+  const tsconfig = resolve(__dirname, '../tsconfig.json');
+  const schemaSdl = `type Query {
+  product(id: ID!): Product
+}
+
+type Product {
+  id: ID!
+  name: String!
+}
+`;
+
+  it('builds a runtime manifest from SDL and resolver metadata', async () => {
+    const runtime = await generateSchemaFirstGraphqlRuntimeForResolvers(
+      [SchemaFirstStorefrontResolver],
+      { schemaSdl, tsconfig },
+    );
+
+    expect(runtime).toEqual({
+      schemaSdl,
+      bindings: {
+        Query: {
+          product: { resolver: 'SchemaFirstStorefrontResolver', method: 'product' },
+        },
+      },
+    });
+
+    const result = await executeGraphqlRequest({
+      runtime,
+      resolvers: [SchemaFirstStorefrontResolver],
+      resolveResolver: (resolver) => new resolver() as object,
+      request: { query: '{ product(id: "p_lamp") { id name } }' },
+    });
+
+    expect(result).toEqual({
+      data: {
+        product: { id: 'p_lamp', name: 'Desk Lamp' },
+      },
+    });
+  });
+
+  it('binds explicit decorator field names without changing the method name', async () => {
+    const runtime = await generateSchemaFirstGraphqlRuntimeForResolvers(
+      [SchemaFirstNamedStorefrontResolver],
+      { schemaSdl, tsconfig },
+    );
+
+    expect(runtime.bindings['Query']?.['product']).toEqual({
+      resolver: 'SchemaFirstNamedStorefrontResolver',
+      method: 'findProduct',
+    });
+  });
+
+  it('fails clearly when a root method does not match the schema field', async () => {
+    @Resolver()
+    class MismatchedResolver {
+      @Query()
+      missing(): Product {
+        return { id: 'p_lamp', name: 'Desk Lamp' };
+      }
+    }
+
+    await expect(
+      generateSchemaFirstGraphqlRuntimeForResolvers([MismatchedResolver], { schemaSdl, tsconfig }),
+    ).rejects.toThrow(
+      'Schema-first binding currently requires method name to match field name: Query.missing',
+    );
+  });
+});

--- a/packages/graphql/src/schema-first-runtime.test.ts
+++ b/packages/graphql/src/schema-first-runtime.test.ts
@@ -95,4 +95,96 @@ type Product {
       'Schema-first binding currently requires method name to match field name: Query.missing',
     );
   });
+
+  it('fails when an SDL query field has no resolver binding', async () => {
+    const schemaWithMissingQuery = `type Query {
+  product(id: ID!): Product
+  viewer: Product
+}
+
+type Product {
+  id: ID!
+  name: String!
+}
+`;
+
+    await expect(
+      generateSchemaFirstGraphqlRuntimeForResolvers([SchemaFirstStorefrontResolver], {
+        schemaSdl: schemaWithMissingQuery,
+        tsconfig,
+      }),
+    ).rejects.toThrow('Schema-first resolver binding missing for Query.viewer');
+  });
+
+  it('fails when an SDL mutation field has no resolver binding', async () => {
+    const schemaWithMissingMutation = `type Query {
+  product(id: ID!): Product
+}
+
+type Mutation {
+  renameProduct(id: ID!, name: String!): Product
+}
+
+type Product {
+  id: ID!
+  name: String!
+}
+`;
+
+    await expect(
+      generateSchemaFirstGraphqlRuntimeForResolvers([SchemaFirstStorefrontResolver], {
+        schemaSdl: schemaWithMissingMutation,
+        tsconfig,
+      }),
+    ).rejects.toThrow('Schema-first resolver binding missing for Mutation.renameProduct');
+  });
+
+  it('allows object type fields without explicit resolver bindings', async () => {
+    type ProductWithDescription = Product & {
+      readonly description: string;
+    };
+
+    @Resolver()
+    class ProductFieldDefaultResolver {
+      @Query()
+      product(input = readGraphqlArgs<{ readonly id: string }>()): ProductWithDescription {
+        return { id: input.id, name: 'Desk Lamp', description: 'Adjustable task light' };
+      }
+    }
+
+    const schemaWithObjectField = `type Query {
+  product(id: ID!): Product
+}
+
+type Product {
+  id: ID!
+  name: String!
+  description: String!
+}
+`;
+
+    const runtime = await generateSchemaFirstGraphqlRuntimeForResolvers(
+      [ProductFieldDefaultResolver],
+      { schemaSdl: schemaWithObjectField, tsconfig },
+    );
+
+    expect(runtime.bindings['Product']?.['description']).toBeUndefined();
+
+    const result = await executeGraphqlRequest({
+      runtime,
+      resolvers: [ProductFieldDefaultResolver],
+      resolveResolver: (resolver) => new resolver() as object,
+      request: { query: '{ product(id: "p_lamp") { id name description } }' },
+    });
+
+    expect(result).toEqual({
+      data: {
+        product: {
+          id: 'p_lamp',
+          name: 'Desk Lamp',
+          description: 'Adjustable task light',
+        },
+      },
+    });
+  });
 });

--- a/packages/graphql/tsdown.config.ts
+++ b/packages/graphql/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/codegen.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   clean: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,9 +315,18 @@ importers:
       chokidar:
         specifier: 5.0.0
         version: 5.0.0
+      citty:
+        specifier: 0.1.6
+        version: 0.1.6
+      consola:
+        specifier: 3.4.2
+        version: 3.4.2
       jiti:
         specifier: 2.6.1
         version: 2.6.1
+      ts-pattern:
+        specifier: 5.7.1
+        version: 5.7.1
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -325,15 +334,6 @@ importers:
       c12:
         specifier: 3.0.4
         version: 3.0.4
-      citty:
-        specifier: 0.1.6
-        version: 0.1.6
-      consola:
-        specifier: 3.4.2
-        version: 3.4.2
-      ts-pattern:
-        specifier: 5.7.1
-        version: 5.7.1
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,12 +312,6 @@ importers:
 
   packages/cli:
     dependencies:
-      '@zeltjs/adapter-node':
-        specifier: workspace:*
-        version: link:../adapter-node
-      '@zeltjs/core':
-        specifier: workspace:*
-        version: link:../core
       chokidar:
         specifier: 5.0.0
         version: 5.0.0


### PR DESCRIPTION
## Summary
- Add an experimental schema-first GraphQL codegen command
- Generate typed `Gql.Query.<field>.args()` helpers from SDL
- Keep schema-first authoring in Zelt style: class resolvers, decorators, DI, and default parameters
- Add schema-first runtime manifest generation from SDL + resolver bindings
- Document the shared runtime manifest boundary used by code-first and schema-first frontends
- Add a small schema-first integration test

## Non-goals
- No resolver map API
- No `args<T>()` user-facing API
- No custom scalar / union / interface support in schema-first yet
- No Zod adapter
- No Standard JSON Schema adapter dispatch
- No changes to #273 scalar/union feature work

## Verification
- `pnpm --filter @zeltjs/graphql typecheck`
- `pnpm --filter @zeltjs/graphql test`
- `./integration/scripts/run-tests.sh dist graphql-dogfooding`
- `./integration/scripts/run-tests.sh dist graphql-schema-first`
- `pnpm run precommit`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784030443&installation_id=133048706&pr_number=275&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F275&signature=971783896188937bfe5be49572560bee131108bfb90db3d7d9930dbbc1bccd7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GraphQLスキーマファースト対応を追加し、スキーマ定義からコード自動生成が可能になりました
  * CLIに新しいGraphQL生成コマンドを追加しました

* **テスト**
  * スキーマファースト構成の統合テストとユニットテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->