### PR TITLE
feat(graphql): generate schema-first resolver checks

### DIFF
--- a/integration/graphql-schema-first/e2e/generated.spec.ts
+++ b/integration/graphql-schema-first/e2e/generated.spec.ts
@@ -1,0 +1,18 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from 'vitest';
+
+import { prepareGeneratedRuntime, resolverChecksPath, runtimeModulePath } from './generated';
+
+describe('GraphQL schema-first generated files', () => {
+  it('generates runtime and resolver check files before typechecking', async () => {
+    await prepareGeneratedRuntime();
+
+    await expect(readFile(runtimeModulePath, 'utf8')).resolves.toContain(
+      'export const graphqlRuntime',
+    );
+    await expect(readFile(resolverChecksPath, 'utf8')).resolves.toContain(
+      'Gql.Query.product.Result',
+    );
+  });
+});

--- a/integration/graphql-schema-first/e2e/generated.ts
+++ b/integration/graphql-schema-first/e2e/generated.ts
@@ -1,0 +1,31 @@
+import { mkdir, rm } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { generateGraphqlSdl } from '@zeltjs/graphql';
+
+import { createGraphqlSchemaFirstApp, graphqlRuntimeModule } from '../src/app';
+
+export const tsconfig = resolve(__dirname, '../tsconfig.json');
+export const schema = resolve(__dirname, '../src/graphql/schema.graphql');
+export const runtimeModulePath = resolve(__dirname, '..', graphqlRuntimeModule);
+export const generatedDir = dirname(runtimeModulePath);
+export const resolverChecksPath = resolve(generatedDir, 'graphql-resolver-checks.ts');
+
+export const prepareGeneratedRuntime = async (): Promise<void> => {
+  await rm(runtimeModulePath, { force: true });
+  await rm(resolverChecksPath, { force: true });
+  await mkdir(generatedDir, { recursive: true });
+
+  const app = createGraphqlSchemaFirstApp();
+  await generateGraphqlSdl(app.http, {
+    mode: 'schema-first',
+    schema,
+    runtimeModule: runtimeModulePath,
+    resolverChecks: {
+      out: resolverChecksPath,
+      gqlTypesImport: './graphql',
+    },
+    distDir: generatedDir,
+    tsconfig,
+  });
+};

--- a/integration/graphql-schema-first/e2e/graphql.spec.ts
+++ b/integration/graphql-schema-first/e2e/graphql.spec.ts
@@ -1,34 +1,13 @@
-import { mkdir, readFile, rm } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
-
-import { generateGraphqlSdl } from '@zeltjs/graphql';
+import { readFile } from 'node:fs/promises';
 import { onTest, shutdownAll } from '@zeltjs/testing';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { createGraphqlSchemaFirstApp, graphqlRuntimeModule } from '../src/app';
-
-const tsconfig = resolve(__dirname, '../tsconfig.json');
-const schema = resolve(__dirname, '../src/graphql/schema.graphql');
-const runtimeModulePath = resolve(__dirname, '..', graphqlRuntimeModule);
-const generatedDir = dirname(runtimeModulePath);
+import { createGraphqlSchemaFirstApp } from '../src/app';
+import { prepareGeneratedRuntime, resolverChecksPath, runtimeModulePath } from './generated';
 
 type AppRuntime = Awaited<
   ReturnType<ReturnType<typeof createGraphqlSchemaFirstApp>['createRuntime']>
 >;
-
-const prepareGeneratedRuntime = async (): Promise<void> => {
-  await rm(runtimeModulePath, { force: true });
-  await mkdir(generatedDir, { recursive: true });
-
-  const app = createGraphqlSchemaFirstApp();
-  await generateGraphqlSdl(app.http, {
-    mode: 'schema-first',
-    schema,
-    runtimeModule: runtimeModulePath,
-    distDir: generatedDir,
-    tsconfig,
-  });
-};
 
 const postGraphql = (runtime: AppRuntime, query: string): Promise<Response> =>
   runtime.http.request('/graphql', {
@@ -52,6 +31,9 @@ describe('GraphQL schema-first app', () => {
   it('runs a schema-first resolver through the generated GraphQL runtime over HTTP', async () => {
     await expect(readFile(runtimeModulePath, 'utf8')).resolves.toContain(
       'export const graphqlRuntime',
+    );
+    await expect(readFile(resolverChecksPath, 'utf8')).resolves.toContain(
+      'Gql.Query.product.Result',
     );
 
     const response = await postGraphql(runtime, '{ product(id: "p_lamp") { id name } }');

--- a/integration/graphql-schema-first/package.extra.json
+++ b/integration/graphql-schema-first/package.extra.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "prepare:integration": "zelt graphql codegen --schema src/graphql/schema.graphql --out src/generated/graphql.ts"
+    "prepare:integration": "zelt graphql codegen --schema src/graphql/schema.graphql --out src/generated/graphql.ts && vitest run e2e/generated.spec.ts"
   }
 }

--- a/integration/graphql-schema-first/src/graphql/storefront.resolver.ts
+++ b/integration/graphql-schema-first/src/graphql/storefront.resolver.ts
@@ -9,7 +9,7 @@ export class StorefrontResolver {
   constructor(private readonly catalog = inject(CatalogService)) {}
 
   @Query()
-  product(input = Gql.Query.product.args()): Gql.Query.product.Result {
+  product(input = Gql.Query.product.args()) {
     return this.catalog.findProduct(input.id) ?? null;
   }
 }

--- a/packages/graphql/src/graphql-plugin.lib.ts
+++ b/packages/graphql/src/graphql-plugin.lib.ts
@@ -8,6 +8,8 @@ import { getGraphqlControllerMetadata } from './graphql-metadata.lib';
 import type { GraphqlRuntimeManifest } from './graphql-runtime.lib';
 import type { GenerateSdlOptions } from './graphql-sdl-generator.lib';
 import { generateGraphqlRuntimeForResolvers } from './graphql-sdl-generator.lib';
+import type { GenerateSchemaFirstResolverChecksOptions } from './schema-first-resolver-checks.lib';
+import { generateSchemaFirstResolverChecks } from './schema-first-resolver-checks.lib';
 import { generateSchemaFirstGraphqlRuntimeForResolvers } from './schema-first-runtime.lib';
 
 type HttpStaticApp = {
@@ -19,6 +21,10 @@ export type GraphqlPluginOptions = {
   readonly outDir?: string;
   readonly schema?: string;
   readonly runtimeModule?: string;
+  readonly resolverChecks?: Pick<
+    GenerateSchemaFirstResolverChecksOptions,
+    'out' | 'gqlTypesImport'
+  >;
   readonly tsconfig?: string;
   readonly schemaAdapter?: GenerateSdlOptions['schemaAdapter'];
   readonly schemaResolver?: GenerateSdlOptions['schemaResolver'];
@@ -29,6 +35,10 @@ export type GenerateGraphqlSdlOptions = GenerateSdlOptions & {
   readonly mode?: 'code-first' | 'schema-first';
   readonly schema?: string;
   readonly runtimeModule?: string;
+  readonly resolverChecks?: Pick<
+    GenerateSchemaFirstResolverChecksOptions,
+    'out' | 'gqlTypesImport'
+  >;
 };
 
 export type GenerateGraphqlSdlResult = {
@@ -168,7 +178,18 @@ const generateSchemaFirstRuntimeModule = async (
   );
   const runtimeChanged = await writeRuntimeModule(runtimeModule, runtime);
   const schemaChanged = await writeIfChanged(toRuntimeSchemaPath(runtimeModule), schemaSdl);
-  return runtimeChanged || schemaChanged;
+  const resolverChecksChanged = options.resolverChecks
+    ? (
+        await generateSchemaFirstResolverChecks({
+          schemaSdl,
+          resolvers: endpoints.flatMap((endpoint) => endpoint.resolvers),
+          out: options.resolverChecks.out,
+          gqlTypesImport: options.resolverChecks.gqlTypesImport,
+          ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
+        })
+      ).changed
+    : false;
+  return runtimeChanged || schemaChanged || resolverChecksChanged;
 };
 
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
@@ -199,6 +220,7 @@ const addGenerateOptions = (
   if (options.mode !== undefined) generateOptions.mode = options.mode;
   if (options.schema !== undefined) generateOptions.schema = options.schema;
   if (options.runtimeModule !== undefined) generateOptions.runtimeModule = options.runtimeModule;
+  if (options.resolverChecks !== undefined) generateOptions.resolverChecks = options.resolverChecks;
   if (options.tsconfig !== undefined) generateOptions.tsconfig = options.tsconfig;
   if (options.schemaAdapter !== undefined) generateOptions.schemaAdapter = options.schemaAdapter;
   if (options.schemaResolver !== undefined) generateOptions.schemaResolver = options.schemaResolver;

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -53,6 +53,14 @@ export type {
   SchemaFirstCodegenResult,
 } from './schema-first-codegen.lib';
 export { generateSchemaFirstCodegen, renderSchemaFirstCodegen } from './schema-first-codegen.lib';
+export type {
+  GenerateSchemaFirstResolverChecksOptions,
+  GenerateSchemaFirstResolverChecksResult,
+} from './schema-first-resolver-checks.lib';
+export {
+  generateSchemaFirstResolverChecks,
+  renderSchemaFirstResolverChecks,
+} from './schema-first-resolver-checks.lib';
 export { generateSchemaFirstGraphqlRuntimeForResolvers } from './schema-first-runtime.lib';
 export type { GraphqlTypeContext, GraphqlTypeResult } from './type-to-graphql.lib';
 export { typeInfoToGraphqlType } from './type-to-graphql.lib';

--- a/packages/graphql/src/plugin.test.ts
+++ b/packages/graphql/src/plugin.test.ts
@@ -76,6 +76,7 @@ describe('graphqlPlugin', () => {
     const outDir = await mkdtemp(join(tmpdir(), 'zelt-graphql-schema-first-'));
     const schema = join(outDir, 'schema.graphql');
     const runtimeModule = join(outDir, 'schema-first-runtime.js');
+    const resolverChecks = join(outDir, 'graphql-resolver-checks.ts');
     await writeFile(
       schema,
       `type Query {
@@ -93,6 +94,10 @@ type ViewerPublic {
       mode: 'schema-first',
       schema,
       runtimeModule,
+      resolverChecks: {
+        out: resolverChecks,
+        gqlTypesImport: './graphql',
+      },
       tsconfig: resolve(__dirname, '../tsconfig.json'),
     });
 
@@ -113,5 +118,6 @@ type ViewerPublic {
     await expect(readFile(runtimeModule.replace(/\.js$/, '.graphql'), 'utf8')).resolves.toContain(
       'type Query',
     );
+    await expect(readFile(resolverChecks, 'utf8')).resolves.toContain('Gql.Query.viewer.Result');
   });
 });

--- a/packages/graphql/src/schema-first-resolver-checks.lib.ts
+++ b/packages/graphql/src/schema-first-resolver-checks.lib.ts
@@ -1,0 +1,248 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';
+
+import type { ClassMetadata, MethodInfo } from '@zeltjs/decorator-metadata/inspect';
+import { getTypeMetadata } from '@zeltjs/decorator-metadata/inspect';
+import type { ObjectTypeDefinitionNode } from 'graphql';
+import { Kind, parse } from 'graphql';
+
+import type { GraphqlOperationMetadata, GraphqlResolverClass } from './graphql-metadata.lib';
+
+export type GenerateSchemaFirstResolverChecksOptions = {
+  readonly schemaSdl: string;
+  readonly resolvers: readonly GraphqlResolverClass[];
+  readonly tsconfig?: string;
+  readonly out: string;
+  readonly gqlTypesImport: string;
+};
+
+export type GenerateSchemaFirstResolverChecksResult = {
+  readonly changed: boolean;
+};
+
+type RootOperationKind = 'Query' | 'Mutation';
+
+type SchemaFirstCheckIndex = {
+  readonly queryFields: ReadonlySet<string>;
+  readonly mutationFields: ReadonlySet<string>;
+};
+
+type ResolverCheck = {
+  readonly resolverName: string;
+  readonly sourceFile: string;
+  readonly methodName: string;
+  readonly rootTypeName: RootOperationKind;
+  readonly fieldName: string;
+};
+
+function toInspectableClass(cls: GraphqlResolverClass): new (...args: unknown[]) => object;
+function toInspectableClass(cls: GraphqlResolverClass): unknown {
+  return cls;
+}
+
+const collectFieldNames = (type: ObjectTypeDefinitionNode | undefined): ReadonlySet<string> =>
+  new Set((type?.fields ?? []).map((field) => field.name.value));
+
+const buildSchemaIndex = (schemaSdl: string): SchemaFirstCheckIndex => {
+  const objectTypes = new Map<string, ObjectTypeDefinitionNode>();
+  for (const definition of parse(schemaSdl).definitions) {
+    if (definition.kind === Kind.OBJECT_TYPE_DEFINITION) {
+      objectTypes.set(definition.name.value, definition);
+    }
+  }
+  return {
+    queryFields: collectFieldNames(objectTypes.get('Query')),
+    mutationFields: collectFieldNames(objectTypes.get('Mutation')),
+  };
+};
+
+const getOperationMetadata = (method: MethodInfo): GraphqlOperationMetadata | undefined => {
+  for (const prop of method.props) {
+    const kind: unknown = Reflect.get(prop, 'kind');
+    if (kind === 'query' || kind === 'mutation' || kind === 'resolveField') {
+      const fieldName: unknown = Reflect.get(prop, 'fieldName');
+      return {
+        kind,
+        ...(typeof fieldName === 'string' ? { fieldName } : {}),
+      };
+    }
+  }
+  return undefined;
+};
+
+/** @throws {Error} */
+const requireIdentifier = (name: string, usage: string): void => {
+  if (/^[$A-Z_a-z][$\w]*$/.test(name)) return;
+  throw new Error(`Schema-first resolver checks require ${usage} to be a TypeScript identifier.`);
+};
+
+/** @throws {Error} */
+const requireRootField = (
+  fields: ReadonlySet<string>,
+  typeName: RootOperationKind,
+  fieldName: string,
+): void => {
+  if (fields.has(fieldName)) return;
+  throw new Error(`Schema-first resolver checks could not find ${typeName}.${fieldName}.`);
+};
+
+const quoteTsString = (value: string): string =>
+  `'${value.replaceAll('\\', '\\\\').replaceAll("'", "\\'")}'`;
+
+const toAliasPart = (name: string): string => {
+  const sanitized = name.replaceAll(/[^0-9A-Z_a-z]+/g, '_');
+  return sanitized.replace(/^[0-9]/, '_$&');
+};
+
+const toImportSpecifier = (fromFile: string, toFile: string): string => {
+  const raw = relative(dirname(resolve(fromFile)), resolve(toFile))
+    .replaceAll('\\', '/')
+    .replace(/\.[cm]?[tj]sx?$/, '');
+  return raw.startsWith('.') ? raw : `./${raw}`;
+};
+
+/** @throws {Error} */
+const getResolverSourceFile = (metadata: ClassMetadata, resolverName: string): string => {
+  const sourceFile = metadata.pos?.sourceFile;
+  if (!sourceFile) {
+    throw new Error(`Schema-first resolver checks could not locate ${resolverName}.`);
+  }
+  return sourceFile;
+};
+
+/** @throws {Error} */
+const addRootCheck = (
+  checks: ResolverCheck[],
+  index: SchemaFirstCheckIndex,
+  resolverName: string,
+  sourceFile: string,
+  methodName: string,
+  operation: GraphqlOperationMetadata,
+): void => {
+  if (operation.kind === 'resolveField') return;
+
+  const rootTypeName = operation.kind === 'query' ? 'Query' : 'Mutation';
+  const fieldName = operation.fieldName ?? methodName;
+  requireIdentifier(fieldName, `${rootTypeName}.${fieldName}`);
+  requireRootField(
+    operation.kind === 'query' ? index.queryFields : index.mutationFields,
+    rootTypeName,
+    fieldName,
+  );
+  checks.push({ resolverName, sourceFile, methodName, rootTypeName, fieldName });
+};
+
+/** @throws {Error | UnsupportedTypeScriptVersionError} */
+const collectResolverChecks = async (
+  options: GenerateSchemaFirstResolverChecksOptions,
+): Promise<readonly ResolverCheck[]> => {
+  const index = buildSchemaIndex(options.schemaSdl);
+  const checks: ResolverCheck[] = [];
+
+  for (const resolver of options.resolvers) {
+    const metadataResult = await getTypeMetadata(toInspectableClass(resolver), {
+      expandStrategy: 'always',
+      ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
+    });
+    if (metadataResult.isErr()) {
+      throw new Error(
+        `Failed to inspect GraphQL resolver ${resolver.name}: ${metadataResult.error.message}`,
+      );
+    }
+
+    const metadata = metadataResult.value;
+    const sourceFile = getResolverSourceFile(metadata, resolver.name);
+    requireIdentifier(resolver.name, resolver.name);
+
+    for (const method of metadata.methods) {
+      if (typeof method.name !== 'string') continue;
+      const operation = getOperationMetadata(method);
+      if (!operation) continue;
+      addRootCheck(checks, index, resolver.name, sourceFile, method.name, operation);
+    }
+  }
+
+  return checks;
+};
+
+const renderImports = (
+  checks: readonly ResolverCheck[],
+  options: GenerateSchemaFirstResolverChecksOptions,
+): readonly string[] => {
+  const importsByFile = new Map<string, Set<string>>();
+  for (const check of checks) {
+    const names = importsByFile.get(check.sourceFile) ?? new Set<string>();
+    names.add(check.resolverName);
+    importsByFile.set(check.sourceFile, names);
+  }
+
+  return [
+    `import type { Gql } from ${quoteTsString(options.gqlTypesImport)};`,
+    ...[...importsByFile.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([sourceFile, names]) => {
+        const importedNames = [...names].sort().join(', ');
+        return `import type { ${importedNames} } from ${quoteTsString(
+          toImportSpecifier(options.out, sourceFile),
+        )};`;
+      }),
+  ];
+};
+
+const renderPreamble = (): readonly string[] => [
+  'type AwaitedValue<T> = T extends PromiseLike<infer U> ? AwaitedValue<U> : T;',
+  'type FirstArg<Fn> = Fn extends (...args: infer Params) => unknown',
+  '  ? Params extends readonly []',
+  '    ? never',
+  '    : Params[0]',
+  '  : never;',
+  'type AssertTrue<T extends true> = T;',
+  'type IsAssignable<Actual, Expected> = [Actual] extends [Expected] ? true : false;',
+  'type IsOptionalArg<Arg> = undefined extends Arg ? true : false;',
+];
+
+const renderCheck = (check: ResolverCheck): readonly string[] => {
+  const aliasBase = `_Check_${toAliasPart(check.resolverName)}_${toAliasPart(check.methodName)}`;
+  const methodType = `${check.resolverName}[${quoteTsString(check.methodName)}]`;
+  const fieldTypes = `Gql.${check.rootTypeName}.${check.fieldName}`;
+  return [
+    `type ${aliasBase}_args = AssertTrue<IsAssignable<Exclude<FirstArg<${methodType}>, undefined>, ${fieldTypes}.Args>>;`,
+    `type ${aliasBase}_args_optional = AssertTrue<IsOptionalArg<FirstArg<${methodType}>>>;`,
+    `type ${aliasBase}_return = AssertTrue<IsAssignable<AwaitedValue<ReturnType<${methodType}>>, ${fieldTypes}.Result>>;`,
+  ];
+};
+
+/** @throws {Error | UnsupportedTypeScriptVersionError} */
+export const renderSchemaFirstResolverChecks = async (
+  options: GenerateSchemaFirstResolverChecksOptions,
+): Promise<string> => {
+  const checks = await collectResolverChecks(options);
+  const parts = [
+    ...renderImports(checks, options),
+    '',
+    ...renderPreamble(),
+    '',
+    ...checks.flatMap((check) => [...renderCheck(check), '']),
+  ];
+  return parts.join('\n');
+};
+
+const writeIfChanged = async (path: string, content: string): Promise<boolean> => {
+  if (existsSync(path)) {
+    const existing = await readFile(path, 'utf8');
+    if (existing === content) return false;
+  }
+  await writeFile(path, content, 'utf8');
+  return true;
+};
+
+/** @throws {Error | UnsupportedTypeScriptVersionError} */
+export const generateSchemaFirstResolverChecks = async (
+  options: GenerateSchemaFirstResolverChecksOptions,
+): Promise<GenerateSchemaFirstResolverChecksResult> => {
+  const outPath = resolve(options.out);
+  const generated = await renderSchemaFirstResolverChecks({ ...options, out: outPath });
+  await mkdir(dirname(outPath), { recursive: true });
+  return { changed: await writeIfChanged(outPath, generated) };
+};

--- a/packages/graphql/src/schema-first-resolver-checks.lib.ts
+++ b/packages/graphql/src/schema-first-resolver-checks.lib.ts
@@ -23,9 +23,13 @@ export type GenerateSchemaFirstResolverChecksResult = {
 
 type RootOperationKind = 'Query' | 'Mutation';
 
+type SchemaFirstFieldInfo = {
+  readonly hasArgs: boolean;
+};
+
 type SchemaFirstCheckIndex = {
-  readonly queryFields: ReadonlySet<string>;
-  readonly mutationFields: ReadonlySet<string>;
+  readonly queryFields: ReadonlyMap<string, SchemaFirstFieldInfo>;
+  readonly mutationFields: ReadonlyMap<string, SchemaFirstFieldInfo>;
 };
 
 type ResolverCheck = {
@@ -34,6 +38,7 @@ type ResolverCheck = {
   readonly methodName: string;
   readonly rootTypeName: RootOperationKind;
   readonly fieldName: string;
+  readonly hasArgs: boolean;
 };
 
 function toInspectableClass(cls: GraphqlResolverClass): new (...args: unknown[]) => object;
@@ -41,8 +46,15 @@ function toInspectableClass(cls: GraphqlResolverClass): unknown {
   return cls;
 }
 
-const collectFieldNames = (type: ObjectTypeDefinitionNode | undefined): ReadonlySet<string> =>
-  new Set((type?.fields ?? []).map((field) => field.name.value));
+const collectFields = (
+  type: ObjectTypeDefinitionNode | undefined,
+): ReadonlyMap<string, SchemaFirstFieldInfo> =>
+  new Map(
+    (type?.fields ?? []).map((field) => [
+      field.name.value,
+      { hasArgs: (field.arguments ?? []).length > 0 },
+    ]),
+  );
 
 const buildSchemaIndex = (schemaSdl: string): SchemaFirstCheckIndex => {
   const objectTypes = new Map<string, ObjectTypeDefinitionNode>();
@@ -52,8 +64,8 @@ const buildSchemaIndex = (schemaSdl: string): SchemaFirstCheckIndex => {
     }
   }
   return {
-    queryFields: collectFieldNames(objectTypes.get('Query')),
-    mutationFields: collectFieldNames(objectTypes.get('Mutation')),
+    queryFields: collectFields(objectTypes.get('Query')),
+    mutationFields: collectFields(objectTypes.get('Mutation')),
   };
 };
 
@@ -79,11 +91,12 @@ const requireIdentifier = (name: string, usage: string): void => {
 
 /** @throws {Error} */
 const requireRootField = (
-  fields: ReadonlySet<string>,
+  fields: ReadonlyMap<string, SchemaFirstFieldInfo>,
   typeName: RootOperationKind,
   fieldName: string,
-): void => {
-  if (fields.has(fieldName)) return;
+): SchemaFirstFieldInfo => {
+  const field = fields.get(fieldName);
+  if (field) return field;
   throw new Error(`Schema-first resolver checks could not find ${typeName}.${fieldName}.`);
 };
 
@@ -125,12 +138,19 @@ const addRootCheck = (
   const rootTypeName = operation.kind === 'query' ? 'Query' : 'Mutation';
   const fieldName = operation.fieldName ?? methodName;
   requireIdentifier(fieldName, `${rootTypeName}.${fieldName}`);
-  requireRootField(
+  const field = requireRootField(
     operation.kind === 'query' ? index.queryFields : index.mutationFields,
     rootTypeName,
     fieldName,
   );
-  checks.push({ resolverName, sourceFile, methodName, rootTypeName, fieldName });
+  checks.push({
+    resolverName,
+    sourceFile,
+    methodName,
+    rootTypeName,
+    fieldName,
+    hasArgs: field.hasArgs,
+  });
 };
 
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
@@ -192,6 +212,7 @@ const renderImports = (
 
 const renderPreamble = (): readonly string[] => [
   'type AwaitedValue<T> = T extends PromiseLike<infer U> ? AwaitedValue<U> : T;',
+  'type Params<Fn> = Fn extends (...args: infer Params) => unknown ? Params : never;',
   'type FirstArg<Fn> = Fn extends (...args: infer Params) => unknown',
   '  ? Params extends readonly []',
   '    ? never',
@@ -200,12 +221,28 @@ const renderPreamble = (): readonly string[] => [
   'type AssertTrue<T extends true> = T;',
   'type IsAssignable<Actual, Expected> = [Actual] extends [Expected] ? true : false;',
   'type IsOptionalArg<Arg> = undefined extends Arg ? true : false;',
+  'type HasNoParams<Fn> = Params<Fn> extends readonly unknown[]',
+  "  ? Params<Fn>['length'] extends 0",
+  '    ? true',
+  '    : false',
+  '  : false;',
+  'type AllowsNoArgsField<Fn, Args> = HasNoParams<Fn> extends true',
+  '  ? true',
+  '  : IsAssignable<Exclude<FirstArg<Fn>, undefined>, Args> extends true',
+  '    ? IsOptionalArg<FirstArg<Fn>>',
+  '    : false;',
 ];
 
 const renderCheck = (check: ResolverCheck): readonly string[] => {
   const aliasBase = `_Check_${toAliasPart(check.resolverName)}_${toAliasPart(check.methodName)}`;
   const methodType = `${check.resolverName}[${quoteTsString(check.methodName)}]`;
   const fieldTypes = `Gql.${check.rootTypeName}.${check.fieldName}`;
+  if (!check.hasArgs) {
+    return [
+      `type ${aliasBase}_args = AssertTrue<AllowsNoArgsField<${methodType}, ${fieldTypes}.Args>>;`,
+      `type ${aliasBase}_return = AssertTrue<IsAssignable<AwaitedValue<ReturnType<${methodType}>>, ${fieldTypes}.Result>>;`,
+    ];
+  }
   return [
     `type ${aliasBase}_args = AssertTrue<IsAssignable<Exclude<FirstArg<${methodType}>, undefined>, ${fieldTypes}.Args>>;`,
     `type ${aliasBase}_args_optional = AssertTrue<IsOptionalArg<FirstArg<${methodType}>>>;`,

--- a/packages/graphql/src/schema-first-resolver-checks.lib.ts
+++ b/packages/graphql/src/schema-first-resolver-checks.lib.ts
@@ -160,7 +160,7 @@ const collectResolverChecks = async (
   const index = buildSchemaIndex(options.schemaSdl);
   const checks: ResolverCheck[] = [];
 
-  for (const resolver of options.resolvers) {
+  for (const resolver of new Set(options.resolvers)) {
     const metadataResult = await getTypeMetadata(toInspectableClass(resolver), {
       expandStrategy: 'always',
       ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
@@ -220,6 +220,9 @@ const renderPreamble = (): readonly string[] => [
   '  : never;',
   'type AssertTrue<T extends true> = T;',
   'type IsAssignable<Actual, Expected> = [Actual] extends [Expected] ? true : false;',
+  'type IsMutuallyAssignable<Actual, Expected> = IsAssignable<Actual, Expected> extends true',
+  '  ? IsAssignable<Expected, Actual>',
+  '  : false;',
   'type IsOptionalArg<Arg> = undefined extends Arg ? true : false;',
   'type HasNoParams<Fn> = Params<Fn> extends readonly unknown[]',
   "  ? Params<Fn>['length'] extends 0",
@@ -233,7 +236,7 @@ const renderPreamble = (): readonly string[] => [
   '    : false;',
   'type AllowsNoArgsField<Fn, Args> = HasNoParams<Fn> extends true',
   '  ? HasCompatibleTailParams<Fn>',
-  '  : IsAssignable<Exclude<FirstArg<Fn>, undefined>, Args> extends true',
+  '  : IsMutuallyAssignable<Exclude<FirstArg<Fn>, undefined>, Args> extends true',
   '    ? IsOptionalArg<FirstArg<Fn>> extends true',
   '      ? HasCompatibleTailParams<Fn>',
   '      : false',
@@ -251,7 +254,7 @@ const renderCheck = (check: ResolverCheck): readonly string[] => {
     ];
   }
   return [
-    `type ${aliasBase}_args = AssertTrue<IsAssignable<Exclude<FirstArg<${methodType}>, undefined>, ${fieldTypes}.Args>>;`,
+    `type ${aliasBase}_args = AssertTrue<IsMutuallyAssignable<Exclude<FirstArg<${methodType}>, undefined>, ${fieldTypes}.Args>>;`,
     `type ${aliasBase}_args_optional = AssertTrue<IsOptionalArg<FirstArg<${methodType}>>>;`,
     `type ${aliasBase}_args_tail = AssertTrue<HasCompatibleTailParams<${methodType}>>;`,
     `type ${aliasBase}_return = AssertTrue<IsAssignable<AwaitedValue<ReturnType<${methodType}>>, ${fieldTypes}.Result>>;`,

--- a/packages/graphql/src/schema-first-resolver-checks.lib.ts
+++ b/packages/graphql/src/schema-first-resolver-checks.lib.ts
@@ -226,10 +226,17 @@ const renderPreamble = (): readonly string[] => [
   '    ? true',
   '    : false',
   '  : false;',
-  'type AllowsNoArgsField<Fn, Args> = HasNoParams<Fn> extends true',
+  'type HasCompatibleTailParams<Fn> = Params<Fn> extends readonly []',
   '  ? true',
+  '  : Fn extends (arg: FirstArg<Fn>) => unknown',
+  '    ? true',
+  '    : false;',
+  'type AllowsNoArgsField<Fn, Args> = HasNoParams<Fn> extends true',
+  '  ? HasCompatibleTailParams<Fn>',
   '  : IsAssignable<Exclude<FirstArg<Fn>, undefined>, Args> extends true',
-  '    ? IsOptionalArg<FirstArg<Fn>>',
+  '    ? IsOptionalArg<FirstArg<Fn>> extends true',
+  '      ? HasCompatibleTailParams<Fn>',
+  '      : false',
   '    : false;',
 ];
 
@@ -246,6 +253,7 @@ const renderCheck = (check: ResolverCheck): readonly string[] => {
   return [
     `type ${aliasBase}_args = AssertTrue<IsAssignable<Exclude<FirstArg<${methodType}>, undefined>, ${fieldTypes}.Args>>;`,
     `type ${aliasBase}_args_optional = AssertTrue<IsOptionalArg<FirstArg<${methodType}>>>;`,
+    `type ${aliasBase}_args_tail = AssertTrue<HasCompatibleTailParams<${methodType}>>;`,
     `type ${aliasBase}_return = AssertTrue<IsAssignable<AwaitedValue<ReturnType<${methodType}>>, ${fieldTypes}.Result>>;`,
   ];
 };

--- a/packages/graphql/src/schema-first-resolver-checks.test.ts
+++ b/packages/graphql/src/schema-first-resolver-checks.test.ts
@@ -76,6 +76,9 @@ type Viewer {
     expect(generated).toContain("FirstArg<SchemaFirstCheckStorefrontResolver['product']>");
     expect(generated).toContain('Gql.Query.product.Args');
     expect(generated).toContain('Gql.Query.product.Result');
+    expect(generated).toContain(
+      "AssertTrue<IsMutuallyAssignable<Exclude<FirstArg<SchemaFirstCheckStorefrontResolver['product']>, undefined>, Gql.Query.product.Args>>",
+    );
     expect(generated).toContain('AssertTrue<IsOptionalArg<');
     expect(generated).toContain(
       "AssertTrue<HasCompatibleTailParams<SchemaFirstCheckStorefrontResolver['product']>>",
@@ -111,6 +114,9 @@ type Viewer {
     expect(generated).toContain(
       "AssertTrue<AllowsNoArgsField<SchemaFirstCheckViewerResolver['viewer'], Gql.Query.viewer.Args>>",
     );
+    expect(generated).toContain(
+      ': IsMutuallyAssignable<Exclude<FirstArg<Fn>, undefined>, Args> extends true',
+    );
     expect(generated).toContain('type HasCompatibleTailParams<Fn>');
     expect(generated).toContain('? HasCompatibleTailParams<Fn>');
     expect(generated).not.toContain(
@@ -118,6 +124,20 @@ type Viewer {
     );
     expect(generated).not.toContain(
       "Exclude<FirstArg<SchemaFirstCheckViewerResolver['viewer']>, undefined>",
+    );
+  });
+
+  it('deduplicates repeated resolver classes', async () => {
+    const generated = await renderSchemaFirstResolverChecks({
+      schemaSdl,
+      resolvers: [SchemaFirstCheckStorefrontResolver, SchemaFirstCheckStorefrontResolver],
+      tsconfig,
+      out: resolve(__dirname, 'generated/graphql-resolver-checks.ts'),
+      gqlTypesImport: './graphql',
+    });
+
+    expect(generated.match(/_Check_SchemaFirstCheckStorefrontResolver_product_args/g)).toHaveLength(
+      3,
     );
   });
 

--- a/packages/graphql/src/schema-first-resolver-checks.test.ts
+++ b/packages/graphql/src/schema-first-resolver-checks.test.ts
@@ -77,6 +77,9 @@ type Viewer {
     expect(generated).toContain('Gql.Query.product.Args');
     expect(generated).toContain('Gql.Query.product.Result');
     expect(generated).toContain('AssertTrue<IsOptionalArg<');
+    expect(generated).toContain(
+      "AssertTrue<HasCompatibleTailParams<SchemaFirstCheckStorefrontResolver['product']>>",
+    );
     expect(generated).toContain('AwaitedValue<ReturnType<');
     expect(generated).not.toContain('AllowsNoArgsField<SchemaFirstCheckStorefrontResolver');
   });
@@ -108,6 +111,8 @@ type Viewer {
     expect(generated).toContain(
       "AssertTrue<AllowsNoArgsField<SchemaFirstCheckViewerResolver['viewer'], Gql.Query.viewer.Args>>",
     );
+    expect(generated).toContain('type HasCompatibleTailParams<Fn>');
+    expect(generated).toContain('? HasCompatibleTailParams<Fn>');
     expect(generated).not.toContain(
       "IsOptionalArg<FirstArg<SchemaFirstCheckViewerResolver['viewer']>>",
     );

--- a/packages/graphql/src/schema-first-resolver-checks.test.ts
+++ b/packages/graphql/src/schema-first-resolver-checks.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { Query, Resolver } from './index';
+import {
+  generateSchemaFirstResolverChecks,
+  renderSchemaFirstResolverChecks,
+} from './schema-first-resolver-checks.lib';
+
+type Product = {
+  readonly id: string;
+  readonly name: string;
+};
+
+@Resolver()
+class SchemaFirstCheckStorefrontResolver {
+  @Query()
+  product(input = { id: 'p_lamp' }): Product | null {
+    return { id: input.id, name: 'Desk Lamp' };
+  }
+}
+
+@Resolver()
+class SchemaFirstCheckNamedStorefrontResolver {
+  @Query('product')
+  findProduct(input = { id: 'p_lamp' }): Promise<Product | null> {
+    return Promise.resolve({ id: input.id, name: 'Desk Lamp' });
+  }
+}
+
+describe('schema-first resolver checks generation', () => {
+  const tsconfig = resolve(__dirname, '../tsconfig.json');
+  const schemaSdl = `type Query {
+  product(id: ID!): Product
+}
+
+type Product {
+  id: ID!
+  name: String!
+}
+`;
+
+  it('generates args, optional args and return checks for root Query fields', async () => {
+    const generated = await renderSchemaFirstResolverChecks({
+      schemaSdl,
+      resolvers: [SchemaFirstCheckStorefrontResolver],
+      tsconfig,
+      out: resolve(__dirname, 'generated/graphql-resolver-checks.ts'),
+      gqlTypesImport: './graphql',
+    });
+
+    expect(generated).toContain("import type { Gql } from './graphql';");
+    expect(generated).toContain('SchemaFirstCheckStorefrontResolver');
+    expect(generated).toContain("FirstArg<SchemaFirstCheckStorefrontResolver['product']>");
+    expect(generated).toContain('Gql.Query.product.Args');
+    expect(generated).toContain('Gql.Query.product.Result');
+    expect(generated).toContain('AssertTrue<IsOptionalArg<');
+    expect(generated).toContain('AwaitedValue<ReturnType<');
+  });
+
+  it('uses explicit decorator field names while checking the implementation method', async () => {
+    const generated = await renderSchemaFirstResolverChecks({
+      schemaSdl,
+      resolvers: [SchemaFirstCheckNamedStorefrontResolver],
+      tsconfig,
+      out: resolve(__dirname, 'generated/graphql-resolver-checks.ts'),
+      gqlTypesImport: './graphql',
+    });
+
+    expect(generated).toContain("FirstArg<SchemaFirstCheckNamedStorefrontResolver['findProduct']>");
+    expect(generated).toContain('Gql.Query.product.Args');
+    expect(generated).toContain('Gql.Query.product.Result');
+  });
+
+  it('writes the generated check file', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'zelt-graphql-resolver-checks-'));
+    const out = join(outDir, 'graphql-resolver-checks.ts');
+
+    const result = await generateSchemaFirstResolverChecks({
+      schemaSdl,
+      resolvers: [SchemaFirstCheckStorefrontResolver],
+      tsconfig,
+      out,
+      gqlTypesImport: './graphql',
+    });
+
+    expect(result.changed).toBe(true);
+    await expect(readFile(out, 'utf8')).resolves.toContain('Gql.Query.product.Result');
+  });
+});

--- a/packages/graphql/src/schema-first-resolver-checks.test.ts
+++ b/packages/graphql/src/schema-first-resolver-checks.test.ts
@@ -14,6 +14,10 @@ type Product = {
   readonly name: string;
 };
 
+type Viewer = {
+  readonly id: string;
+};
+
 @Resolver()
 class SchemaFirstCheckStorefrontResolver {
   @Query()
@@ -30,6 +34,14 @@ class SchemaFirstCheckNamedStorefrontResolver {
   }
 }
 
+@Resolver()
+class SchemaFirstCheckViewerResolver {
+  @Query()
+  viewer(): Viewer {
+    return { id: 'viewer_1' };
+  }
+}
+
 describe('schema-first resolver checks generation', () => {
   const tsconfig = resolve(__dirname, '../tsconfig.json');
   const schemaSdl = `type Query {
@@ -39,6 +51,14 @@ describe('schema-first resolver checks generation', () => {
 type Product {
   id: ID!
   name: String!
+}
+`;
+  const viewerSchemaSdl = `type Query {
+  viewer: Viewer!
+}
+
+type Viewer {
+  id: ID!
 }
 `;
 
@@ -58,6 +78,7 @@ type Product {
     expect(generated).toContain('Gql.Query.product.Result');
     expect(generated).toContain('AssertTrue<IsOptionalArg<');
     expect(generated).toContain('AwaitedValue<ReturnType<');
+    expect(generated).not.toContain('AllowsNoArgsField<SchemaFirstCheckStorefrontResolver');
   });
 
   it('uses explicit decorator field names while checking the implementation method', async () => {
@@ -72,6 +93,27 @@ type Product {
     expect(generated).toContain("FirstArg<SchemaFirstCheckNamedStorefrontResolver['findProduct']>");
     expect(generated).toContain('Gql.Query.product.Args');
     expect(generated).toContain('Gql.Query.product.Result');
+  });
+
+  it('allows no-parameter root operation methods for fields without SDL args', async () => {
+    const generated = await renderSchemaFirstResolverChecks({
+      schemaSdl: viewerSchemaSdl,
+      resolvers: [SchemaFirstCheckViewerResolver],
+      tsconfig,
+      out: resolve(__dirname, 'generated/graphql-resolver-checks.ts'),
+      gqlTypesImport: './graphql',
+    });
+
+    expect(generated).toContain("ReturnType<SchemaFirstCheckViewerResolver['viewer']>");
+    expect(generated).toContain(
+      "AssertTrue<AllowsNoArgsField<SchemaFirstCheckViewerResolver['viewer'], Gql.Query.viewer.Args>>",
+    );
+    expect(generated).not.toContain(
+      "IsOptionalArg<FirstArg<SchemaFirstCheckViewerResolver['viewer']>>",
+    );
+    expect(generated).not.toContain(
+      "Exclude<FirstArg<SchemaFirstCheckViewerResolver['viewer']>, undefined>",
+    );
   });
 
   it('writes the generated check file', async () => {


### PR DESCRIPTION
## Summary
- Generate schema-first resolver type check files
- Check Query/Mutation resolver method args and return types against SDL-generated `Gql` types
- Ensure root operation methods use optional/default args compatible with GraphQL runtime invocation
- Wire resolver check generation into schema-first `graphqlPlugin`
- Update schema-first integration to typecheck through generated checks

## Non-goals
- No resolver map API
- No user-facing `args<T>()`
- No custom scalar/union/interface schema-first type support
- No @ResolveField parent/return full check yet
- No docs-heavy release boundary work
- No dev/watch codegen automation

## Verification
- `pnpm --filter @zeltjs/graphql typecheck`
- `pnpm --filter @zeltjs/graphql test`
- `./integration/scripts/run-tests.sh dist graphql-schema-first`
- `./integration/scripts/run-tests.sh dist graphql-dogfooding`
- `pnpm --filter @zeltjs/eslint-plugin build`
- `pnpx lint-staged`
- `pnpm typecheck`
- `pnpm lint:cycle`
- `pnpm nx run-many -t build --skip-nx-cache`
- `pnpm --filter '@examples/*' typecheck`
- `pnpm --filter website verify:docs`
- `pnpm verify-dist`
- `pnpm check:no-neverthrow-leak`
- `pnpm throw-trace`
- `pnpm test`

Note: after merging the latest `origin/main`, `pnpm run precommit` stops in `scripts/format-staged.sh` when it re-adds the tracked-but-ignored `docs/superpowers/specs/2026-06-13-graphql-scalars-unions-design.md` introduced by the #273 merge. The equivalent checks above were run manually, then `precommit-verify` was saved before committing the merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784050612&installation_id=133048706&pr_number=277&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F277&signature=063d4c15554a83b7600b8888258ca9eb7087e7edc56a723947b7cb8a3b0c0f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * GraphQL スキーマファースト開発時に、リゾルバメソッドのシグネチャがスキーマ定義と一致するかを自動チェックする機能を追加しました。

* **テスト**
  * リゾルバ型チェック生成機能の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->