### PR TITLE
feat: add generated async invocation hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           UNEXPECTED=$(echo "$HONO_REFS" \
             | grep -v "^import { HTTPException } from ['\"]hono/http-exception['\"];$" \
             | grep -v "^import { TypedResponse } from ['\"]hono['\"];$" \
+            | grep -v "^import { Context, TypedResponse } from ['\"]hono['\"];$" \
             | grep -v "^import { Context, Env, Input, MiddlewareHandler, TypedResponse } from ['\"]hono['\"];$" \
             | grep -v "^import { Context, Env as Env\\\$1, Input, MiddlewareHandler, TypedResponse } from ['\"]hono['\"];$" \
             | grep -v "^import { ContentfulStatusCode } from ['\"]hono/utils/http-status['\"];$" \

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -124,6 +124,8 @@ export default tseslint.config(
     files: [
       'packages/core/src/internal-bridge/testing.ts',
       'packages/core/src/internal-bridge/errors.ts',
+      'packages/core/src/http-invocation.ts',
+      'packages/core/src/http-invocation-runtime.ts',
       'packages/testing/src/adapters/vitest.ts',
       'packages/testing/src/adapters/jest.ts',
       'packages/testing/src/adapters/bun.ts',

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -67,7 +67,12 @@ const config: KnipConfig = {
       // neverthrow は今後 Result wrapper に使う想定で keep。
       ignoreDependencies: ['neverthrow'],
       // barrel files used by test files via '..' import path (required by no-cross-directory-lib-import rule)
-      ignore: ['src/app/index.ts', 'src/features/scheduler/index.ts'],
+      // HTTP invocation fixtures are loaded through AST/runtime generation tests.
+      ignore: [
+        'src/app/index.ts',
+        'src/features/scheduler/index.ts',
+        'src/features/http/invocation/_fixtures/**',
+      ],
     },
     'packages/graphql': {
       // gql-args-sample.lib.ts is a test fixture imported by generate-sdl.test.ts
@@ -87,7 +92,8 @@ const config: KnipConfig = {
     'packages/cli': {
       // c12 is bundled into the CLI dist, but it imports jiti at runtime.
       // jiti must stay external because its package assets are not bundle-safe.
-      ignoreDependencies: ['jiti'],
+      // SWC is referenced from generated hook-artifact tsdown config, not a static import.
+      ignoreDependencies: ['jiti', '@rollup/plugin-swc', '@swc/core'],
     },
     'packages/testing': {
       // node:test requires @types/node for types - referenced via optional peer dependency

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -77,7 +77,12 @@ const config: KnipConfig = {
     'packages/graphql': {
       // gql-args-sample.lib.ts is a test fixture imported by generate-sdl.test.ts
       // for AST-based import resolution testing (must be a separate file)
-      ignore: ['src/gql-args-sample.lib.ts'],
+      // gql-args-node-sample.* is a fixture for generated Node runtime imports.
+      ignore: [
+        'src/gql-args-sample.lib.ts',
+        'src/gql-args-node-sample.d.ts',
+        'src/gql-args-node-sample.js',
+      ],
     },
     'packages/adapter-node': {
       ignoreDependencies: ['@zeltjs/core'],
@@ -93,6 +98,8 @@ const config: KnipConfig = {
       // c12 is bundled into the CLI dist, but it imports jiti at runtime.
       // jiti must stay external because its package assets are not bundle-safe.
       // SWC is referenced from generated hook-artifact tsdown config, not a static import.
+      // HTTP invocation fixtures are loaded by tests, not production entry points.
+      ignore: ['src/_fixtures/http-local-schema-controller.ts'],
       ignoreDependencies: ['jiti', '@rollup/plugin-swc', '@swc/core'],
     },
     'packages/testing': {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "precommit": "pnpm --filter @zeltjs/eslint-plugin build && ./scripts/format-staged.sh && pnpx lint-staged && pnpm typecheck && pnpm lint:cycle && pnpm nx run-many -t build --skip-nx-cache && pnpm --filter '@examples/*' typecheck && pnpm --filter website verify:docs && pnpm verify-dist && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
     "prepare": "pnpx lefthook install",
     "codepolicy:diff": "time codepolicy --filter=diff 2>&1 | tee codepolicy.diff.log",
-    "throw-trace": "throw-trace check --exclude '**/*.test.ts' --exclude '**/dist/**' packages",
+    "throw-trace": "throw-trace check --exclude '**/*.test.ts' --exclude '**/*.d.ts' --exclude '**/dist/**' packages",
     "verify-dist": "node scripts/verify-dist-imports.mjs"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,9 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
+    "@rollup/plugin-swc": "0.4.0",
+    "@swc/core": "1.15.33",
+    "@zeltjs/core": "workspace:*",
     "chokidar": "5.0.0",
     "citty": "0.1.6",
     "consola": "3.4.2",

--- a/packages/cli/src/_fixtures/http-local-schema-controller.ts
+++ b/packages/cli/src/_fixtures/http-local-schema-controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Post, validated } from '@zeltjs/core';
+
+type LocalStandardSchema = {
+  readonly '~standard': {
+    version: 1;
+    readonly vendor: string;
+    readonly validate: (
+      value: unknown,
+    ) =>
+      | { readonly value: { readonly id: string } }
+      | { readonly issues: readonly { readonly message: string }[] };
+    types: undefined;
+  };
+};
+
+const readProperty = (value: unknown, key: string): unknown =>
+  typeof value === 'object' && value !== null ? Reflect.get(value, key) : undefined;
+
+export const LocalArtifactSchema: LocalStandardSchema = {
+  '~standard': {
+    version: 1,
+    vendor: 'zelt-test',
+    validate: (value) => {
+      const id = readProperty(value, 'id');
+      if (id !== undefined) {
+        return { value: { id: String(id) } };
+      }
+      return { issues: [{ message: 'Invalid local artifact' }] };
+    },
+    types: undefined,
+  },
+};
+
+@Controller('/local-artifact')
+export class LocalArtifactController {
+  @Post('/')
+  create(data = validated(LocalArtifactSchema)) {
+    return data;
+  }
+}

--- a/packages/cli/src/build.command.ts
+++ b/packages/cli/src/build.command.ts
@@ -17,6 +17,10 @@ import {
 import { nodeCliRuntime } from './cli-runtime.lib';
 import type { BuildConfig } from './config/config.types';
 import { loadZeltConfig } from './config/index';
+import {
+  generateHttpInvocationArtifacts,
+  invalidateHttpInvocationArtifacts,
+} from './http-invocation-artifacts.lib';
 import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './plugin-runner.lib';
 import { runTsdownBuild } from './tsdown.lib';
 
@@ -32,11 +36,59 @@ type RunBuildError =
   | InstanceType<typeof ZeltNoEntryError>
   | InstanceType<typeof ZeltMultipleBuildHooksError>;
 
+type BuildHookOptions = Parameters<typeof runPreBuildHooks>[0];
+
 const resolveBuildConfig = (args: BuildArgs, buildConfig: BuildConfig | undefined) => ({
   ...buildConfig,
   entry: args.entry ?? buildConfig?.entry,
   outDir: args.outDir ?? buildConfig?.outDir,
 });
+
+const runPreBuildHooksWithArtifactInvalidation = async (
+  cwd: string,
+  hookOptions: BuildHookOptions,
+): Promise<void> => {
+  try {
+    await runPreBuildHooks(hookOptions);
+  } catch (error) {
+    await invalidateHttpInvocationArtifacts({ cwd });
+    throw error;
+  }
+};
+
+const runBuildSteps = async (
+  cwd: string,
+  hookOptions: BuildHookOptions,
+  buildConfig: BuildConfig & { readonly entry: string },
+): Promise<void> => {
+  await generateHttpInvocationArtifacts({
+    ...hookOptions,
+    runtime: {
+      kind: 'node',
+    },
+  });
+
+  const buildResult = await runBuildHook(hookOptions);
+
+  if (!buildResult.handled) {
+    consola.start('Building...');
+    await runTsdownBuild({ cwd, config: buildConfig });
+    consola.success('Build completed');
+  }
+};
+
+const runPostBuildHooksWithArtifactInvalidation = async (
+  cwd: string,
+  hookOptions: BuildHookOptions,
+  success: boolean,
+): Promise<void> => {
+  try {
+    await runPostBuildHooks(hookOptions, { success });
+  } catch (error) {
+    await invalidateHttpInvocationArtifacts({ cwd });
+    throw error;
+  }
+};
 
 /** @throws {ZeltNoEntryError | ZeltBuildError | ZeltMultipleBuildHooksError | ZeltConfigLoadError | {} | null} */
 const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
@@ -48,30 +100,33 @@ const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
     throw new ZeltNoEntryError({});
   }
 
+  const buildConfigWithEntry = { ...buildConfig, entry: buildConfig.entry };
   const hookOptions = { cwd, config, loadStaticApp: async () => config.app() };
-
-  await runPreBuildHooks(hookOptions);
+  await runPreBuildHooksWithArtifactInvalidation(cwd, hookOptions);
 
   let success = true;
   let buildError: unknown;
+  let postBuildError: unknown;
 
   try {
-    const buildResult = await runBuildHook(hookOptions);
-
-    if (!buildResult.handled) {
-      consola.start('Building...');
-      await runTsdownBuild({ cwd, config: buildConfig });
-      consola.success('Build completed');
-    }
+    await runBuildSteps(cwd, hookOptions, buildConfigWithEntry);
   } catch (error) {
     success = false;
     buildError = error;
+    await invalidateHttpInvocationArtifacts({ cwd });
   } finally {
-    await runPostBuildHooks(hookOptions, { success });
+    try {
+      await runPostBuildHooksWithArtifactInvalidation(cwd, hookOptions, success);
+    } catch (error) {
+      postBuildError = error;
+    }
   }
 
   if (buildError !== undefined) {
     throw buildError;
+  }
+  if (postBuildError !== undefined) {
+    throw postBuildError;
   }
 };
 

--- a/packages/cli/src/build.command.ts
+++ b/packages/cli/src/build.command.ts
@@ -56,6 +56,7 @@ const runPreBuildHooksWithArtifactInvalidation = async (
   }
 };
 
+/** @throws {ZeltBuildError | ZeltMultipleBuildHooksError | Error | unsupportedParameterError | ZeltDecoratorUsageError | UnsupportedTypeScriptVersionError} */
 const runBuildSteps = async (
   cwd: string,
   hookOptions: BuildHookOptions,

--- a/packages/cli/src/dev-server.lib.ts
+++ b/packages/cli/src/dev-server.lib.ts
@@ -94,21 +94,30 @@ const runHooks = async (cwd: string, config: ZeltConfig): Promise<void> => {
   }
 
   let success = true;
+  let hookError: unknown;
+  let postBuildError: unknown;
 
   try {
     await generateHttpInvocationArtifacts(hookOptions);
     await runBuildHook(hookOptions);
   } catch (error) {
     success = false;
+    hookError = error;
     await invalidateHttpInvocationArtifacts({ cwd });
-    throw error;
   } finally {
     try {
       await runPostBuildHooks(hookOptions, { success });
     } catch (error) {
+      postBuildError = error;
       await invalidateHttpInvocationArtifacts({ cwd });
-      throw error;
     }
+  }
+
+  if (hookError !== undefined) {
+    throw hookError;
+  }
+  if (postBuildError !== undefined) {
+    throw postBuildError;
   }
 };
 

--- a/packages/cli/src/dev-server.lib.ts
+++ b/packages/cli/src/dev-server.lib.ts
@@ -82,7 +82,7 @@ const startProcess = (cwd: string, entry: string): ChildProcess => {
   return child;
 };
 
-/** @throws {ZeltMultipleBuildHooksError} */
+/** @throws {ZeltMultipleBuildHooksError | {} | null} */
 const runHooks = async (cwd: string, config: ZeltConfig): Promise<void> => {
   const hookOptions = { cwd, config, loadStaticApp: async () => config.app() };
 

--- a/packages/cli/src/dev-server.lib.ts
+++ b/packages/cli/src/dev-server.lib.ts
@@ -5,6 +5,10 @@ import consola from 'consola';
 
 import type { CliRuntime } from './cli-runtime.lib';
 import type { DevConfig, ZeltConfig } from './config/config.types';
+import {
+  generateHttpInvocationArtifacts,
+  invalidateHttpInvocationArtifacts,
+} from './http-invocation-artifacts.lib';
 import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './plugin-runner.lib';
 import type { WatcherHandle } from './watcher.lib';
 import { createWatcher } from './watcher.lib';
@@ -82,17 +86,29 @@ const startProcess = (cwd: string, entry: string): ChildProcess => {
 const runHooks = async (cwd: string, config: ZeltConfig): Promise<void> => {
   const hookOptions = { cwd, config, loadStaticApp: async () => config.app() };
 
-  await runPreBuildHooks(hookOptions);
+  try {
+    await runPreBuildHooks(hookOptions);
+  } catch (error) {
+    await invalidateHttpInvocationArtifacts({ cwd });
+    throw error;
+  }
 
   let success = true;
 
   try {
+    await generateHttpInvocationArtifacts(hookOptions);
     await runBuildHook(hookOptions);
   } catch (error) {
     success = false;
+    await invalidateHttpInvocationArtifacts({ cwd });
     throw error;
   } finally {
-    await runPostBuildHooks(hookOptions, { success });
+    try {
+      await runPostBuildHooks(hookOptions, { success });
+    } catch (error) {
+      await invalidateHttpInvocationArtifacts({ cwd });
+      throw error;
+    }
   }
 };
 

--- a/packages/cli/src/http-invocation-artifacts.lib.test.ts
+++ b/packages/cli/src/http-invocation-artifacts.lib.test.ts
@@ -1,0 +1,260 @@
+import { execFile } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { body, Controller, Post } from '@zeltjs/core';
+import { describe, expect, it } from 'vitest';
+
+import type { ZeltConfig } from './config/config.types';
+import {
+  generateHttpInvocationArtifacts,
+  invalidateHttpInvocationArtifacts,
+} from './http-invocation-artifacts.lib';
+import { LocalArtifactController } from './_fixtures/http-local-schema-controller';
+
+@Controller('/artifact')
+class ArtifactController {
+  @Post('/')
+  create(data = body('json')) {
+    return data;
+  }
+}
+
+const tsconfig = resolve(import.meta.dirname, '../tsconfig.json');
+
+const writeFakeCoreRuntime = async (cwd: string): Promise<void> => {
+  const packageDir = join(cwd, 'node_modules/@zeltjs/core');
+  await mkdir(packageDir, { recursive: true });
+  await writeFile(
+    join(packageDir, 'package.json'),
+    JSON.stringify({
+      type: 'module',
+      exports: {
+        '.': './index.mjs',
+        './http-invocation-runtime': './http-invocation-runtime.mjs',
+      },
+    }),
+    'utf8',
+  );
+  await writeFile(
+    join(packageDir, 'index.mjs'),
+    [
+      'export const Controller = () => () => undefined;',
+      'export const Post = () => () => undefined;',
+      'export const validated = () => undefined;',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  await writeFile(
+    join(packageDir, 'http-invocation-runtime.mjs'),
+    [
+      'export const validateBodyAsync = async (schema) => {',
+      "  const result = await schema['~standard'].validate({ id: 'bundled-local' });",
+      '  if (result.issues) throw new Error(result.issues[0]?.message ?? "invalid");',
+      '  return result.value;',
+      '};',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+};
+
+const runNode = async (cwd: string, scriptPath: string): Promise<string> =>
+  new Promise((resolvePromise, rejectPromise) => {
+    execFile('node', [scriptPath], { cwd }, (error, stdout, stderr) => {
+      if (error !== null) {
+        rejectPromise(new Error(stderr || error.message));
+        return;
+      }
+      resolvePromise(stdout.trim());
+    });
+  });
+
+describe('generateHttpInvocationArtifacts', () => {
+  it('writes HTTP invocation hooks and registry for a static HTTP app', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-cli-artifacts-'));
+    const config: ZeltConfig = {
+      app: () => ({ http: { getControllers: () => [ArtifactController] } }),
+    };
+
+    try {
+      const result = await generateHttpInvocationArtifacts({
+        cwd,
+        config,
+        loadStaticApp: async () => ({ http: { getControllers: () => [ArtifactController] } }),
+        tsconfig,
+      });
+
+      expect(result).toEqual({
+        registryPath: join(cwd, '.zelt/registry.mjs'),
+        hookModulePath: join(cwd, '.zelt/http-invocation.ts'),
+        artifactHash: expect.any(String),
+        controllersHash: expect.any(String),
+        hookModuleChanged: true,
+        registryChanged: true,
+      });
+
+      const hookModule = await readFile(join(cwd, '.zelt/http-invocation.ts'), 'utf8');
+      expect(hookModule).toContain(
+        "'POST /artifact ArtifactController.create': async (ctx) => [",
+      );
+
+      const registry = await readFile(join(cwd, '.zelt/registry.mjs'), 'utf8');
+      expect(registry).toContain('export const zeltRegistry = {');
+      expect(registry).toContain('version: 1');
+      expect(registry).toContain("new URL('./http-invocation.ts', import.meta.url).href");
+      expect(registry).toContain(`artifactHash: '${result.artifactHash}'`);
+      expect(registry).toContain(`controllersHash: '${result.controllersHash}'`);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a minimal registry when the static app has no HTTP controllers', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-cli-artifacts-no-http-'));
+    const config: ZeltConfig = {
+      app: () => ({}),
+    };
+
+    try {
+      const result = await generateHttpInvocationArtifacts({
+        cwd,
+        config,
+        loadStaticApp: async () => ({}),
+        tsconfig,
+      });
+
+      expect(result.artifactHash).toBeUndefined();
+      expect(result.controllersHash).toBeUndefined();
+      expect(result.hookModuleChanged).toBe(false);
+      expect(result.registryChanged).toBe(true);
+
+      const registry = await readFile(join(cwd, '.zelt/registry.mjs'), 'utf8');
+      expect(registry).toContain('version: 1');
+      expect(registry).not.toContain('httpInvocation');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('writes JavaScript HTTP invocation artifacts for node runtime mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-cli-artifacts-node-'));
+    const config: ZeltConfig = {
+      app: () => ({ http: { getControllers: () => [ArtifactController] } }),
+    };
+
+    try {
+      const result = await generateHttpInvocationArtifacts({
+        cwd,
+        config,
+        loadStaticApp: async () => ({ http: { getControllers: () => [ArtifactController] } }),
+        tsconfig,
+        runtime: {
+          kind: 'node',
+        },
+      });
+
+      expect(result.hookModulePath).toBe(join(cwd, '.zelt/http-invocation.mjs'));
+
+      const hookModule = await readFile(join(cwd, '.zelt/http-invocation.mjs'), 'utf8');
+      expect(hookModule).toContain('httpInvocationHooks');
+      expect(hookModule).toContain('POST /artifact ArtifactController.create');
+      expect(hookModule).not.toContain('satisfies Readonly');
+      expect(hookModule).not.toContain('type HttpInvocationHook');
+
+      const registry = await readFile(join(cwd, '.zelt/registry.mjs'), 'utf8');
+      expect(registry).toContain("new URL('./http-invocation.mjs', import.meta.url).href");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('bundles local validated schemas from decorator source into node runtime artifacts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-cli-artifacts-node-local-'));
+    const config: ZeltConfig = {
+      app: () => ({ http: { getControllers: () => [LocalArtifactController] } }),
+    };
+
+    try {
+      await writeFakeCoreRuntime(cwd);
+      await generateHttpInvocationArtifacts({
+        cwd,
+        config,
+        loadStaticApp: async () => ({
+          http: { getControllers: () => [LocalArtifactController] },
+        }),
+        tsconfig,
+        runtime: { kind: 'node' },
+      });
+
+      const hookModulePath = join(cwd, '.zelt/http-invocation.mjs');
+      const hookModuleSource = await readFile(hookModulePath, 'utf8');
+      expect(hookModuleSource).not.toContain('@Controller');
+      expect(hookModuleSource).not.toContain('@Post');
+
+      const runnerPath = join(cwd, 'run-hook.mjs');
+      await writeFile(
+        runnerPath,
+        [
+          "const mod = await import('./.zelt/http-invocation.mjs');",
+          "const hook = mod.httpInvocationHooks['POST /local-artifact LocalArtifactController.create'];",
+          "if (!hook) throw new Error('Generated local schema hook was not found');",
+          'const result = await hook();',
+          'console.log(JSON.stringify(result));',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+
+      await expect(runNode(cwd, runnerPath)).resolves.toBe('[{"id":"bundled-local"}]');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes stale registry artifacts when invalidated', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-cli-artifacts-invalid-'));
+    const registryPath = join(cwd, '.zelt/registry.mjs');
+
+    try {
+      await mkdir(join(cwd, '.zelt'), { recursive: true });
+      await writeFile(registryPath, 'export const zeltRegistry = { version: 1 };\n', 'utf8');
+
+      await invalidateHttpInvocationArtifacts({ cwd });
+
+      await expect(access(registryPath)).rejects.toThrow();
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidates stale registry when artifact generation fails', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-cli-artifacts-failure-'));
+    const registryPath = join(cwd, '.zelt/registry.mjs');
+    const config: ZeltConfig = {
+      app: () => ({}),
+    };
+
+    try {
+      await mkdir(join(cwd, '.zelt'), { recursive: true });
+      await writeFile(registryPath, 'export const zeltRegistry = { version: 1 };\n', 'utf8');
+
+      await expect(
+        generateHttpInvocationArtifacts({
+          cwd,
+          config,
+          loadStaticApp: async () => {
+            throw new Error('static app failed');
+          },
+          tsconfig,
+        }),
+      ).rejects.toThrow('static app failed');
+
+      await expect(access(registryPath)).rejects.toThrow();
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/http-invocation-artifacts.lib.test.ts
+++ b/packages/cli/src/http-invocation-artifacts.lib.test.ts
@@ -5,13 +5,12 @@ import { join, resolve } from 'node:path';
 
 import { body, Controller, Post } from '@zeltjs/core';
 import { describe, expect, it } from 'vitest';
-
+import { LocalArtifactController } from './_fixtures/http-local-schema-controller';
 import type { ZeltConfig } from './config/config.types';
 import {
   generateHttpInvocationArtifacts,
   invalidateHttpInvocationArtifacts,
 } from './http-invocation-artifacts.lib';
-import { LocalArtifactController } from './_fixtures/http-local-schema-controller';
 
 @Controller('/artifact')
 class ArtifactController {
@@ -97,9 +96,7 @@ describe('generateHttpInvocationArtifacts', () => {
       });
 
       const hookModule = await readFile(join(cwd, '.zelt/http-invocation.ts'), 'utf8');
-      expect(hookModule).toContain(
-        "'POST /artifact ArtifactController.create': async (ctx) => [",
-      );
+      expect(hookModule).toContain("'POST /artifact ArtifactController.create': async (ctx) => [");
 
       const registry = await readFile(join(cwd, '.zelt/registry.mjs'), 'utf8');
       expect(registry).toContain('export const zeltRegistry = {');

--- a/packages/cli/src/http-invocation-artifacts.lib.ts
+++ b/packages/cli/src/http-invocation-artifacts.lib.ts
@@ -132,6 +132,7 @@ const resolveTsdownBin = (cwd: string): string => {
     : resolve(import.meta.dirname, '../../..', 'node_modules/.bin/tsdown');
 };
 
+/** @throws {Error} */
 const bundleHookArtifact = async (input: {
   readonly cwd: string;
   readonly entry: string;
@@ -242,6 +243,7 @@ export const invalidateHttpInvocationArtifacts = async (
   await rm(resolve(options.cwd, '.zelt/registry.mjs'), { force: true });
 };
 
+/** @throws {Error | unsupportedParameterError | ZeltDecoratorUsageError | UnsupportedTypeScriptVersionError} */
 const generateHookArtifact = async (input: {
   readonly cwd: string;
   readonly controllers: readonly ControllerClass[];
@@ -295,7 +297,7 @@ const writeRegistry = async (input: {
     }),
   );
 
-/** @throws {Error} from HTTP invocation generation or filesystem writes. */
+/** @throws {Error | unsupportedParameterError | ZeltDecoratorUsageError | UnsupportedTypeScriptVersionError} from HTTP invocation generation or filesystem writes. */
 export const generateHttpInvocationArtifacts = async (
   options: GenerateHttpInvocationArtifactsOptions,
 ): Promise<GenerateHttpInvocationArtifactsResult> => {

--- a/packages/cli/src/http-invocation-artifacts.lib.ts
+++ b/packages/cli/src/http-invocation-artifacts.lib.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'node:child_process';
-import { createRequire } from 'node:module';
+import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -49,6 +49,8 @@ type ResolvedArtifactRuntime = {
   readonly bundle: boolean;
 };
 
+type UnknownFunction = (...args: unknown[]) => unknown;
+
 const resolveArtifactRuntime = (
   runtime: HttpInvocationArtifactRuntime | undefined,
 ): ResolvedArtifactRuntime => {
@@ -79,7 +81,7 @@ const readProperty = (value: unknown, key: string): unknown => {
   return property;
 };
 
-const readFunctionProperty = (value: unknown, key: string): Function | undefined => {
+const readFunctionProperty = (value: unknown, key: string): UnknownFunction | undefined => {
   const property = readProperty(value, key);
   return typeof property === 'function' ? property : undefined;
 };
@@ -227,9 +229,7 @@ const renderRegistry = (input: {
           '  },',
         ];
 
-  return ['export const zeltRegistry = {', '  version: 1,', ...httpInvocation, '};', ''].join(
-    '\n',
-  );
+  return ['export const zeltRegistry = {', '  version: 1,', ...httpInvocation, '};', ''].join('\n');
 };
 
 export type InvalidateHttpInvocationArtifactsOptions = {

--- a/packages/cli/src/http-invocation-artifacts.lib.ts
+++ b/packages/cli/src/http-invocation-artifacts.lib.ts
@@ -83,7 +83,7 @@ const readProperty = (value: unknown, key: string): unknown => {
 
 const readFunctionProperty = (value: unknown, key: string): UnknownFunction | undefined => {
   const property = readProperty(value, key);
-  return typeof property === 'function' ? property : undefined;
+  return typeof property === 'function' ? (property as UnknownFunction) : undefined;
 };
 
 const readControllers = (http: object | undefined): readonly ControllerClass[] => {

--- a/packages/cli/src/http-invocation-artifacts.lib.ts
+++ b/packages/cli/src/http-invocation-artifacts.lib.ts
@@ -1,0 +1,350 @@
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { ControllerClass } from '@zeltjs/core';
+import { generateHttpInvocationModule } from '@zeltjs/core/http-invocation';
+
+import type { ZeltConfig } from './config/config.types';
+
+export type GenerateHttpInvocationArtifactsOptions = {
+  readonly cwd: string;
+  readonly config: ZeltConfig;
+  readonly loadStaticApp: () => Promise<object>;
+  readonly tsconfig?: string;
+  readonly runtime?: HttpInvocationArtifactRuntime;
+};
+
+export type GenerateHttpInvocationArtifactsResult = {
+  readonly registryPath: string;
+  readonly hookModulePath: string;
+  readonly artifactHash: string | undefined;
+  readonly controllersHash: string | undefined;
+  readonly hookModuleChanged: boolean;
+  readonly registryChanged: boolean;
+};
+
+type HttpArtifactInput = {
+  readonly controllers: readonly ControllerClass[];
+  readonly metadata: unknown;
+};
+
+type HttpInvocationArtifactRuntime =
+  | {
+      kind: 'typescript';
+    }
+  | {
+      kind: 'node';
+    };
+
+type ResolvedArtifactRuntime = {
+  readonly sourceModuleFileName: string;
+  readonly hookModuleFileName: string;
+  readonly moduleSpecifierMode: 'typescript' | 'node';
+  readonly moduleSyntax: 'typescript' | 'javascript';
+  readonly bundle: boolean;
+};
+
+const resolveArtifactRuntime = (
+  runtime: HttpInvocationArtifactRuntime | undefined,
+): ResolvedArtifactRuntime => {
+  if (runtime?.kind === 'node') {
+    return {
+      sourceModuleFileName: 'http-invocation.mts',
+      hookModuleFileName: 'http-invocation.mjs',
+      moduleSpecifierMode: 'typescript',
+      moduleSyntax: 'typescript',
+      bundle: true,
+    };
+  }
+  return {
+    sourceModuleFileName: 'http-invocation.ts',
+    hookModuleFileName: 'http-invocation.ts',
+    moduleSpecifierMode: 'typescript',
+    moduleSyntax: 'typescript',
+    bundle: false,
+  };
+};
+
+const readObject = (value: unknown): object | undefined =>
+  typeof value === 'object' && value !== null ? value : undefined;
+
+const readProperty = (value: unknown, key: string): unknown => {
+  const object = readObject(value);
+  const property: unknown = object === undefined ? undefined : Reflect.get(object, key);
+  return property;
+};
+
+const readFunctionProperty = (value: unknown, key: string): Function | undefined => {
+  const property = readProperty(value, key);
+  return typeof property === 'function' ? property : undefined;
+};
+
+const readControllers = (http: object | undefined): readonly ControllerClass[] => {
+  if (http === undefined) return [];
+  const getControllers = readFunctionProperty(http, 'getControllers');
+  if (getControllers === undefined) return [];
+  const controllers: unknown = Reflect.apply(getControllers, http, []);
+  return Array.isArray(controllers) ? Array.from<ControllerClass>(controllers) : [];
+};
+
+const readMetadata = (http: object | undefined): unknown => {
+  if (http === undefined) return undefined;
+  const getMetadata = readFunctionProperty(http, 'getMetadata');
+  return getMetadata === undefined ? undefined : Reflect.apply(getMetadata, http, []);
+};
+
+const readHttpArtifactInput = (app: object): HttpArtifactInput => {
+  const http = readObject(readProperty(app, 'http'));
+  return {
+    controllers: readControllers(http),
+    metadata: readMetadata(http),
+  };
+};
+
+const hashText = (text: string): string => createHash('sha256').update(text).digest('hex');
+
+const writeIfChanged = async (path: string, content: string): Promise<boolean> => {
+  if (existsSync(path)) {
+    const existing = await readFile(path, 'utf8');
+    if (existing === content) return false;
+  }
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, 'utf8');
+  return true;
+};
+
+const requireFromCli = createRequire(import.meta.url);
+
+const resolvePackageImport = (specifier: string): string =>
+  pathToFileURL(requireFromCli.resolve(specifier)).href;
+
+const resolveTsdownBin = (cwd: string): string => {
+  const localBin = resolve(cwd, 'node_modules/.bin/tsdown');
+  return existsSync(localBin)
+    ? localBin
+    : resolve(import.meta.dirname, '../../..', 'node_modules/.bin/tsdown');
+};
+
+const bundleHookArtifact = async (input: {
+  readonly cwd: string;
+  readonly entry: string;
+  readonly outDir: string;
+}): Promise<void> => {
+  const tsdownBin = resolveTsdownBin(input.cwd);
+  const configPath = join(input.outDir, 'http-invocation.tsdown.config.mjs');
+  const configSource = [
+    `import swc from ${JSON.stringify(resolvePackageImport('@rollup/plugin-swc'))};`,
+    `import { defineConfig } from ${JSON.stringify(resolvePackageImport('tsdown'))};`,
+    '',
+    'const swcDecoratorPlugin = swc({',
+    '  jsc: {',
+    "    parser: { syntax: 'typescript', decorators: true },",
+    "    transform: { decoratorVersion: '2022-03' },",
+    '  },',
+    '});',
+    '',
+    'export default defineConfig({',
+    '  plugins: [swcDecoratorPlugin],',
+    `  entry: [${JSON.stringify(input.entry)}],`,
+    `  outDir: ${JSON.stringify(input.outDir)},`,
+    "  format: ['esm'],",
+    "  platform: 'node',",
+    '  clean: false,',
+    '  dts: false,',
+    '  deps: { neverBundle: [/^[^./]/] },',
+    '});',
+    '',
+  ].join('\n');
+  await writeIfChanged(configPath, configSource);
+  const args = ['--config', configPath];
+
+  const exitCode = await new Promise<number>((resolvePromise, rejectPromise) => {
+    const child = spawn(tsdownBin, args, { cwd: input.cwd, stdio: 'inherit' });
+    child.on('close', (code) => {
+      resolvePromise(code ?? 0);
+    });
+    child.on('error', (error) => {
+      rejectPromise(error);
+    });
+  });
+
+  if (exitCode !== 0) {
+    throw new Error(`Failed to bundle HTTP invocation artifact with tsdown: exit ${exitCode}`);
+  }
+};
+
+const stableJson = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`;
+  }
+  const object = readObject(value);
+  if (object !== undefined) {
+    const entries = Object.entries(object)
+      .filter(([, entryValue]) => typeof entryValue !== 'function')
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJson(entryValue)}`);
+    return `{${entries.join(',')}}`;
+  }
+  if (typeof value === 'symbol') return JSON.stringify(String(value));
+  if (typeof value === 'undefined') return '"__undefined__"';
+  return JSON.stringify(value);
+};
+
+const buildControllersHash = (
+  controllers: readonly ControllerClass[],
+  metadata: unknown,
+  artifactHash: string,
+): string =>
+  hashText(
+    stableJson({
+      controllers: controllers.map((controller) => controller.name),
+      metadata,
+      artifactHash,
+    }),
+  );
+
+const renderRegistry = (input: {
+  readonly artifactHash: string | undefined;
+  readonly controllersHash: string | undefined;
+  readonly generatedAt: string;
+  readonly hookModuleFileName: string;
+}): string => {
+  const httpInvocation =
+    input.artifactHash === undefined || input.controllersHash === undefined
+      ? []
+      : [
+          '  httpInvocation: {',
+          '    version: 1,',
+          `    module: new URL('./${input.hookModuleFileName}', import.meta.url).href,`,
+          `    artifactHash: '${input.artifactHash}',`,
+          `    generatedAt: '${input.generatedAt}',`,
+          `    controllersHash: '${input.controllersHash}',`,
+          '  },',
+        ];
+
+  return ['export const zeltRegistry = {', '  version: 1,', ...httpInvocation, '};', ''].join(
+    '\n',
+  );
+};
+
+export type InvalidateHttpInvocationArtifactsOptions = {
+  readonly cwd: string;
+};
+
+export const invalidateHttpInvocationArtifacts = async (
+  options: InvalidateHttpInvocationArtifactsOptions,
+): Promise<void> => {
+  await rm(resolve(options.cwd, '.zelt/registry.mjs'), { force: true });
+};
+
+const generateHookArtifact = async (input: {
+  readonly cwd: string;
+  readonly controllers: readonly ControllerClass[];
+  readonly metadata: unknown;
+  readonly sourceModulePath: string;
+  readonly hookModulePath: string;
+  readonly tsconfig: string;
+  readonly artifactRuntime: ResolvedArtifactRuntime;
+}): Promise<{
+  readonly artifactHash: string;
+  readonly controllersHash: string;
+  readonly hookModuleChanged: boolean;
+}> => {
+  const result = await generateHttpInvocationModule({
+    controllers: input.controllers,
+    tsconfig: input.tsconfig,
+    out: input.sourceModulePath,
+    coreImport: '@zeltjs/core/http-invocation-runtime',
+    moduleSpecifierMode: input.artifactRuntime.moduleSpecifierMode,
+    moduleSyntax: input.artifactRuntime.moduleSyntax,
+  });
+  if (input.artifactRuntime.bundle) {
+    await bundleHookArtifact({
+      cwd: input.cwd,
+      entry: input.sourceModulePath,
+      outDir: dirname(input.hookModulePath),
+    });
+  }
+  const hookModuleSource = await readFile(input.hookModulePath, 'utf8');
+  const artifactHash = hashText(hookModuleSource);
+  return {
+    artifactHash,
+    controllersHash: buildControllersHash(input.controllers, input.metadata, artifactHash),
+    hookModuleChanged: result.changed,
+  };
+};
+
+const writeRegistry = async (input: {
+  readonly registryPath: string;
+  readonly artifactHash: string | undefined;
+  readonly controllersHash: string | undefined;
+  readonly hookModuleFileName: string;
+}): Promise<boolean> =>
+  writeIfChanged(
+    input.registryPath,
+    renderRegistry({
+      artifactHash: input.artifactHash,
+      controllersHash: input.controllersHash,
+      generatedAt: new Date().toISOString(),
+      hookModuleFileName: input.hookModuleFileName,
+    }),
+  );
+
+/** @throws {Error} from HTTP invocation generation or filesystem writes. */
+export const generateHttpInvocationArtifacts = async (
+  options: GenerateHttpInvocationArtifactsOptions,
+): Promise<GenerateHttpInvocationArtifactsResult> => {
+  const artifactDir = resolve(options.cwd, '.zelt');
+  const artifactRuntime = resolveArtifactRuntime(options.runtime);
+  const sourceModulePath = join(artifactDir, artifactRuntime.sourceModuleFileName);
+  const hookModulePath = join(artifactDir, artifactRuntime.hookModuleFileName);
+  const registryPath = join(artifactDir, 'registry.mjs');
+
+  let hookModuleChanged = false;
+  let artifactHash: string | undefined;
+  let controllersHash: string | undefined;
+
+  try {
+    const staticApp = await options.loadStaticApp();
+    const input = readHttpArtifactInput(staticApp);
+
+    if (input.controllers.length > 0) {
+      const result = await generateHookArtifact({
+        cwd: options.cwd,
+        controllers: input.controllers,
+        metadata: input.metadata,
+        sourceModulePath,
+        hookModulePath,
+        tsconfig: options.tsconfig ?? resolve(options.cwd, 'tsconfig.json'),
+        artifactRuntime,
+      });
+      hookModuleChanged = result.hookModuleChanged;
+      artifactHash = result.artifactHash;
+      controllersHash = result.controllersHash;
+    }
+
+    const registryChanged = await writeRegistry({
+      registryPath,
+      artifactHash,
+      controllersHash,
+      hookModuleFileName: artifactRuntime.hookModuleFileName,
+    });
+
+    return {
+      registryPath,
+      hookModulePath,
+      artifactHash,
+      controllersHash,
+      hookModuleChanged,
+      registryChanged,
+    };
+  } catch (error) {
+    await invalidateHttpInvocationArtifacts({ cwd: options.cwd });
+    throw error;
+  }
+};

--- a/packages/cli/src/http-invocation-artifacts.lib.ts
+++ b/packages/cli/src/http-invocation-artifacts.lib.ts
@@ -51,6 +51,11 @@ type ResolvedArtifactRuntime = {
 
 type UnknownFunction = (...args: unknown[]) => unknown;
 
+function narrowToUnknownFunction(value: unknown): UnknownFunction;
+function narrowToUnknownFunction(value: unknown): unknown {
+  return value;
+}
+
 const resolveArtifactRuntime = (
   runtime: HttpInvocationArtifactRuntime | undefined,
 ): ResolvedArtifactRuntime => {
@@ -83,7 +88,7 @@ const readProperty = (value: unknown, key: string): unknown => {
 
 const readFunctionProperty = (value: unknown, key: string): UnknownFunction | undefined => {
   const property = readProperty(value, key);
-  return typeof property === 'function' ? (property as UnknownFunction) : undefined;
+  return typeof property === 'function' ? narrowToUnknownFunction(property) : undefined;
 };
 
 const readControllers = (http: object | undefined): readonly ControllerClass[] => {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -13,6 +13,7 @@ export default mergeConfig(
     },
     resolve: {
       alias: {
+        '@zeltjs/core/http-invocation': path.resolve(__dirname, '../core/src/http-invocation.ts'),
         '@zeltjs/core/internal-bridge/testing': path.resolve(
           __dirname,
           '../core/src/internal-bridge/testing.ts',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,26 @@
         "types": "./dist/internal-bridge/errors.d.cts",
         "default": "./dist/internal-bridge/errors.cjs"
       }
+    },
+    "./http-invocation": {
+      "import": {
+        "types": "./dist/http-invocation.d.ts",
+        "default": "./dist/http-invocation.js"
+      },
+      "require": {
+        "types": "./dist/http-invocation.d.cts",
+        "default": "./dist/http-invocation.cjs"
+      }
+    },
+    "./http-invocation-runtime": {
+      "import": {
+        "types": "./dist/http-invocation-runtime.d.ts",
+        "default": "./dist/http-invocation-runtime.js"
+      },
+      "require": {
+        "types": "./dist/http-invocation-runtime.d.cts",
+        "default": "./dist/http-invocation-runtime.cjs"
+      }
     }
   },
   "files": [

--- a/packages/core/src/features/http/http-invocation-registry.lib.test.ts
+++ b/packages/core/src/features/http/http-invocation-registry.lib.test.ts
@@ -1,0 +1,241 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { createApp } from '../../app';
+import { http } from './http.feature';
+import { loadHttpInvocationHooksFromRegistry } from './http-invocation-registry.lib';
+import { Controller } from './routing/controller.decorator';
+import { Post } from './routing/http-method.decorator';
+
+@Controller('/registry-runtime')
+class RegistryRuntimeController {
+  @Post('/')
+  create(data?: unknown) {
+    return data;
+  }
+}
+
+const hashText = (text: string): string => createHash('sha256').update(text).digest('hex');
+
+describe('loadHttpInvocationHooksFromRegistry', () => {
+  it('loads HTTP invocation hooks from .zelt registry', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-core-registry-'));
+    const artifactDir = join(cwd, '.zelt');
+
+    try {
+      await mkdir(artifactDir, { recursive: true });
+      const hookModuleSource = [
+        'export const httpInvocationHooks = {',
+        "  'POST /registry RegistryController.create': async () => ['from-registry'],",
+        '};',
+        '',
+      ].join('\n');
+      await writeFile(
+        join(artifactDir, 'http-invocation.mjs'),
+        hookModuleSource,
+      );
+      await writeFile(
+        join(artifactDir, 'registry.mjs'),
+        [
+          'export const zeltRegistry = {',
+          '  version: 1,',
+          '  httpInvocation: {',
+          '    version: 1,',
+          "    module: new URL('./http-invocation.mjs', import.meta.url).href,",
+          `    artifactHash: '${hashText(hookModuleSource)}',`,
+          "    generatedAt: '2026-06-15T00:00:00.000Z',",
+          "    controllersHash: 'test',",
+          '  },',
+          '};',
+          '',
+        ].join('\n'),
+      );
+
+      const hooks = await loadHttpInvocationHooksFromRegistry({ cwd });
+
+      expect(hooks).toHaveProperty('POST /registry RegistryController.create');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns undefined when registry is missing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-core-registry-missing-'));
+
+    try {
+      await expect(loadHttpInvocationHooksFromRegistry({ cwd })).resolves.toBeUndefined();
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a clear error for unsupported registry versions', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-core-registry-version-'));
+    const artifactDir = join(cwd, '.zelt');
+
+    try {
+      await mkdir(artifactDir, { recursive: true });
+      await writeFile(
+        join(artifactDir, 'registry.mjs'),
+        [
+          'export const zeltRegistry = {',
+          '  version: 2,',
+          '};',
+          '',
+        ].join('\n'),
+      );
+
+      await expect(loadHttpInvocationHooksFromRegistry({ cwd })).rejects.toThrow(
+        'Unsupported .zelt registry version 2; expected 1.',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a clear error when the HTTP invocation artifact version is unsupported', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-core-registry-artifact-version-'));
+    const artifactDir = join(cwd, '.zelt');
+
+    try {
+      await mkdir(artifactDir, { recursive: true });
+      await writeFile(join(artifactDir, 'http-invocation.mjs'), 'export const httpInvocationHooks = {};\n');
+      await writeFile(
+        join(artifactDir, 'registry.mjs'),
+        [
+          'export const zeltRegistry = {',
+          '  version: 1,',
+          '  httpInvocation: {',
+          '    version: 2,',
+          "    module: new URL('./http-invocation.mjs', import.meta.url).href,",
+          "    artifactHash: 'unused',",
+          '  },',
+          '};',
+          '',
+        ].join('\n'),
+      );
+
+      await expect(loadHttpInvocationHooksFromRegistry({ cwd })).rejects.toThrow(
+        'Unsupported HTTP invocation artifact version 2; expected 1.',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a clear error when the HTTP invocation module URL is malformed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-core-registry-module-url-'));
+    const artifactDir = join(cwd, '.zelt');
+
+    try {
+      await mkdir(artifactDir, { recursive: true });
+      await writeFile(
+        join(artifactDir, 'registry.mjs'),
+        [
+          'export const zeltRegistry = {',
+          '  version: 1,',
+          '  httpInvocation: {',
+          '    version: 1,',
+          "    module: 'not a url',",
+          "    artifactHash: 'unused',",
+          '  },',
+          '};',
+          '',
+        ].join('\n'),
+      );
+
+      await expect(loadHttpInvocationHooksFromRegistry({ cwd })).rejects.toThrow(
+        'HTTP invocation registry module URL is malformed: not a url.',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a clear error when the HTTP invocation artifact hash does not match', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-core-registry-artifact-hash-'));
+    const artifactDir = join(cwd, '.zelt');
+
+    try {
+      await mkdir(artifactDir, { recursive: true });
+      await writeFile(join(artifactDir, 'http-invocation.mjs'), 'export const httpInvocationHooks = {};\n');
+      await writeFile(
+        join(artifactDir, 'registry.mjs'),
+        [
+          'export const zeltRegistry = {',
+          '  version: 1,',
+          '  httpInvocation: {',
+          '    version: 1,',
+          "    module: new URL('./http-invocation.mjs', import.meta.url).href,",
+          "    artifactHash: 'stale-hash',",
+          '  },',
+          '};',
+          '',
+        ].join('\n'),
+      );
+
+      await expect(loadHttpInvocationHooksFromRegistry({ cwd })).rejects.toThrow(
+        'HTTP invocation artifact hash mismatch',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('lets HttpService build routes with hooks loaded from the cwd registry', async () => {
+    const originalCwd = process.cwd();
+    const cwd = await mkdtemp(join(tmpdir(), 'zelt-core-registry-runtime-'));
+    const artifactDir = join(cwd, '.zelt');
+
+    try {
+      await mkdir(artifactDir, { recursive: true });
+      const hookModuleSource = [
+        'export const httpInvocationHooks = {',
+        "  'POST /registry-runtime RegistryRuntimeController.create': async (ctx) => [ctx.body('json')],",
+        '};',
+        '',
+      ].join('\n');
+      await writeFile(
+        join(artifactDir, 'http-invocation.mjs'),
+        hookModuleSource,
+      );
+      await writeFile(
+        join(artifactDir, 'registry.mjs'),
+        [
+          'export const zeltRegistry = {',
+          '  version: 1,',
+          '  httpInvocation: {',
+          '    version: 1,',
+          "    module: new URL('./http-invocation.mjs', import.meta.url).href,",
+          `    artifactHash: '${hashText(hookModuleSource)}',`,
+          "    generatedAt: '2026-06-15T00:00:00.000Z',",
+          "    controllersHash: 'runtime-test',",
+          '  },',
+          '};',
+          '',
+        ].join('\n'),
+      );
+
+      process.chdir(cwd);
+      const app = createApp([http({ controllers: [RegistryRuntimeController] })]);
+      const runtime = await app.createRuntime();
+      const response = await runtime.http.fetch(
+        new Request('https://example.com/registry-runtime', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ source: 'registry' }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ source: 'registry' });
+    } finally {
+      process.chdir(originalCwd);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/features/http/http-invocation-registry.lib.test.ts
+++ b/packages/core/src/features/http/http-invocation-registry.lib.test.ts
@@ -1,5 +1,5 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -34,10 +34,7 @@ describe('loadHttpInvocationHooksFromRegistry', () => {
         '};',
         '',
       ].join('\n');
-      await writeFile(
-        join(artifactDir, 'http-invocation.mjs'),
-        hookModuleSource,
-      );
+      await writeFile(join(artifactDir, 'http-invocation.mjs'), hookModuleSource);
       await writeFile(
         join(artifactDir, 'registry.mjs'),
         [
@@ -81,12 +78,7 @@ describe('loadHttpInvocationHooksFromRegistry', () => {
       await mkdir(artifactDir, { recursive: true });
       await writeFile(
         join(artifactDir, 'registry.mjs'),
-        [
-          'export const zeltRegistry = {',
-          '  version: 2,',
-          '};',
-          '',
-        ].join('\n'),
+        ['export const zeltRegistry = {', '  version: 2,', '};', ''].join('\n'),
       );
 
       await expect(loadHttpInvocationHooksFromRegistry({ cwd })).rejects.toThrow(
@@ -103,7 +95,10 @@ describe('loadHttpInvocationHooksFromRegistry', () => {
 
     try {
       await mkdir(artifactDir, { recursive: true });
-      await writeFile(join(artifactDir, 'http-invocation.mjs'), 'export const httpInvocationHooks = {};\n');
+      await writeFile(
+        join(artifactDir, 'http-invocation.mjs'),
+        'export const httpInvocationHooks = {};\n',
+      );
       await writeFile(
         join(artifactDir, 'registry.mjs'),
         [
@@ -162,7 +157,10 @@ describe('loadHttpInvocationHooksFromRegistry', () => {
 
     try {
       await mkdir(artifactDir, { recursive: true });
-      await writeFile(join(artifactDir, 'http-invocation.mjs'), 'export const httpInvocationHooks = {};\n');
+      await writeFile(
+        join(artifactDir, 'http-invocation.mjs'),
+        'export const httpInvocationHooks = {};\n',
+      );
       await writeFile(
         join(artifactDir, 'registry.mjs'),
         [
@@ -199,10 +197,7 @@ describe('loadHttpInvocationHooksFromRegistry', () => {
         '};',
         '',
       ].join('\n');
-      await writeFile(
-        join(artifactDir, 'http-invocation.mjs'),
-        hookModuleSource,
-      );
+      await writeFile(join(artifactDir, 'http-invocation.mjs'), hookModuleSource);
       await writeFile(
         join(artifactDir, 'registry.mjs'),
         [

--- a/packages/core/src/features/http/http-invocation-registry.lib.ts
+++ b/packages/core/src/features/http/http-invocation-registry.lib.ts
@@ -30,6 +30,11 @@ type NodeModules = {
 
 type UnknownFunction = (...args: unknown[]) => unknown;
 
+function narrowToUnknownFunction(value: unknown): UnknownFunction;
+function narrowToUnknownFunction(value: unknown): unknown {
+  return value;
+}
+
 const readObject = (value: unknown): object | undefined =>
   typeof value === 'object' && value !== null ? value : undefined;
 
@@ -41,7 +46,7 @@ const readProperty = (value: unknown, key: string): unknown => {
 
 const readFunctionProperty = (value: unknown, key: string): UnknownFunction | undefined => {
   const property = readProperty(value, key);
-  return typeof property === 'function' ? (property as UnknownFunction) : undefined;
+  return typeof property === 'function' ? narrowToUnknownFunction(property) : undefined;
 };
 
 /** @throws {Error} */
@@ -149,7 +154,7 @@ const readHooks = (
     if (typeof hook !== 'function') {
       throw new Error(`HTTP invocation hook "${key}" from ${moduleUrl} must be a function.`);
     }
-    hooks[key] = toHttpInvocationHook(hook as UnknownFunction, moduleUrl, key);
+    hooks[key] = toHttpInvocationHook(narrowToUnknownFunction(hook), moduleUrl, key);
   }
   return hooks;
 };

--- a/packages/core/src/features/http/http-invocation-registry.lib.ts
+++ b/packages/core/src/features/http/http-invocation-registry.lib.ts
@@ -28,6 +28,8 @@ type NodeModules = {
   readonly fileURLToPath: (url: string | URL) => string;
 };
 
+type UnknownFunction = (...args: unknown[]) => unknown;
+
 const readObject = (value: unknown): object | undefined =>
   typeof value === 'object' && value !== null ? value : undefined;
 
@@ -37,7 +39,7 @@ const readProperty = (value: unknown, key: string): unknown => {
   return property;
 };
 
-const readFunctionProperty = (value: unknown, key: string): Function | undefined => {
+const readFunctionProperty = (value: unknown, key: string): UnknownFunction | undefined => {
   const property = readProperty(value, key);
   return typeof property === 'function' ? property : undefined;
 };
@@ -75,9 +77,7 @@ const readHttpInvocationEntry = (value: unknown): HttpInvocationRegistryEntry =>
   const entry = readRequiredObject(value, '.zelt registry httpInvocation must be an object.');
   const version: unknown = Reflect.get(entry, 'version');
   if (version !== 1) {
-    throw new Error(
-      `Unsupported HTTP invocation artifact version ${String(version)}; expected 1.`,
-    );
+    throw new Error(`Unsupported HTTP invocation artifact version ${String(version)}; expected 1.`);
   }
   return {
     version: 1,
@@ -95,7 +95,10 @@ const readHttpInvocationEntry = (value: unknown): HttpInvocationRegistryEntry =>
 };
 
 const readRegistry = (value: unknown): ZeltRegistry => {
-  const registry = readRequiredObject(value, '.zelt registry must export zeltRegistry as an object.');
+  const registry = readRequiredObject(
+    value,
+    '.zelt registry must export zeltRegistry as an object.',
+  );
   const version: unknown = Reflect.get(registry, 'version');
   if (version !== 1) {
     throw new Error(`Unsupported .zelt registry version ${String(version)}; expected 1.`);
@@ -107,7 +110,11 @@ const readRegistry = (value: unknown): ZeltRegistry => {
     : { version: 1, httpInvocation: readHttpInvocationEntry(httpInvocation) };
 };
 
-const toHttpInvocationHook = (hook: Function, moduleUrl: string, key: string): HttpInvocationHook => {
+const toHttpInvocationHook = (
+  hook: UnknownFunction,
+  moduleUrl: string,
+  key: string,
+): HttpInvocationHook => {
   return async (ctx) => {
     const result: unknown = await Reflect.apply(hook, undefined, [ctx]);
     if (!Array.isArray(result)) {
@@ -159,14 +166,19 @@ const toFilePath = (moduleUrl: string, fileURLToPath: (url: string | URL) => str
 };
 
 const loadNodeModules = async (): Promise<NodeModules> => {
-  const [{ existsSync }, { readFile }, { createHash }, { resolve }, { pathToFileURL, fileURLToPath }] =
-    await Promise.all([
-      import('node:fs'),
-      import('node:fs/promises'),
-      import('node:crypto'),
-      import('node:path'),
-      import('node:url'),
-    ]);
+  const [
+    { existsSync },
+    { readFile },
+    { createHash },
+    { resolve },
+    { pathToFileURL, fileURLToPath },
+  ] = await Promise.all([
+    import('node:fs'),
+    import('node:fs/promises'),
+    import('node:crypto'),
+    import('node:path'),
+    import('node:url'),
+  ]);
 
   return {
     existsSync,

--- a/packages/core/src/features/http/http-invocation-registry.lib.ts
+++ b/packages/core/src/features/http/http-invocation-registry.lib.ts
@@ -41,7 +41,7 @@ const readProperty = (value: unknown, key: string): unknown => {
 
 const readFunctionProperty = (value: unknown, key: string): UnknownFunction | undefined => {
   const property = readProperty(value, key);
-  return typeof property === 'function' ? property : undefined;
+  return typeof property === 'function' ? (property as UnknownFunction) : undefined;
 };
 
 const readRequiredObject = (value: unknown, message: string): object => {
@@ -143,7 +143,7 @@ const readHooks = (
     if (typeof hook !== 'function') {
       throw new Error(`HTTP invocation hook "${key}" from ${moduleUrl} must be a function.`);
     }
-    hooks[key] = toHttpInvocationHook(hook, moduleUrl, key);
+    hooks[key] = toHttpInvocationHook(hook as UnknownFunction, moduleUrl, key);
   }
   return hooks;
 };

--- a/packages/core/src/features/http/http-invocation-registry.lib.ts
+++ b/packages/core/src/features/http/http-invocation-registry.lib.ts
@@ -1,0 +1,243 @@
+import type { HttpInvocationHook } from './routing';
+
+export type LoadHttpInvocationHooksOptions = {
+  readonly cwd?: string;
+};
+
+type NodeProcess = {
+  readonly cwd: () => string | undefined;
+};
+
+type HttpInvocationRegistryEntry = {
+  version: 1;
+  readonly module: string;
+  readonly artifactHash: string;
+};
+
+type ZeltRegistry = {
+  version: 1;
+  readonly httpInvocation?: HttpInvocationRegistryEntry;
+};
+
+type NodeModules = {
+  readonly existsSync: (path: string) => boolean;
+  readonly readFile: (path: string, encoding: 'utf8') => Promise<string>;
+  readonly hashText: (text: string) => string;
+  readonly resolve: (...paths: readonly string[]) => string;
+  readonly pathToFileURL: (path: string) => URL;
+  readonly fileURLToPath: (url: string | URL) => string;
+};
+
+const readObject = (value: unknown): object | undefined =>
+  typeof value === 'object' && value !== null ? value : undefined;
+
+const readProperty = (value: unknown, key: string): unknown => {
+  const object = readObject(value);
+  const property: unknown = object === undefined ? undefined : Reflect.get(object, key);
+  return property;
+};
+
+const readFunctionProperty = (value: unknown, key: string): Function | undefined => {
+  const property = readProperty(value, key);
+  return typeof property === 'function' ? property : undefined;
+};
+
+const readRequiredObject = (value: unknown, message: string): object => {
+  const object = readObject(value);
+  if (object === undefined) throw new Error(message);
+  return object;
+};
+
+const readRequiredStringProperty = (value: object, key: string, message: string): string => {
+  const property: unknown = Reflect.get(value, key);
+  if (typeof property !== 'string') throw new Error(message);
+  return property;
+};
+
+const getNodeProcess = (): NodeProcess | undefined => {
+  const processObject = readObject(readProperty(globalThis, 'process'));
+  const versions = readObject(readProperty(processObject, 'versions'));
+  const cwd = readFunctionProperty(processObject, 'cwd');
+
+  if (typeof readProperty(versions, 'node') !== 'string' || cwd === undefined) {
+    return undefined;
+  }
+
+  return {
+    cwd: () => {
+      const value: unknown = Reflect.apply(cwd, processObject, []);
+      return typeof value === 'string' ? value : undefined;
+    },
+  };
+};
+
+const readHttpInvocationEntry = (value: unknown): HttpInvocationRegistryEntry => {
+  const entry = readRequiredObject(value, '.zelt registry httpInvocation must be an object.');
+  const version: unknown = Reflect.get(entry, 'version');
+  if (version !== 1) {
+    throw new Error(
+      `Unsupported HTTP invocation artifact version ${String(version)}; expected 1.`,
+    );
+  }
+  return {
+    version: 1,
+    module: readRequiredStringProperty(
+      entry,
+      'module',
+      '.zelt registry httpInvocation.module must be a string URL.',
+    ),
+    artifactHash: readRequiredStringProperty(
+      entry,
+      'artifactHash',
+      '.zelt registry httpInvocation.artifactHash must be a string.',
+    ),
+  };
+};
+
+const readRegistry = (value: unknown): ZeltRegistry => {
+  const registry = readRequiredObject(value, '.zelt registry must export zeltRegistry as an object.');
+  const version: unknown = Reflect.get(registry, 'version');
+  if (version !== 1) {
+    throw new Error(`Unsupported .zelt registry version ${String(version)}; expected 1.`);
+  }
+
+  const httpInvocation: unknown = Reflect.get(registry, 'httpInvocation');
+  return httpInvocation === undefined
+    ? { version: 1 }
+    : { version: 1, httpInvocation: readHttpInvocationEntry(httpInvocation) };
+};
+
+const toHttpInvocationHook = (hook: Function, moduleUrl: string, key: string): HttpInvocationHook => {
+  return async (ctx) => {
+    const result: unknown = await Reflect.apply(hook, undefined, [ctx]);
+    if (!Array.isArray(result)) {
+      throw new Error(`HTTP invocation hook "${key}" from ${moduleUrl} must return an array.`);
+    }
+    return Array.from<unknown>(result);
+  };
+};
+
+const readHooks = (
+  value: unknown,
+  moduleUrl: string,
+): Readonly<Record<string, HttpInvocationHook>> => {
+  const moduleObject = readRequiredObject(
+    value,
+    `HTTP invocation module ${moduleUrl} must export httpInvocationHooks.`,
+  );
+  const hooksObject = readRequiredObject(
+    readProperty(moduleObject, 'httpInvocationHooks'),
+    `HTTP invocation module ${moduleUrl} must export httpInvocationHooks.`,
+  );
+
+  const hooks: Record<string, HttpInvocationHook> = {};
+  for (const key of Object.keys(hooksObject)) {
+    const hook: unknown = Reflect.get(hooksObject, key);
+    if (typeof hook !== 'function') {
+      throw new Error(`HTTP invocation hook "${key}" from ${moduleUrl} must be a function.`);
+    }
+    hooks[key] = toHttpInvocationHook(hook, moduleUrl, key);
+  }
+  return hooks;
+};
+
+const toFilePath = (moduleUrl: string, fileURLToPath: (url: string | URL) => string): string => {
+  let parsed: URL;
+  try {
+    parsed = new URL(moduleUrl);
+  } catch (cause) {
+    throw new Error(`HTTP invocation registry module URL is malformed: ${moduleUrl}.`, {
+      cause,
+    });
+  }
+  if (parsed.protocol !== 'file:') {
+    throw new Error(
+      `HTTP invocation artifact hash verification requires a file URL, got ${moduleUrl}.`,
+    );
+  }
+  return fileURLToPath(parsed);
+};
+
+const loadNodeModules = async (): Promise<NodeModules> => {
+  const [{ existsSync }, { readFile }, { createHash }, { resolve }, { pathToFileURL, fileURLToPath }] =
+    await Promise.all([
+      import('node:fs'),
+      import('node:fs/promises'),
+      import('node:crypto'),
+      import('node:path'),
+      import('node:url'),
+    ]);
+
+  return {
+    existsSync,
+    readFile,
+    hashText: (text) => createHash('sha256').update(text).digest('hex'),
+    resolve,
+    pathToFileURL,
+    fileURLToPath,
+  };
+};
+
+const loadRegistry = async (registryPath: string, modules: NodeModules): Promise<ZeltRegistry> => {
+  const registryUrl = modules.pathToFileURL(registryPath).href;
+  let registryModule: unknown;
+  try {
+    registryModule = await import(registryUrl);
+  } catch (cause) {
+    throw new Error(`Failed to load .zelt registry at ${registryPath}.`, { cause });
+  }
+  return readRegistry(readProperty(registryModule, 'zeltRegistry'));
+};
+
+const verifyArtifact = async (
+  entry: HttpInvocationRegistryEntry,
+  modules: NodeModules,
+): Promise<void> => {
+  const modulePath = toFilePath(entry.module, modules.fileURLToPath);
+  const artifactSource = await modules.readFile(modulePath, 'utf8');
+  const actualArtifactHash = modules.hashText(artifactSource);
+  if (actualArtifactHash !== entry.artifactHash) {
+    throw new Error(
+      `HTTP invocation artifact hash mismatch for ${modulePath}; registry has ${entry.artifactHash}, file has ${actualArtifactHash}.`,
+    );
+  }
+};
+
+const loadHooks = async (
+  entry: HttpInvocationRegistryEntry,
+): Promise<Readonly<Record<string, HttpInvocationHook>>> => {
+  let hooksModule: unknown;
+  try {
+    hooksModule = await import(entry.module);
+  } catch (cause) {
+    throw new Error(`Failed to load HTTP invocation hooks from ${entry.module}.`, { cause });
+  }
+  return readHooks(hooksModule, entry.module);
+};
+
+const resolveRegistryPath = (
+  options: LoadHttpInvocationHooksOptions,
+  processLike: NodeProcess,
+  modules: NodeModules,
+): string | undefined => {
+  const cwd = options.cwd ?? processLike.cwd();
+  return cwd === undefined ? undefined : modules.resolve(cwd, '.zelt/registry.mjs');
+};
+
+/** @throws {Error} when a present registry is malformed or its hook module cannot be loaded. */
+export const loadHttpInvocationHooksFromRegistry = async (
+  options: LoadHttpInvocationHooksOptions = {},
+): Promise<Readonly<Record<string, HttpInvocationHook>> | undefined> => {
+  const processLike = getNodeProcess();
+  if (processLike === undefined) return undefined;
+
+  const modules = await loadNodeModules();
+  const registryPath = resolveRegistryPath(options, processLike, modules);
+  if (registryPath === undefined || !modules.existsSync(registryPath)) return undefined;
+
+  const registry = await loadRegistry(registryPath, modules);
+  if (registry.httpInvocation === undefined) return undefined;
+
+  await verifyArtifact(registry.httpInvocation, modules);
+  return loadHooks(registry.httpInvocation);
+};

--- a/packages/core/src/features/http/http-invocation-registry.lib.ts
+++ b/packages/core/src/features/http/http-invocation-registry.lib.ts
@@ -44,12 +44,14 @@ const readFunctionProperty = (value: unknown, key: string): UnknownFunction | un
   return typeof property === 'function' ? (property as UnknownFunction) : undefined;
 };
 
+/** @throws {Error} */
 const readRequiredObject = (value: unknown, message: string): object => {
   const object = readObject(value);
   if (object === undefined) throw new Error(message);
   return object;
 };
 
+/** @throws {Error} */
 const readRequiredStringProperty = (value: object, key: string, message: string): string => {
   const property: unknown = Reflect.get(value, key);
   if (typeof property !== 'string') throw new Error(message);
@@ -73,6 +75,7 @@ const getNodeProcess = (): NodeProcess | undefined => {
   };
 };
 
+/** @throws {Error} */
 const readHttpInvocationEntry = (value: unknown): HttpInvocationRegistryEntry => {
   const entry = readRequiredObject(value, '.zelt registry httpInvocation must be an object.');
   const version: unknown = Reflect.get(entry, 'version');
@@ -94,6 +97,7 @@ const readHttpInvocationEntry = (value: unknown): HttpInvocationRegistryEntry =>
   };
 };
 
+/** @throws {Error} */
 const readRegistry = (value: unknown): ZeltRegistry => {
   const registry = readRequiredObject(
     value,
@@ -110,6 +114,7 @@ const readRegistry = (value: unknown): ZeltRegistry => {
     : { version: 1, httpInvocation: readHttpInvocationEntry(httpInvocation) };
 };
 
+/** @throws {Error} */
 const toHttpInvocationHook = (
   hook: UnknownFunction,
   moduleUrl: string,
@@ -124,6 +129,7 @@ const toHttpInvocationHook = (
   };
 };
 
+/** @throws {Error} */
 const readHooks = (
   value: unknown,
   moduleUrl: string,
@@ -148,6 +154,7 @@ const readHooks = (
   return hooks;
 };
 
+/** @throws {Error} */
 const toFilePath = (moduleUrl: string, fileURLToPath: (url: string | URL) => string): string => {
   let parsed: URL;
   try {
@@ -190,6 +197,7 @@ const loadNodeModules = async (): Promise<NodeModules> => {
   };
 };
 
+/** @throws {Error} */
 const loadRegistry = async (registryPath: string, modules: NodeModules): Promise<ZeltRegistry> => {
   const registryUrl = modules.pathToFileURL(registryPath).href;
   let registryModule: unknown;
@@ -201,6 +209,7 @@ const loadRegistry = async (registryPath: string, modules: NodeModules): Promise
   return readRegistry(readProperty(registryModule, 'zeltRegistry'));
 };
 
+/** @throws {Error} */
 const verifyArtifact = async (
   entry: HttpInvocationRegistryEntry,
   modules: NodeModules,
@@ -215,6 +224,7 @@ const verifyArtifact = async (
   }
 };
 
+/** @throws {Error} */
 const loadHooks = async (
   entry: HttpInvocationRegistryEntry,
 ): Promise<Readonly<Record<string, HttpInvocationHook>>> => {

--- a/packages/core/src/features/http/http.service.ts
+++ b/packages/core/src/features/http/http.service.ts
@@ -5,6 +5,7 @@ import { DefaultErrorHandler } from './error/default.error-handler';
 import type { HttpOptions } from './http.types';
 import { createBootstrapMiddleware, createRequestRootChecker } from './http-bootstrap.lib';
 import { createRouterErrorHandler, resolveErrorHandlers } from './http-error-handlers.lib';
+import { loadHttpInvocationHooksFromRegistry } from './http-invocation-registry.lib';
 import {
   guardMiddleware,
   middlewareIdentity,
@@ -107,11 +108,14 @@ export class HttpService {
       hono.use(guardMiddleware(middlewareIdentity(input), resolveMiddleware(input, resolver)));
     }
 
+    const invocationHooks = await loadHttpInvocationHooksFromRegistry();
+
     buildRoutes({
       hono,
       controllers: options.controllers ?? [],
       resolver,
       lifecycle: this.lifecycleManager,
+      ...(invocationHooks !== undefined && { invocationHooks }),
     });
 
     return hono;

--- a/packages/core/src/features/http/invocation/_fixtures/custom-core.ts
+++ b/packages/core/src/features/http/invocation/_fixtures/custom-core.ts
@@ -1,0 +1,1 @@
+export const body = (): unknown => ({ from: 'custom-core' });

--- a/packages/core/src/features/http/invocation/_fixtures/schemas.ts
+++ b/packages/core/src/features/http/invocation/_fixtures/schemas.ts
@@ -1,0 +1,28 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
+const readProperty = (value: unknown, key: string): unknown =>
+  typeof value === 'object' && value !== null ? Reflect.get(value, key) : undefined;
+
+export const ImportedUserSchema: StandardSchemaV1<unknown, { readonly name: string }> = {
+  '~standard': {
+    version: 1,
+    vendor: 'zelt-test',
+    validate: (value) => {
+      const name = readProperty(value, 'name');
+      if (typeof name === 'string') {
+        return { value: { name } };
+      }
+      return { issues: [{ message: 'Invalid user' }] };
+    },
+    types: undefined,
+  },
+};
+
+export const httpInvocationHooks: StandardSchemaV1<unknown, { readonly name: string }> =
+  ImportedUserSchema;
+
+export const HttpInvocationHook: StandardSchemaV1<unknown, { readonly name: string }> =
+  ImportedUserSchema;
+
+export const makeSchema = (): StandardSchemaV1<unknown, { readonly name: string }> =>
+  ImportedUserSchema;

--- a/packages/core/src/features/http/invocation/generate-http-invocation-internal.lib.ts
+++ b/packages/core/src/features/http/invocation/generate-http-invocation-internal.lib.ts
@@ -1,9 +1,8 @@
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
-
-import { collectRoutes } from '../routing';
 import type { ControllerClass } from '../routing';
+import { collectRoutes } from '../routing';
 
 type TSProgram = import('typescript').Program;
 type TypeScriptModule = typeof import('typescript');
@@ -191,8 +190,7 @@ class ImportRegistry {
   }
 }
 
-const stripKnownExtension = (path: string): string =>
-  path.replace(/\.(?:[cm]?[tj]sx?)$/, '');
+const stripKnownExtension = (path: string): string => path.replace(/\.(?:[cm]?[tj]sx?)$/, '');
 
 const normalizePath = (path: string): string => path.replaceAll('\\', '/');
 
@@ -358,15 +356,15 @@ const findParameterAtPosition = (
   return visit(sourceFile);
 };
 
-const getSourceFileForPosition = (
-  program: TSProgram,
-  pos: Position,
-): TSSourceFile | undefined => program.getSourceFile(pos.sourceFile);
+const getSourceFileForPosition = (program: TSProgram, pos: Position): TSSourceFile | undefined =>
+  program.getSourceFile(pos.sourceFile);
 
 const findParameterNode = (
   param: ParamInfo,
   ctx: RenderContext,
-): { readonly sourceFile: TSSourceFile; readonly parameter: TSParameterDeclaration } | undefined => {
+):
+  | { readonly sourceFile: TSSourceFile; readonly parameter: TSParameterDeclaration }
+  | undefined => {
   if (!param.pos) return undefined;
   const sourceFile = getSourceFileForPosition(ctx.program, param.pos);
   if (!sourceFile) return undefined;
@@ -467,10 +465,7 @@ const hasExportModifier = (node: TSNode, ts: TypeScriptModule): boolean =>
   (ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ??
     false);
 
-const exportDeclarationNames = (
-  stmt: TSStatement,
-  ts: TypeScriptModule,
-): readonly string[] => {
+const exportDeclarationNames = (stmt: TSStatement, ts: TypeScriptModule): readonly string[] => {
   if (!ts.isExportDeclaration(stmt)) return [];
   const clause = stmt.exportClause;
   if (!clause || !ts.isNamedExports(clause)) return [];
@@ -529,10 +524,7 @@ const resolveSchemaIdentifier = (
   return undefined;
 };
 
-const isLocalCoreInjectionModule = (
-  sourceFile: TSSourceFile,
-  moduleSpecifier: string,
-): boolean => {
+const isLocalCoreInjectionModule = (sourceFile: TSSourceFile, moduleSpecifier: string): boolean => {
   if (!moduleSpecifier.startsWith('.')) return false;
   const resolved = normalizePath(resolve(dirname(sourceFile.fileName), moduleSpecifier));
   return (
@@ -543,10 +535,7 @@ const isLocalCoreInjectionModule = (
   );
 };
 
-const isAllowedHelperModule = (
-  sourceFile: TSSourceFile,
-  moduleSpecifier: string,
-): boolean =>
+const isAllowedHelperModule = (sourceFile: TSSourceFile, moduleSpecifier: string): boolean =>
   moduleSpecifier === '@zeltjs/core' || isLocalCoreInjectionModule(sourceFile, moduleSpecifier);
 
 const helperKindFromExportName = (exportedName: string): HelperKind | undefined => {
@@ -764,10 +753,7 @@ type AnalyzableCall = {
   readonly call: TSCallExpression;
 };
 
-const findAnalyzableCall = (
-  param: ParamInfo,
-  ctx: RenderContext,
-): AnalyzableCall | undefined => {
+const findAnalyzableCall = (param: ParamInfo, ctx: RenderContext): AnalyzableCall | undefined => {
   const found = findParameterNode(param, ctx);
   const initializer = found?.parameter.initializer;
   if (!found || !initializer) return undefined;
@@ -870,9 +856,9 @@ const renderHook = (hook: HookSpec): string => {
 
 const renderTypePrelude = (): string =>
   [
-    "type HttpInvocationHookContext = {",
+    'type HttpInvocationHookContext = {',
     "  readonly body: (type?: 'json' | 'form' | 'text') => unknown;",
-    "};",
+    '};',
     '',
     'type HttpInvocationHook = (',
     '  ctx: HttpInvocationHookContext,',
@@ -892,9 +878,7 @@ const renderModule = (
   ];
   const typePrelude = syntax === 'typescript' ? [renderTypePrelude(), ''] : [];
   const exportEnd =
-    syntax === 'typescript'
-      ? '} satisfies Readonly<Record<string, HttpInvocationHook>>;'
-      : '};';
+    syntax === 'typescript' ? '} satisfies Readonly<Record<string, HttpInvocationHook>>;' : '};';
   const parts = [
     ...importLines,
     ...(importLines.length > 0 ? [''] : []),
@@ -921,7 +905,10 @@ export const renderHttpInvocationModule = async (
     ts: cachedProgram.ts,
     out: options.out,
     coreImport: options.coreImport ?? '@zeltjs/core/http-invocation-runtime',
-    imports: new ImportRegistry(options.moduleSpecifierMode ?? 'typescript', options.runtimeImportMap),
+    imports: new ImportRegistry(
+      options.moduleSpecifierMode ?? 'typescript',
+      options.runtimeImportMap,
+    ),
     inspect,
   };
 

--- a/packages/core/src/features/http/invocation/generate-http-invocation-internal.lib.ts
+++ b/packages/core/src/features/http/invocation/generate-http-invocation-internal.lib.ts
@@ -1,0 +1,952 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
+
+import { collectRoutes } from '../routing';
+import type { ControllerClass } from '../routing';
+
+type TSProgram = import('typescript').Program;
+type TypeScriptModule = typeof import('typescript');
+type TSSourceFile = import('typescript').SourceFile;
+type TSNode = import('typescript').Node;
+type TSExpression = import('typescript').Expression;
+type TSParameterDeclaration = import('typescript').ParameterDeclaration;
+type TSCallExpression = import('typescript').CallExpression;
+type TSImportDeclaration = import('typescript').ImportDeclaration;
+type TSStatement = import('typescript').Statement;
+type TSClassDeclaration = import('typescript').ClassDeclaration;
+
+type Position = {
+  readonly sourceFile: string;
+  readonly line: number;
+  readonly column: number;
+};
+
+type ParamInfo = {
+  readonly name: string;
+  readonly pos: Position | undefined;
+};
+
+type MethodInfo = {
+  readonly name: string | symbol;
+  readonly params: readonly ParamInfo[];
+};
+
+type ClassMetadata = {
+  readonly methods: readonly MethodInfo[];
+};
+
+type InspectError = {
+  readonly code: string;
+  readonly message: string;
+};
+
+type InspectResult<T> = {
+  readonly value?: T;
+  readonly error?: InspectError;
+  isErr(): boolean;
+};
+
+type CachedProgram = {
+  readonly program: TSProgram;
+  readonly ts: TypeScriptModule;
+};
+
+type InspectModule = {
+  readonly getOrCreateProgram: (tsconfigPath: string) => PromiseLike<InspectResult<CachedProgram>>;
+  readonly getSourcePosition: (cls: object) => Position | undefined;
+};
+
+type ModuleSpecifierMode = 'typescript' | 'node';
+type ModuleSyntax = 'typescript' | 'javascript';
+
+export type RuntimeImportMap = {
+  readonly sourceRoot: string;
+  readonly runtimeRoot: string;
+};
+
+export type RenderHttpInvocationModuleOptions = {
+  readonly controllers: readonly ControllerClass[];
+  readonly tsconfig: string;
+  readonly out: string;
+  /** Controls where the generated module imports validateBodyAsync from. */
+  readonly coreImport?: string;
+  readonly moduleSpecifierMode?: ModuleSpecifierMode;
+  readonly moduleSyntax?: ModuleSyntax;
+  readonly runtimeImportMap?: RuntimeImportMap;
+};
+
+export type GenerateHttpInvocationModuleOptions = RenderHttpInvocationModuleOptions;
+
+export type GenerateHttpInvocationModuleResult = {
+  readonly changed: boolean;
+};
+
+type InjectableExpression = {
+  readonly expression: string;
+  readonly usesCtx: boolean;
+  readonly usesValidation: boolean;
+};
+
+type HookSpec = {
+  readonly key: string;
+  readonly params: readonly InjectableExpression[];
+};
+
+type ResolvedImport = {
+  readonly modulePath: string;
+  readonly exportName: string;
+  readonly localName: string;
+};
+
+type HelperKind = 'body' | 'validated';
+
+type RenderContext = {
+  readonly program: TSProgram;
+  readonly ts: TypeScriptModule;
+  readonly out: string;
+  readonly coreImport: string;
+  readonly imports: ImportRegistry;
+  readonly inspect: InspectModule;
+};
+
+type ImportEntry = {
+  readonly moduleSpecifier: string;
+  readonly exportName: string;
+  readonly localName: string;
+};
+
+class ImportRegistry {
+  readonly #entries: ImportEntry[] = [];
+  readonly #mode: ModuleSpecifierMode;
+  readonly #runtimeImportMap: RuntimeImportMap | undefined;
+  readonly #usedNames = new Set<string>([
+    'ctx',
+    'validateBodyAsync',
+    'HttpInvocationHookContext',
+    'HttpInvocationHook',
+    'httpInvocationHooks',
+  ]);
+
+  constructor(mode: ModuleSpecifierMode, runtimeImportMap: RuntimeImportMap | undefined) {
+    this.#mode = mode;
+    this.#runtimeImportMap = runtimeImportMap;
+  }
+
+  add(input: ResolvedImport, out: string): string {
+    const moduleSpecifier = toGeneratedModuleSpecifier(
+      out,
+      input.modulePath,
+      this.#mode,
+      this.#runtimeImportMap,
+    );
+    const existing = this.#entries.find(
+      (entry) =>
+        entry.moduleSpecifier === moduleSpecifier &&
+        entry.exportName === input.exportName &&
+        entry.localName === input.localName,
+    );
+    if (existing) return existing.localName;
+
+    const localName = this.#reserveName(input.localName);
+    this.#entries.push({ moduleSpecifier, exportName: input.exportName, localName });
+    return localName;
+  }
+
+  render(): readonly string[] {
+    const grouped = new Map<string, ImportEntry[]>();
+    for (const entry of this.#entries) {
+      const entries = grouped.get(entry.moduleSpecifier) ?? [];
+      entries.push(entry);
+      grouped.set(entry.moduleSpecifier, entries);
+    }
+
+    return [...grouped.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([moduleSpecifier, entries]) => {
+        const specifiers = entries
+          .map((entry) =>
+            entry.exportName === entry.localName
+              ? entry.exportName
+              : `${entry.exportName} as ${entry.localName}`,
+          )
+          .join(', ');
+        return `import { ${specifiers} } from '${moduleSpecifier}';`;
+      });
+  }
+
+  #reserveName(preferred: string): string {
+    if (!this.#usedNames.has(preferred)) {
+      this.#usedNames.add(preferred);
+      return preferred;
+    }
+
+    let suffix = 2;
+    while (this.#usedNames.has(`${preferred}${suffix}`)) {
+      suffix += 1;
+    }
+    const name = `${preferred}${suffix}`;
+    this.#usedNames.add(name);
+    return name;
+  }
+}
+
+const stripKnownExtension = (path: string): string =>
+  path.replace(/\.(?:[cm]?[tj]sx?)$/, '');
+
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
+
+const NODE_EXTENSION_REPLACEMENTS: readonly [RegExp, string][] = [
+  [/\.mts$/, '.mjs'],
+  [/\.cts$/, '.cjs'],
+  [/\.(?:tsx?|jsx)$/, '.js'],
+];
+
+const hasNodeRuntimeExtension = (path: string): boolean =>
+  ['.mjs', '.cjs', '.js'].some((extension) => path.endsWith(extension));
+
+const toNodeImportPath = (path: string): string => {
+  if (hasNodeRuntimeExtension(path)) return path;
+  const replacement = NODE_EXTENSION_REPLACEMENTS.find(([pattern]) => pattern.test(path));
+  if (replacement) return path.replace(replacement[0], replacement[1]);
+  return `${stripKnownExtension(path)}.js`;
+};
+
+const renderModulePath = (modulePath: string, mode: ModuleSpecifierMode): string =>
+  mode === 'node' ? toNodeImportPath(modulePath) : stripKnownExtension(modulePath);
+
+const isRelativeInsideRoot = (path: string): boolean =>
+  path !== '' && !path.startsWith('..') && !isAbsolute(path);
+
+const toRuntimeImportPath = (
+  modulePath: string,
+  runtimeImportMap: RuntimeImportMap | undefined,
+): string => {
+  if (runtimeImportMap === undefined) return modulePath;
+  const sourceRoot = resolve(runtimeImportMap.sourceRoot);
+  const sourcePath = resolve(modulePath);
+  const relativeSourcePath = relative(sourceRoot, sourcePath);
+  if (!isRelativeInsideRoot(relativeSourcePath)) return modulePath;
+  return resolve(runtimeImportMap.runtimeRoot, relativeSourcePath);
+};
+
+const toGeneratedModuleSpecifier = (
+  out: string,
+  modulePath: string,
+  mode: ModuleSpecifierMode,
+  runtimeImportMap: RuntimeImportMap | undefined,
+): string => {
+  if (!modulePath.startsWith('.') && !modulePath.startsWith('/')) return modulePath;
+
+  const outDir = dirname(resolve(out));
+  const runtimeModulePath = toRuntimeImportPath(modulePath, runtimeImportMap);
+  const resolvedModule = renderModulePath(resolve(runtimeModulePath), mode);
+  const relativePath = normalizePath(relative(outDir, resolvedModule));
+  return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+};
+
+const writeIfChanged = async (path: string, content: string): Promise<boolean> => {
+  if (existsSync(path)) {
+    const existing = await readFile(path, 'utf8');
+    if (existing === content) return false;
+  }
+  await writeFile(path, content, 'utf8');
+  return true;
+};
+
+const findMethodInfo = (
+  metadata: ClassMetadata,
+  methodName: string | symbol,
+): MethodInfo | undefined => metadata.methods.find((method) => method.name === methodName);
+
+const findClassAtPosition = (
+  sourceFile: TSSourceFile,
+  offset: number,
+  ts: TypeScriptModule,
+): TSClassDeclaration | undefined => {
+  const visit = (node: TSNode): TSClassDeclaration | undefined => {
+    const child = ts.forEachChild(node, visit);
+    if (child) return child;
+    return ts.isClassDeclaration(node) && node.pos <= offset && offset < node.end
+      ? node
+      : undefined;
+  };
+  return visit(sourceFile);
+};
+
+const methodNameFromNode = (
+  name: import('typescript').PropertyName,
+  ts: TypeScriptModule,
+): string | symbol => {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return name.getText();
+};
+
+const parameterNameFromNode = (param: TSParameterDeclaration, ts: TypeScriptModule): string =>
+  ts.isIdentifier(param.name) ? param.name.text : param.name.getText();
+
+const positionFromNode = (
+  sourceFile: TSSourceFile,
+  node: TSNode,
+  ts: TypeScriptModule,
+): Position => {
+  const point = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart());
+  return {
+    sourceFile: sourceFile.fileName,
+    line: point.line + 1,
+    column: point.character + 1,
+  };
+};
+
+const methodInfoFromNode = (
+  member: import('typescript').MethodDeclaration,
+  sourceFile: TSSourceFile,
+  ts: TypeScriptModule,
+): MethodInfo => ({
+  name: methodNameFromNode(member.name, ts),
+  params: member.parameters.map((param) => ({
+    name: parameterNameFromNode(param, ts),
+    pos: positionFromNode(sourceFile, param, ts),
+  })),
+});
+
+const buildClassMetadata = (
+  classNode: TSClassDeclaration,
+  sourceFile: TSSourceFile,
+  ts: TypeScriptModule,
+): ClassMetadata => ({
+  methods: classNode.members
+    .filter((member) => ts.isMethodDeclaration(member))
+    .map((member) => methodInfoFromNode(member, sourceFile, ts)),
+});
+
+const resolveControllerMetadata = (
+  controller: ControllerClass,
+  ctx: RenderContext,
+): ClassMetadata => {
+  const position = ctx.inspect.getSourcePosition(controller);
+  if (!position) {
+    throw new Error(`Failed to inspect ${controller.name} for HTTP invocation generation`);
+  }
+  const sourceFile = ctx.program.getSourceFile(position.sourceFile);
+  if (!sourceFile) {
+    throw new Error(`Failed to inspect ${controller.name}: source file not found`);
+  }
+  const offset = ctx.ts.getPositionOfLineAndCharacter(
+    sourceFile,
+    position.line - 1,
+    position.column - 1,
+  );
+  const classNode = findClassAtPosition(sourceFile, offset, ctx.ts);
+  if (!classNode) {
+    throw new Error(`Failed to inspect ${controller.name}: class declaration not found`);
+  }
+  return buildClassMetadata(classNode, sourceFile, ctx.ts);
+};
+
+const findParameterAtPosition = (
+  sourceFile: TSSourceFile,
+  offset: number,
+  ts: TypeScriptModule,
+): TSParameterDeclaration | undefined => {
+  const visit = (node: TSNode): TSParameterDeclaration | undefined => {
+    if (node.getStart() === offset && ts.isParameter(node)) return node;
+    return ts.forEachChild(node, visit);
+  };
+  return visit(sourceFile);
+};
+
+const getSourceFileForPosition = (
+  program: TSProgram,
+  pos: Position,
+): TSSourceFile | undefined => program.getSourceFile(pos.sourceFile);
+
+const findParameterNode = (
+  param: ParamInfo,
+  ctx: RenderContext,
+): { readonly sourceFile: TSSourceFile; readonly parameter: TSParameterDeclaration } | undefined => {
+  if (!param.pos) return undefined;
+  const sourceFile = getSourceFileForPosition(ctx.program, param.pos);
+  if (!sourceFile) return undefined;
+  const offset = ctx.ts.getPositionOfLineAndCharacter(
+    sourceFile,
+    param.pos.line - 1,
+    param.pos.column - 1,
+  );
+  const parameter = findParameterAtPosition(sourceFile, offset, ctx.ts);
+  return parameter ? { sourceFile, parameter } : undefined;
+};
+
+const unwrapExpression = (expr: TSExpression, ts: TypeScriptModule): TSExpression => {
+  let current = expr;
+  while (
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isParenthesizedExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+};
+
+const getStringLiteral = (
+  expr: TSExpression | undefined,
+  ts: TypeScriptModule,
+): string | undefined => {
+  if (!expr) return undefined;
+  const unwrapped = unwrapExpression(expr, ts);
+  return ts.isStringLiteral(unwrapped) ? unwrapped.text : undefined;
+};
+
+const resolveRelativeImport = (sourceFile: TSSourceFile, moduleSpecifier: string): string => {
+  if (!moduleSpecifier.startsWith('.')) return moduleSpecifier;
+  return resolve(dirname(sourceFile.fileName), moduleSpecifier);
+};
+
+const getImportModuleSpecifier = (
+  importDecl: TSImportDeclaration,
+  ts: TypeScriptModule,
+): string | undefined =>
+  ts.isStringLiteral(importDecl.moduleSpecifier) ? importDecl.moduleSpecifier.text : undefined;
+
+const getNamedImportElements = (
+  namedBindings: import('typescript').NamedImportBindings | undefined,
+  ts: TypeScriptModule,
+): readonly import('typescript').ImportSpecifier[] => {
+  if (!namedBindings || !ts.isNamedImports(namedBindings)) return [];
+  return [...namedBindings.elements];
+};
+
+const importSpecifierName = (
+  element: import('typescript').ImportSpecifier,
+): { readonly exportName: string; readonly localName: string } => ({
+  exportName: element.propertyName?.text ?? element.name.text,
+  localName: element.name.text,
+});
+
+const resolveNamedImport = (
+  importDecl: TSImportDeclaration,
+  localName: string,
+  ts: TypeScriptModule,
+): { readonly exportName: string; readonly localName: string } | undefined => {
+  const importClause = importDecl.importClause;
+  if (!importClause || importClause.isTypeOnly) return undefined;
+  const elements = getNamedImportElements(importClause.namedBindings, ts);
+
+  const element = elements.find(
+    (candidate) => !candidate.isTypeOnly && candidate.name.text === localName,
+  );
+  return element ? importSpecifierName(element) : undefined;
+};
+
+const findIdentifierImport = (
+  sourceFile: TSSourceFile,
+  localName: string,
+  ts: TypeScriptModule,
+): ResolvedImport | undefined => {
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    const specifier = getImportModuleSpecifier(stmt, ts);
+    if (!specifier) continue;
+    const named = resolveNamedImport(stmt, localName, ts);
+    if (!named) continue;
+    return {
+      modulePath: resolveRelativeImport(sourceFile, specifier),
+      exportName: named.exportName,
+      localName: named.localName,
+    };
+  }
+  return undefined;
+};
+
+const hasExportModifier = (node: TSNode, ts: TypeScriptModule): boolean =>
+  ts.canHaveModifiers(node) &&
+  (ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ??
+    false);
+
+const exportDeclarationNames = (
+  stmt: TSStatement,
+  ts: TypeScriptModule,
+): readonly string[] => {
+  if (!ts.isExportDeclaration(stmt)) return [];
+  const clause = stmt.exportClause;
+  if (!clause || !ts.isNamedExports(clause)) return [];
+  return clause.elements.map((element) => element.name.text);
+};
+
+const declaresIdentifier = (
+  stmt: TSStatement,
+  identifierName: string,
+  ts: TypeScriptModule,
+): boolean => {
+  if (ts.isVariableStatement(stmt)) {
+    return stmt.declarationList.declarations.some(
+      (decl) => ts.isIdentifier(decl.name) && decl.name.text === identifierName,
+    );
+  }
+  if ((ts.isFunctionDeclaration(stmt) || ts.isClassDeclaration(stmt)) && stmt.name) {
+    return stmt.name.text === identifierName;
+  }
+  return false;
+};
+
+const hasExportedLocalDeclaration = (
+  sourceFile: TSSourceFile,
+  identifierName: string,
+  ts: TypeScriptModule,
+): boolean => {
+  for (const stmt of sourceFile.statements) {
+    if (declaresIdentifier(stmt, identifierName, ts)) {
+      if (hasExportModifier(stmt, ts)) return true;
+    }
+    if (exportDeclarationNames(stmt, ts).includes(identifierName)) return true;
+  }
+  return false;
+};
+
+const resolveSchemaIdentifier = (
+  sourceFile: TSSourceFile,
+  identifierName: string,
+  ctx: RenderContext,
+): string | undefined => {
+  const imported = findIdentifierImport(sourceFile, identifierName, ctx.ts);
+  if (imported) return ctx.imports.add(imported, ctx.out);
+
+  if (hasExportedLocalDeclaration(sourceFile, identifierName, ctx.ts)) {
+    return ctx.imports.add(
+      {
+        modulePath: sourceFile.fileName,
+        exportName: identifierName,
+        localName: identifierName,
+      },
+      ctx.out,
+    );
+  }
+
+  return undefined;
+};
+
+const isLocalCoreInjectionModule = (
+  sourceFile: TSSourceFile,
+  moduleSpecifier: string,
+): boolean => {
+  if (!moduleSpecifier.startsWith('.')) return false;
+  const resolved = normalizePath(resolve(dirname(sourceFile.fileName), moduleSpecifier));
+  return (
+    resolved.endsWith('/features/http/request/injection') ||
+    resolved.endsWith('/features/http/request/injection/index') ||
+    resolved.endsWith('/features/http/request/injection/body.lib') ||
+    resolved.endsWith('/features/http/request/injection/validated.lib')
+  );
+};
+
+const isAllowedHelperModule = (
+  sourceFile: TSSourceFile,
+  moduleSpecifier: string,
+): boolean =>
+  moduleSpecifier === '@zeltjs/core' || isLocalCoreInjectionModule(sourceFile, moduleSpecifier);
+
+const helperKindFromExportName = (exportedName: string): HelperKind | undefined => {
+  if (exportedName === 'body') return 'body';
+  if (exportedName === 'validated') return 'validated';
+  return undefined;
+};
+
+const getRuntimeNamedImportElements = (
+  importClause: import('typescript').ImportClause | undefined,
+  ts: TypeScriptModule,
+): readonly import('typescript').ImportSpecifier[] => {
+  if (!importClause || importClause.isTypeOnly) return [];
+  return getNamedImportElements(importClause.namedBindings, ts);
+};
+
+const getHelperImportElements = (
+  stmt: TSImportDeclaration,
+  sourceFile: TSSourceFile,
+  ctx: RenderContext,
+): readonly import('typescript').ImportSpecifier[] => {
+  const moduleSpecifier = getImportModuleSpecifier(stmt, ctx.ts);
+  if (!moduleSpecifier) return [];
+  if (!isAllowedHelperModule(sourceFile, moduleSpecifier)) return [];
+  return getRuntimeNamedImportElements(stmt.importClause, ctx.ts);
+};
+
+const registerHelperImportElement = (
+  element: import('typescript').ImportSpecifier,
+  helpers: Map<string, HelperKind>,
+): void => {
+  if (element.isTypeOnly) return;
+  const helper = helperKindFromExportName(element.propertyName?.text ?? element.name.text);
+  if (helper) helpers.set(element.name.text, helper);
+};
+
+const collectHelpersFromImport = (
+  stmt: TSImportDeclaration,
+  sourceFile: TSSourceFile,
+  ctx: RenderContext,
+  helpers: Map<string, HelperKind>,
+): void => {
+  for (const element of getHelperImportElements(stmt, sourceFile, ctx)) {
+    registerHelperImportElement(element, helpers);
+  }
+};
+
+const collectImportedHelpers = (
+  sourceFile: TSSourceFile,
+  ctx: RenderContext,
+): ReadonlyMap<string, HelperKind> => {
+  const helpers = new Map<string, HelperKind>();
+  for (const stmt of sourceFile.statements) {
+    if (!ctx.ts.isImportDeclaration(stmt)) continue;
+    collectHelpersFromImport(stmt, sourceFile, ctx, helpers);
+  }
+  return helpers;
+};
+
+const unsupportedParameterError = (
+  controllerName: string,
+  methodName: string | symbol,
+  param: ParamInfo,
+  reason: string,
+): Error =>
+  new Error(
+    `Unsupported HTTP invocation parameter ${controllerName}.${String(methodName)}(${param.name}): ${reason}`,
+  );
+
+const renderBodyExpression = (
+  call: TSCallExpression,
+  controllerName: string,
+  methodName: string | symbol,
+  param: ParamInfo,
+  ctx: RenderContext,
+): InjectableExpression => {
+  if (call.arguments.length > 1) {
+    throw unsupportedParameterError(
+      controllerName,
+      methodName,
+      param,
+      'body() accepts only an optional body target',
+    );
+  }
+  const target = resolveBodyTarget(call, controllerName, methodName, param, ctx);
+  return { expression: `ctx.body('${target}')`, usesCtx: true, usesValidation: false };
+};
+
+const resolveBodyTarget = (
+  call: TSCallExpression,
+  controllerName: string,
+  methodName: string | symbol,
+  param: ParamInfo,
+  ctx: RenderContext,
+): 'json' | 'form' | 'text' => {
+  const targetArg = call.arguments[0];
+  const target = targetArg ? getStringLiteral(targetArg, ctx.ts) : 'json';
+  if (!target) {
+    throw unsupportedParameterError(
+      controllerName,
+      methodName,
+      param,
+      'body() target must be a string literal',
+    );
+  }
+  if (target === 'json' || target === 'form' || target === 'text') return target;
+  throw unsupportedParameterError(
+    controllerName,
+    methodName,
+    param,
+    `body() target must be "json", "form", or "text"`,
+  );
+};
+
+const validateValidatedArity = (
+  call: TSCallExpression,
+  controllerName: string,
+  methodName: string | symbol,
+  param: ParamInfo,
+): void => {
+  if (call.arguments.length <= 2) return;
+  throw unsupportedParameterError(
+    controllerName,
+    methodName,
+    param,
+    'validated() accepts only a schema and optional body target',
+  );
+};
+
+const resolveValidatedSchemaName = (
+  call: TSCallExpression,
+  sourceFile: TSSourceFile,
+  controllerName: string,
+  methodName: string | symbol,
+  param: ParamInfo,
+  ctx: RenderContext,
+): string => {
+  const schemaArg = call.arguments[0];
+  const schemaExpr = schemaArg ? unwrapExpression(schemaArg, ctx.ts) : undefined;
+  if (!schemaExpr || !ctx.ts.isIdentifier(schemaExpr)) {
+    throw unsupportedParameterError(
+      controllerName,
+      methodName,
+      param,
+      'validated() requires an imported or exported schema identifier',
+    );
+  }
+
+  const schemaName = resolveSchemaIdentifier(sourceFile, schemaExpr.text, ctx);
+  if (!schemaName) {
+    throw unsupportedParameterError(
+      controllerName,
+      methodName,
+      param,
+      'validated() requires an imported or exported schema identifier',
+    );
+  }
+  return schemaName;
+};
+
+const resolveValidatedTarget = (
+  call: TSCallExpression,
+  controllerName: string,
+  methodName: string | symbol,
+  param: ParamInfo,
+  ctx: RenderContext,
+): 'json' | 'form' => {
+  const targetArg = call.arguments[1];
+  const target = targetArg ? getStringLiteral(targetArg, ctx.ts) : 'json';
+  if (!target) {
+    throw unsupportedParameterError(
+      controllerName,
+      methodName,
+      param,
+      'validated() target must be a string literal',
+    );
+  }
+  if (target === 'json' || target === 'form') return target;
+  throw unsupportedParameterError(
+    controllerName,
+    methodName,
+    param,
+    `validated() target must be "json" or "form"`,
+  );
+};
+
+const renderValidatedExpression = (
+  call: TSCallExpression,
+  sourceFile: TSSourceFile,
+  controllerName: string,
+  methodName: string | symbol,
+  param: ParamInfo,
+  ctx: RenderContext,
+): InjectableExpression => {
+  validateValidatedArity(call, controllerName, methodName, param);
+  const schemaName = resolveValidatedSchemaName(
+    call,
+    sourceFile,
+    controllerName,
+    methodName,
+    param,
+    ctx,
+  );
+  const target = resolveValidatedTarget(call, controllerName, methodName, param, ctx);
+
+  return {
+    expression: `await validateBodyAsync(${schemaName}, '${target}')`,
+    usesCtx: false,
+    usesValidation: true,
+  };
+};
+
+type AnalyzableCall = {
+  readonly sourceFile: TSSourceFile;
+  readonly call: TSCallExpression;
+};
+
+const findAnalyzableCall = (
+  param: ParamInfo,
+  ctx: RenderContext,
+): AnalyzableCall | undefined => {
+  const found = findParameterNode(param, ctx);
+  const initializer = found?.parameter.initializer;
+  if (!found || !initializer) return undefined;
+
+  const expression = unwrapExpression(initializer, ctx.ts);
+  if (!ctx.ts.isCallExpression(expression) || !ctx.ts.isIdentifier(expression.expression)) {
+    return undefined;
+  }
+  return { sourceFile: found.sourceFile, call: expression };
+};
+
+const analyzeParameter = (
+  controllerName: string,
+  methodName: string | symbol,
+  param: ParamInfo,
+  ctx: RenderContext,
+): InjectableExpression | undefined => {
+  const found = findAnalyzableCall(param, ctx);
+  if (!found || !ctx.ts.isIdentifier(found.call.expression)) return undefined;
+  const helpers = collectImportedHelpers(found.sourceFile, ctx);
+  const helper = helpers.get(found.call.expression.text);
+  if (!helper) return undefined;
+
+  if (helper === 'body') {
+    return renderBodyExpression(found.call, controllerName, methodName, param, ctx);
+  }
+  return renderValidatedExpression(
+    found.call,
+    found.sourceFile,
+    controllerName,
+    methodName,
+    param,
+    ctx,
+  );
+};
+
+const buildHookSpec = (
+  controller: ControllerClass,
+  methodInfo: MethodInfo | undefined,
+  routeKey: string,
+  methodName: string | symbol,
+  ctx: RenderContext,
+): HookSpec | undefined => {
+  if (!methodInfo) return undefined;
+
+  const params: InjectableExpression[] = [];
+  const unsupportedParams: ParamInfo[] = [];
+
+  for (const param of methodInfo.params) {
+    const rendered = analyzeParameter(controller.name, methodName, param, ctx);
+    if (rendered) {
+      params.push(rendered);
+      continue;
+    }
+    unsupportedParams.push(param);
+  }
+
+  if (params.length === 0) return undefined;
+  if (unsupportedParams.length > 0) {
+    const first = unsupportedParams[0];
+    if (!first) {
+      throw new Error('Unexpected missing unsupported HTTP invocation parameter');
+    }
+    throw unsupportedParameterError(
+      controller.name,
+      methodName,
+      first,
+      'cannot safely generate a hook for this method because another parameter uses a supported HTTP injection helper',
+    );
+  }
+
+  return { key: routeKey, params };
+};
+
+const loadInspectModule = async (): Promise<InspectModule> => {
+  const inspectModule = await import('@zeltjs/decorator-metadata/inspect');
+  return {
+    getOrCreateProgram: async (tsconfigPath) => inspectModule.getOrCreateProgram(tsconfigPath),
+    getSourcePosition: (cls) => inspectModule.getSourcePosition(cls),
+  };
+};
+
+const unwrapInspectResult = <T>(result: InspectResult<T>, label: string): T => {
+  if (result.isErr()) {
+    const error = result.error ?? { code: 'UNKNOWN', message: 'Unknown inspect error' };
+    throw new Error(`${label}: ${error.code}: ${error.message}`);
+  }
+  if (result.value === undefined) {
+    throw new Error(`${label}: missing inspect result value`);
+  }
+  return result.value;
+};
+
+const renderHook = (hook: HookSpec): string => {
+  const usesCtx = hook.params.some((param) => param.usesCtx);
+  const args = usesCtx ? 'ctx' : '';
+  const lines = hook.params.map((param) => `    ${param.expression},`);
+  return [`  '${hook.key}': async (${args}) => [`, ...lines, '  ],'].join('\n');
+};
+
+const renderTypePrelude = (): string =>
+  [
+    "type HttpInvocationHookContext = {",
+    "  readonly body: (type?: 'json' | 'form' | 'text') => unknown;",
+    "};",
+    '',
+    'type HttpInvocationHook = (',
+    '  ctx: HttpInvocationHookContext,',
+    ') => readonly unknown[] | Promise<readonly unknown[]>;',
+  ].join('\n');
+
+const renderModule = (
+  hooks: readonly HookSpec[],
+  imports: ImportRegistry,
+  coreImport: string,
+  syntax: ModuleSyntax,
+): string => {
+  const needsValidation = hooks.some((hook) => hook.params.some((param) => param.usesValidation));
+  const importLines = [
+    ...(needsValidation ? [`import { validateBodyAsync } from '${coreImport}';`] : []),
+    ...imports.render(),
+  ];
+  const typePrelude = syntax === 'typescript' ? [renderTypePrelude(), ''] : [];
+  const exportEnd =
+    syntax === 'typescript'
+      ? '} satisfies Readonly<Record<string, HttpInvocationHook>>;'
+      : '};';
+  const parts = [
+    ...importLines,
+    ...(importLines.length > 0 ? [''] : []),
+    ...typePrelude,
+    'export const httpInvocationHooks = {',
+    ...hooks.map(renderHook),
+    exportEnd,
+    '',
+  ];
+  return parts.join('\n');
+};
+
+/** @throws {Error} */
+export const renderHttpInvocationModule = async (
+  options: RenderHttpInvocationModuleOptions,
+): Promise<string> => {
+  const tsconfigPath = resolve(options.tsconfig);
+  const inspect = await loadInspectModule();
+  const programResult = await inspect.getOrCreateProgram(tsconfigPath);
+  const cachedProgram = unwrapInspectResult(programResult, 'Failed to load TypeScript program');
+
+  const ctx: RenderContext = {
+    program: cachedProgram.program,
+    ts: cachedProgram.ts,
+    out: options.out,
+    coreImport: options.coreImport ?? '@zeltjs/core/http-invocation-runtime',
+    imports: new ImportRegistry(options.moduleSpecifierMode ?? 'typescript', options.runtimeImportMap),
+    inspect,
+  };
+
+  const routes = collectRoutes(options.controllers);
+  const hooks: HookSpec[] = [];
+
+  for (const controller of options.controllers) {
+    const metadata = resolveControllerMetadata(controller, ctx);
+    const controllerRoutes = routes.filter((route) => route.controllerClass === controller);
+    for (const route of controllerRoutes) {
+      const methodInfo = findMethodInfo(metadata, route.methodName);
+      const hook = buildHookSpec(controller, methodInfo, route.hook, route.methodName, ctx);
+      if (hook) hooks.push(hook);
+    }
+  }
+
+  return renderModule(hooks, ctx.imports, ctx.coreImport, options.moduleSyntax ?? 'typescript');
+};
+
+/** @throws {Error} */
+export const generateHttpInvocationModule = async (
+  options: GenerateHttpInvocationModuleOptions,
+): Promise<GenerateHttpInvocationModuleResult> => {
+  const outPath = resolve(options.out);
+  const source = await renderHttpInvocationModule({ ...options, out: outPath });
+  await mkdir(dirname(outPath), { recursive: true });
+  return { changed: await writeIfChanged(outPath, source) };
+};

--- a/packages/core/src/features/http/invocation/generate-http-invocation-internal.lib.ts
+++ b/packages/core/src/features/http/invocation/generate-http-invocation-internal.lib.ts
@@ -320,6 +320,7 @@ const buildClassMetadata = (
     .map((member) => methodInfoFromNode(member, sourceFile, ts)),
 });
 
+/** @throws {Error} */
 const resolveControllerMetadata = (
   controller: ControllerClass,
   ctx: RenderContext,
@@ -605,6 +606,7 @@ const unsupportedParameterError = (
     `Unsupported HTTP invocation parameter ${controllerName}.${String(methodName)}(${param.name}): ${reason}`,
   );
 
+/** @throws {unsupportedParameterError} */
 const renderBodyExpression = (
   call: TSCallExpression,
   controllerName: string,
@@ -624,6 +626,7 @@ const renderBodyExpression = (
   return { expression: `ctx.body('${target}')`, usesCtx: true, usesValidation: false };
 };
 
+/** @throws {unsupportedParameterError} */
 const resolveBodyTarget = (
   call: TSCallExpression,
   controllerName: string,
@@ -650,6 +653,7 @@ const resolveBodyTarget = (
   );
 };
 
+/** @throws {unsupportedParameterError} */
 const validateValidatedArity = (
   call: TSCallExpression,
   controllerName: string,
@@ -665,6 +669,7 @@ const validateValidatedArity = (
   );
 };
 
+/** @throws {unsupportedParameterError} */
 const resolveValidatedSchemaName = (
   call: TSCallExpression,
   sourceFile: TSSourceFile,
@@ -696,6 +701,7 @@ const resolveValidatedSchemaName = (
   return schemaName;
 };
 
+/** @throws {unsupportedParameterError} */
 const resolveValidatedTarget = (
   call: TSCallExpression,
   controllerName: string,
@@ -722,6 +728,7 @@ const resolveValidatedTarget = (
   );
 };
 
+/** @throws {unsupportedParameterError} */
 const renderValidatedExpression = (
   call: TSCallExpression,
   sourceFile: TSSourceFile,
@@ -765,6 +772,7 @@ const findAnalyzableCall = (param: ParamInfo, ctx: RenderContext): AnalyzableCal
   return { sourceFile: found.sourceFile, call: expression };
 };
 
+/** @throws {unsupportedParameterError} */
 const analyzeParameter = (
   controllerName: string,
   methodName: string | symbol,
@@ -790,6 +798,7 @@ const analyzeParameter = (
   );
 };
 
+/** @throws {Error | unsupportedParameterError} */
 const buildHookSpec = (
   controller: ControllerClass,
   methodInfo: MethodInfo | undefined,
@@ -828,6 +837,7 @@ const buildHookSpec = (
   return { key: routeKey, params };
 };
 
+/** @throws {UnsupportedTypeScriptVersionError} */
 const loadInspectModule = async (): Promise<InspectModule> => {
   const inspectModule = await import('@zeltjs/decorator-metadata/inspect');
   return {
@@ -836,6 +846,7 @@ const loadInspectModule = async (): Promise<InspectModule> => {
   };
 };
 
+/** @throws {Error} */
 const unwrapInspectResult = <T>(result: InspectResult<T>, label: string): T => {
   if (result.isErr()) {
     const error = result.error ?? { code: 'UNKNOWN', message: 'Unknown inspect error' };
@@ -891,7 +902,7 @@ const renderModule = (
   return parts.join('\n');
 };
 
-/** @throws {Error} */
+/** @throws {Error | unsupportedParameterError | ZeltDecoratorUsageError | UnsupportedTypeScriptVersionError} */
 export const renderHttpInvocationModule = async (
   options: RenderHttpInvocationModuleOptions,
 ): Promise<string> => {
@@ -928,7 +939,7 @@ export const renderHttpInvocationModule = async (
   return renderModule(hooks, ctx.imports, ctx.coreImport, options.moduleSyntax ?? 'typescript');
 };
 
-/** @throws {Error} */
+/** @throws {Error | unsupportedParameterError | ZeltDecoratorUsageError | UnsupportedTypeScriptVersionError} */
 export const generateHttpInvocationModule = async (
   options: GenerateHttpInvocationModuleOptions,
 ): Promise<GenerateHttpInvocationModuleResult> => {

--- a/packages/core/src/features/http/invocation/generate-http-invocation.lib.ts
+++ b/packages/core/src/features/http/invocation/generate-http-invocation.lib.ts
@@ -1,0 +1,10 @@
+export {
+  generateHttpInvocationModule,
+  renderHttpInvocationModule,
+} from './generate-http-invocation-internal.lib';
+export type {
+  GenerateHttpInvocationModuleOptions,
+  GenerateHttpInvocationModuleResult,
+  RenderHttpInvocationModuleOptions,
+  RuntimeImportMap,
+} from './generate-http-invocation-internal.lib';

--- a/packages/core/src/features/http/invocation/generate-http-invocation.lib.ts
+++ b/packages/core/src/features/http/invocation/generate-http-invocation.lib.ts
@@ -1,10 +1,10 @@
-export {
-  generateHttpInvocationModule,
-  renderHttpInvocationModule,
-} from './generate-http-invocation-internal.lib';
 export type {
   GenerateHttpInvocationModuleOptions,
   GenerateHttpInvocationModuleResult,
   RenderHttpInvocationModuleOptions,
   RuntimeImportMap,
+} from './generate-http-invocation-internal.lib';
+export {
+  generateHttpInvocationModule,
+  renderHttpInvocationModule,
 } from './generate-http-invocation-internal.lib';

--- a/packages/core/src/features/http/invocation/generate-http-invocation.test.ts
+++ b/packages/core/src/features/http/invocation/generate-http-invocation.test.ts
@@ -1,0 +1,408 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { describe, expect, it } from 'vitest';
+
+import { Controller } from '../routing/controller.decorator';
+import { Post } from '../routing/http-method.decorator';
+import { body, validated } from '../request/injection';
+import { body as customBody } from './_fixtures/custom-core';
+import {
+  HttpInvocationHook,
+  ImportedUserSchema,
+  ImportedUserSchema as AliasedUserSchema,
+  httpInvocationHooks,
+} from './_fixtures/schemas';
+import {
+  generateHttpInvocationModule,
+  renderHttpInvocationModule,
+} from './generate-http-invocation.lib';
+
+const tsconfig = resolve(import.meta.dirname, '../../../..', 'tsconfig.json');
+const generatedOut = resolve(import.meta.dirname, 'generated-hooks.ts');
+
+export const LocalUserSchema: StandardSchemaV1<unknown, { readonly id: string }> = {
+  '~standard': {
+    version: 1,
+    vendor: 'zelt-test',
+    validate: (value) => {
+      if (typeof value === 'object' && value !== null && 'id' in value) {
+        return { value: { id: String(value.id) } };
+      }
+      return { issues: [{ message: 'Invalid local user' }] };
+    },
+    types: undefined,
+  },
+};
+
+const normalize = (source: string): string => source.replaceAll('\\', '/');
+const dynamicTarget = 'form';
+
+describe('renderHttpInvocationModule', () => {
+  it('renders body() and body("form") hook code', async () => {
+    @Controller('/body')
+    class BodyController {
+      @Post('/json')
+      create(data = body()) {
+        return data;
+      }
+
+      @Post('/form')
+      upload(data = body('form')) {
+        return data;
+      }
+    }
+
+    const source = await renderHttpInvocationModule({
+      controllers: [BodyController],
+      tsconfig,
+      out: generatedOut,
+    });
+
+    expect(source).toContain("'POST /body/json BodyController.create': async (ctx) => [");
+    expect(source).toContain("ctx.body('json')");
+    expect(source).toContain("'POST /body/form BodyController.upload': async (ctx) => [");
+    expect(source).toContain("ctx.body('form')");
+    expect(source).not.toContain('undefined');
+  });
+
+  it('renders imported schema validation with validateBodyAsync import', async () => {
+    @Controller('/users')
+    class ImportedSchemaController {
+      @Post('/')
+      create(data = validated(ImportedUserSchema)) {
+        return data;
+      }
+    }
+
+    const source = normalize(
+      await renderHttpInvocationModule({
+        controllers: [ImportedSchemaController],
+        tsconfig,
+        out: generatedOut,
+      }),
+    );
+
+    expect(source).toContain(
+      "import { validateBodyAsync } from '@zeltjs/core/http-invocation-runtime';",
+    );
+    expect(source).toContain(
+      "import { ImportedUserSchema } from './_fixtures/schemas';",
+    );
+    expect(source).toContain(
+      "'POST /users ImportedSchemaController.create': async () => [\n    await validateBodyAsync(ImportedUserSchema, 'json'),\n  ],",
+    );
+  });
+
+  it('renders exported local schema declarations from the controller source file', async () => {
+    @Controller('/local-users')
+    class LocalSchemaController {
+      @Post('/')
+      create(data = validated(LocalUserSchema, 'form')) {
+        return data;
+      }
+    }
+
+    const source = normalize(
+      await renderHttpInvocationModule({
+        controllers: [LocalSchemaController],
+        tsconfig,
+        out: generatedOut,
+      }),
+    );
+
+    expect(source).toContain(
+      "import { LocalUserSchema } from './generate-http-invocation.test';",
+    );
+    expect(source).toContain("await validateBodyAsync(LocalUserSchema, 'form')");
+  });
+
+  it('renders aliased schema imports using the exported schema name', async () => {
+    @Controller('/aliased-users')
+    class AliasedSchemaController {
+      @Post('/')
+      create(data = validated(AliasedUserSchema)) {
+        return data;
+      }
+    }
+
+    const source = normalize(
+      await renderHttpInvocationModule({
+        controllers: [AliasedSchemaController],
+        tsconfig,
+        out: generatedOut,
+      }),
+    );
+
+    expect(source).toContain(
+      "import { ImportedUserSchema as AliasedUserSchema } from './_fixtures/schemas';",
+    );
+    expect(source).toContain("await validateBodyAsync(AliasedUserSchema, 'json')");
+  });
+
+  it('aliases schema imports that collide with generated top-level identifiers', async () => {
+    @Controller('/collision')
+    class CollisionController {
+      @Post('/hooks')
+      hooks(data = validated(httpInvocationHooks)) {
+        return data;
+      }
+
+      @Post('/hook-type')
+      hookType(data = validated(HttpInvocationHook)) {
+        return data;
+      }
+    }
+
+    const source = normalize(
+      await renderHttpInvocationModule({
+        controllers: [CollisionController],
+        tsconfig,
+        out: generatedOut,
+      }),
+    );
+
+    expect(source).toContain(
+      "import { httpInvocationHooks as httpInvocationHooks2, HttpInvocationHook as HttpInvocationHook2 } from './_fixtures/schemas';",
+    );
+    expect(source).toContain('await validateBodyAsync(httpInvocationHooks2');
+    expect(source).toContain('await validateBodyAsync(HttpInvocationHook2');
+  });
+
+  it('renders .js suffix for relative schema imports in node module specifier mode', async () => {
+    @Controller('/node-mode')
+    class NodeModeController {
+      @Post('/')
+      create(data = validated(ImportedUserSchema)) {
+        return data;
+      }
+    }
+
+    const source = normalize(
+      await renderHttpInvocationModule({
+        controllers: [NodeModeController],
+        tsconfig,
+        out: generatedOut,
+        moduleSpecifierMode: 'node',
+      }),
+    );
+
+    expect(source).toContain("import { ImportedUserSchema } from './_fixtures/schemas.js';");
+  });
+
+  it('renders executable JavaScript hooks that import local schemas from runtime output', async () => {
+    @Controller('/node-local-users')
+    class NodeLocalSchemaController {
+      @Post('/')
+      create(data = validated(LocalUserSchema)) {
+        return data;
+      }
+    }
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'zelt-http-invocation-node-'));
+    const artifactDir = join(tempDir, '.zelt');
+    const runtimeDir = join(tempDir, 'dist');
+    const runtimeCorePath = join(tempDir, 'runtime-core.mjs');
+    const out = join(artifactDir, 'http-invocation.mjs');
+
+    try {
+      await writeFile(
+        runtimeCorePath,
+        [
+          'export const validateBodyAsync = async (schema) => {',
+          "  const result = await schema['~standard'].validate({ id: 'node-runtime' });",
+          '  if (result.issues) throw new Error(result.issues[0]?.message ?? "invalid");',
+          '  return result.value;',
+          '};',
+          '',
+        ].join('\n'),
+      );
+      await generateHttpInvocationModule({
+        controllers: [NodeLocalSchemaController],
+        tsconfig,
+        out,
+        coreImport: pathToFileURL(runtimeCorePath).href,
+        moduleSpecifierMode: 'node',
+        moduleSyntax: 'javascript',
+        runtimeImportMap: {
+          sourceRoot: import.meta.dirname,
+          runtimeRoot: runtimeDir,
+        },
+      });
+
+      await mkdir(runtimeDir, { recursive: true });
+      await writeFile(
+        join(runtimeDir, 'generate-http-invocation.test.js'),
+        [
+          'export const LocalUserSchema = {',
+          "  '~standard': {",
+          "    validate: (value) => ({ value: { id: String(value.id) } }),",
+          '  },',
+          '};',
+          '',
+        ].join('\n'),
+      );
+
+      const module = (await import(`${pathToFileURL(out).href}?t=${Date.now()}`)) as {
+        readonly httpInvocationHooks: Record<string, () => Promise<unknown[]>>;
+      };
+      const hook = module.httpInvocationHooks[
+        'POST /node-local-users NodeLocalSchemaController.create'
+      ];
+      if (!hook) {
+        throw new Error('Generated node executable hook was not found');
+      }
+      await expect(hook()).resolves.toEqual([{ id: 'node-runtime' }]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails clearly for non-literal body targets', async () => {
+    @Controller('/dynamic-body')
+    class DynamicBodyTargetController {
+      @Post('/')
+      create(data = body(dynamicTarget)) {
+        return data;
+      }
+    }
+
+    await expect(
+      renderHttpInvocationModule({
+        controllers: [DynamicBodyTargetController],
+        tsconfig,
+        out: generatedOut,
+      }),
+    ).rejects.toThrow(
+      'Unsupported HTTP invocation parameter DynamicBodyTargetController.create(data): body() target must be a string literal',
+    );
+  });
+
+  it('fails clearly for non-literal validated targets', async () => {
+    @Controller('/dynamic-validated')
+    class DynamicValidatedTargetController {
+      @Post('/')
+      create(data = validated(ImportedUserSchema, dynamicTarget)) {
+        return data;
+      }
+    }
+
+    await expect(
+      renderHttpInvocationModule({
+        controllers: [DynamicValidatedTargetController],
+        tsconfig,
+        out: generatedOut,
+      }),
+    ).rejects.toThrow(
+      'Unsupported HTTP invocation parameter DynamicValidatedTargetController.create(data): validated() target must be a string literal',
+    );
+  });
+
+  it('does not treat coreImport as a controller helper source', async () => {
+    @Controller('/custom-core')
+    class CustomCoreImportController {
+      @Post('/')
+      create(data = customBody()) {
+        return data;
+      }
+    }
+
+    const source = await renderHttpInvocationModule({
+      controllers: [CustomCoreImportController],
+      tsconfig,
+      out: generatedOut,
+      coreImport: './_fixtures/custom-core',
+    });
+
+    expect(source).not.toContain('CustomCoreImportController.create');
+  });
+
+  it('fails clearly when supported injection params are mixed with unsupported params', async () => {
+    @Controller('/mixed')
+    class MixedParamController {
+      @Post('/')
+      create(data = body(), plain: string) {
+        return { data, plain };
+      }
+    }
+
+    await expect(
+      renderHttpInvocationModule({
+        controllers: [MixedParamController],
+        tsconfig,
+        out: generatedOut,
+      }),
+    ).rejects.toThrow(
+      'Unsupported HTTP invocation parameter MixedParamController.create(plain): cannot safely generate a hook for this method because another parameter uses a supported HTTP injection helper',
+    );
+  });
+
+  it('fails clearly for validated(makeSchema())', async () => {
+    @Controller('/invalid')
+    class InvalidSchemaController {
+      @Post('/')
+      create(data = validated(makeInvalidSchema())) {
+        return data;
+      }
+    }
+
+    await expect(
+      renderHttpInvocationModule({
+        controllers: [InvalidSchemaController],
+        tsconfig,
+        out: generatedOut,
+      }),
+    ).rejects.toThrow(
+      'Unsupported HTTP invocation parameter InvalidSchemaController.create(data): validated() requires an imported or exported schema identifier',
+    );
+  });
+
+  it('writes generated modules only when content changes and generated body hook is executable', async () => {
+    @Controller('/exec')
+    class ExecutableController {
+      @Post('/')
+      create(data = body('text')) {
+        return data;
+      }
+    }
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'zelt-http-invocation-'));
+    const out = join(tempDir, 'http-invocation.ts');
+    try {
+      await expect(
+        generateHttpInvocationModule({ controllers: [ExecutableController], tsconfig, out }),
+      ).resolves.toEqual({ changed: true });
+      await expect(
+        generateHttpInvocationModule({ controllers: [ExecutableController], tsconfig, out }),
+      ).resolves.toEqual({ changed: false });
+
+      const generated = await readFile(out, 'utf8');
+      const executable = generated
+        .replace(/type HttpInvocationHookContext[\\s\\S]*?;\\n\\n/, '')
+        .replace(/type HttpInvocationHook[\\s\\S]*?;\\n\\n/, '')
+        .replace(/ satisfies Readonly<Record<string, HttpInvocationHook>>/, '');
+      const executablePath = join(dirname(out), 'http-invocation.mjs');
+      await writeFile(executablePath, executable, 'utf8');
+
+      const module = (await import(`${pathToFileURL(executablePath).href}?t=${Date.now()}`)) as {
+        readonly httpInvocationHooks: Record<
+          string,
+          (ctx: { body: (type: string) => unknown }) => Promise<unknown[]>
+        >;
+      };
+      const hook = module.httpInvocationHooks['POST /exec ExecutableController.create'];
+      if (!hook) {
+        throw new Error('Generated executable hook was not found');
+      }
+      await expect(hook({ body: (type) => `parsed:${type}` })).resolves.toEqual(['parsed:text']);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+const makeInvalidSchema = (): StandardSchemaV1<unknown, { readonly name: string }> =>
+  ImportedUserSchema;

--- a/packages/core/src/features/http/invocation/generate-http-invocation.test.ts
+++ b/packages/core/src/features/http/invocation/generate-http-invocation.test.ts
@@ -5,16 +5,15 @@ import { pathToFileURL } from 'node:url';
 
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { describe, expect, it } from 'vitest';
-
+import { body, validated } from '../request/injection';
 import { Controller } from '../routing/controller.decorator';
 import { Post } from '../routing/http-method.decorator';
-import { body, validated } from '../request/injection';
 import { body as customBody } from './_fixtures/custom-core';
 import {
-  HttpInvocationHook,
-  ImportedUserSchema,
   ImportedUserSchema as AliasedUserSchema,
+  HttpInvocationHook,
   httpInvocationHooks,
+  ImportedUserSchema,
 } from './_fixtures/schemas';
 import {
   generateHttpInvocationModule,
@@ -89,9 +88,7 @@ describe('renderHttpInvocationModule', () => {
     expect(source).toContain(
       "import { validateBodyAsync } from '@zeltjs/core/http-invocation-runtime';",
     );
-    expect(source).toContain(
-      "import { ImportedUserSchema } from './_fixtures/schemas';",
-    );
+    expect(source).toContain("import { ImportedUserSchema } from './_fixtures/schemas';");
     expect(source).toContain(
       "'POST /users ImportedSchemaController.create': async () => [\n    await validateBodyAsync(ImportedUserSchema, 'json'),\n  ],",
     );
@@ -114,9 +111,7 @@ describe('renderHttpInvocationModule', () => {
       }),
     );
 
-    expect(source).toContain(
-      "import { LocalUserSchema } from './generate-http-invocation.test';",
-    );
+    expect(source).toContain("import { LocalUserSchema } from './generate-http-invocation.test';");
     expect(source).toContain("await validateBodyAsync(LocalUserSchema, 'form')");
   });
 
@@ -239,7 +234,7 @@ describe('renderHttpInvocationModule', () => {
         [
           'export const LocalUserSchema = {',
           "  '~standard': {",
-          "    validate: (value) => ({ value: { id: String(value.id) } }),",
+          '    validate: (value) => ({ value: { id: String(value.id) } }),',
           '  },',
           '};',
           '',
@@ -249,9 +244,8 @@ describe('renderHttpInvocationModule', () => {
       const module = (await import(`${pathToFileURL(out).href}?t=${Date.now()}`)) as {
         readonly httpInvocationHooks: Record<string, () => Promise<unknown[]>>;
       };
-      const hook = module.httpInvocationHooks[
-        'POST /node-local-users NodeLocalSchemaController.create'
-      ];
+      const hook =
+        module.httpInvocationHooks['POST /node-local-users NodeLocalSchemaController.create'];
       if (!hook) {
         throw new Error('Generated node executable hook was not found');
       }

--- a/packages/core/src/features/http/invocation/index.ts
+++ b/packages/core/src/features/http/invocation/index.ts
@@ -1,10 +1,10 @@
-export {
-  generateHttpInvocationModule,
-  renderHttpInvocationModule,
-} from './generate-http-invocation.lib';
 export type {
   GenerateHttpInvocationModuleOptions,
   GenerateHttpInvocationModuleResult,
   RenderHttpInvocationModuleOptions,
   RuntimeImportMap,
+} from './generate-http-invocation.lib';
+export {
+  generateHttpInvocationModule,
+  renderHttpInvocationModule,
 } from './generate-http-invocation.lib';

--- a/packages/core/src/features/http/invocation/index.ts
+++ b/packages/core/src/features/http/invocation/index.ts
@@ -1,0 +1,10 @@
+export {
+  generateHttpInvocationModule,
+  renderHttpInvocationModule,
+} from './generate-http-invocation.lib';
+export type {
+  GenerateHttpInvocationModuleOptions,
+  GenerateHttpInvocationModuleResult,
+  RenderHttpInvocationModuleOptions,
+  RuntimeImportMap,
+} from './generate-http-invocation.lib';

--- a/packages/core/src/features/http/request/injection/index.ts
+++ b/packages/core/src/features/http/request/injection/index.ts
@@ -8,4 +8,4 @@ export { ip } from './ip.lib';
 export { pathParam, setPathParams } from './path-param.lib';
 export { queryParam, queryParams } from './query-param.lib';
 export { method, path, url } from './url.lib';
-export { validated } from './validated.lib';
+export { validateBodyAsync, validated } from './validated.lib';

--- a/packages/core/src/features/http/request/injection/validated.lib.ts
+++ b/packages/core/src/features/http/request/injection/validated.lib.ts
@@ -47,3 +47,28 @@ export function validated<Schema extends StandardSchemaV1>(
 
   return result.value;
 }
+
+/** @internal Used by generated HTTP invocation hooks. */
+export async function validateBodyAsync<Schema extends StandardSchemaV1>(
+  schema: Schema,
+  target?: 'json',
+): Promise<StandardSchemaV1.InferOutput<Schema>>;
+/** @internal Used by generated HTTP invocation hooks. */
+export async function validateBodyAsync<Schema extends StandardSchemaV1>(
+  schema: Schema,
+  target: 'form',
+): Promise<StandardSchemaV1.InferOutput<Schema>>;
+/** @throws {ValidationFailedException | ZeltContextNotAvailableError | UnsupportedMediaTypeException} */
+export async function validateBodyAsync<Schema extends StandardSchemaV1>(
+  schema: Schema,
+  target: ValidationTarget = 'json',
+): Promise<StandardSchemaV1.InferOutput<Schema>> {
+  const raw = target === 'form' ? body('form') : body('json');
+  const result = await schema['~standard'].validate(raw);
+
+  if (result.issues) {
+    throw new ValidationFailedException({ issues: result.issues });
+  }
+
+  return result.value;
+}

--- a/packages/core/src/features/http/routing/index.ts
+++ b/packages/core/src/features/http/routing/index.ts
@@ -1,5 +1,6 @@
 export { joinPath } from './path-utils.lib';
 export { buildRoutes, collectRoutes } from './route-builder.lib';
+export type { BuildRoutesOptions, HttpInvocationHook } from './route-builder.lib';
 export type {
   ControllerClass,
   ControllerRouteInfo,

--- a/packages/core/src/features/http/routing/index.ts
+++ b/packages/core/src/features/http/routing/index.ts
@@ -1,6 +1,6 @@
 export { joinPath } from './path-utils.lib';
-export { buildRoutes, collectRoutes } from './route-builder.lib';
 export type { BuildRoutesOptions, HttpInvocationHook } from './route-builder.lib';
+export { buildRoutes, collectRoutes } from './route-builder.lib';
 export type {
   ControllerClass,
   ControllerRouteInfo,

--- a/packages/core/src/features/http/routing/route-builder.lib.test.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.test.ts
@@ -1,12 +1,46 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { describe, expect, it } from 'vitest';
 import { createApp } from '../../../app';
+import type { ResolverHandle } from '../../../kernel';
+import { LifecycleManager } from '../../../kernel';
 import { http } from '../http.feature';
-import { body } from '../request/injection';
+import { body, validateBodyAsync } from '../request/injection';
 import { Controller } from './controller.decorator';
 import { Get, Post } from './http-method.decorator';
 
-import { collectRoutes, joinPath } from './route-builder.lib';
+import { buildRoutes, collectRoutes, joinPath } from './route-builder.lib';
+
+type SchemaConfig<Output> = {
+  readonly validate: (
+    value: unknown,
+  ) => StandardSchemaV1.Result<Output> | Promise<StandardSchemaV1.Result<Output>>;
+};
+
+const createStandardSchema = <Output>({
+  validate,
+}: SchemaConfig<Output>): StandardSchemaV1<unknown, Output> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'zelt-test',
+    validate,
+    types: undefined as StandardSchemaV1.Types<unknown, Output> | undefined,
+  },
+});
+
+const createResolver = (): ResolverHandle => {
+  const instances = new Map<object, object>();
+  return {
+    get: <T extends object>(cls: new (...args: never[]) => T): T => {
+      const cached = instances.get(cls);
+      if (cached) return cached as T;
+      const instance = Reflect.construct(cls, []) as T;
+      instances.set(cls, instance);
+      return instance;
+    },
+  };
+};
 
 describe('joinPath', () => {
   it.each([
@@ -71,6 +105,252 @@ describe('buildRoutes (instanceof Response branch)', () => {
     expect(res.status).toBe(418);
     expect(res.headers.get('X-Custom')).toBe('yes');
     expect(await res.text()).toBe('I am a teapot');
+  });
+});
+
+describe('buildRoutes invocation hooks', () => {
+  it('passes hook params to the controller without evaluating body default parameters', async () => {
+    const defaultBody = (): unknown => {
+      throw new Error('body() default parameter should not run when an invocation hook is present');
+    };
+
+    @Controller('/hooked')
+    class HookedController {
+      @Post('/create')
+      create(data = defaultBody()) {
+        return data;
+      }
+    }
+
+    const hono = new Hono({ strict: false });
+    const contexts: unknown[] = [];
+    buildRoutes({
+      hono,
+      controllers: [HookedController],
+      resolver: createResolver(),
+      lifecycle: new LifecycleManager(),
+      invocationHooks: {
+        'POST /hooked/create HookedController.create': async (ctx) => {
+          contexts.push({
+            controllerClass: ctx.controllerClass,
+            methodName: ctx.methodName,
+            fullPath: ctx.route.fullPath,
+            requestMethod: ctx.c.req.method,
+          });
+          return [{ name: 'from-hook' }];
+        },
+      },
+    });
+
+    const res = await hono.fetch(
+      new Request('http://localhost/hooked/create', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'from-body' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ name: 'from-hook' });
+    expect(contexts).toEqual([
+      {
+        controllerClass: HookedController,
+        methodName: 'create',
+        fullPath: '/hooked/create',
+        requestMethod: 'POST',
+      },
+    ]);
+  });
+
+  it('uses the default parameter path when no hook exists for the route', async () => {
+    @Controller('/fallback')
+    class FallbackController {
+      @Post('/create')
+      create(data = body() as { name: string }) {
+        return { name: data.name };
+      }
+    }
+
+    const hono = new Hono({ strict: false });
+    buildRoutes({
+      hono,
+      controllers: [FallbackController],
+      resolver: createResolver(),
+      lifecycle: new LifecycleManager(),
+      invocationHooks: {},
+    });
+
+    const res = await hono.fetch(
+      new Request('http://localhost/fallback/create', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'from-default' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ name: 'from-default' });
+  });
+
+  it('awaits async Standard Schema validation through the hook helper', async () => {
+    const asyncSchema = createStandardSchema<{ name: string }>({
+      validate: async (value) => {
+        if (typeof value === 'object' && value !== null && 'name' in value) {
+          return { value: { name: String(value.name) } };
+        }
+        return { issues: [{ message: 'Invalid payload' }] };
+      },
+    });
+
+    @Controller('/validated-hook')
+    class ValidatedHookController {
+      @Post('/create')
+      create(data: { name: string }) {
+        return { receivedName: data.name };
+      }
+    }
+
+    const hono = new Hono({ strict: false });
+    buildRoutes({
+      hono,
+      controllers: [ValidatedHookController],
+      resolver: createResolver(),
+      lifecycle: new LifecycleManager(),
+      invocationHooks: {
+        'POST /validated-hook/create ValidatedHookController.create': async () => [
+          await validateBodyAsync(asyncSchema),
+        ],
+      },
+    });
+
+    const res = await hono.fetch(
+      new Request('http://localhost/validated-hook/create', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Ada' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ receivedName: 'Ada' });
+  });
+
+  it('uses route identity so same named controller methods on different paths can be hooked independently', async () => {
+    const FirstController = (() => {
+      @Controller('/first')
+      class DuplicateController {
+        @Post('/create')
+        create(data = body() as { name: string }) {
+          return { route: 'first', name: data.name };
+        }
+      }
+      return DuplicateController;
+    })();
+    const SecondController = (() => {
+      @Controller('/second')
+      class DuplicateController {
+        @Post('/create')
+        create(data = body() as { name: string }) {
+          return { route: 'second', name: data.name };
+        }
+      }
+      return DuplicateController;
+    })();
+
+    const hono = new Hono({ strict: false });
+    buildRoutes({
+      hono,
+      controllers: [FirstController, SecondController],
+      resolver: createResolver(),
+      lifecycle: new LifecycleManager(),
+      invocationHooks: {
+        'POST /second/create DuplicateController.create': async () => [{ name: 'from-hook' }],
+      },
+    });
+
+    const first = await hono.fetch(
+      new Request('http://localhost/first/create', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'from-body' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const second = await hono.fetch(
+      new Request('http://localhost/second/create', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'from-body' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    expect(await first.json()).toEqual({ route: 'first', name: 'from-body' });
+    expect(await second.json()).toEqual({ route: 'second', name: 'from-hook' });
+  });
+
+  it('throws during build when invocation hook keys collide across routes', () => {
+    @Controller('/duplicate')
+    class DuplicateRouteController {
+      @Post('/create')
+      create() {
+        return {};
+      }
+    }
+
+    const hono = new Hono({ strict: false });
+    expect(() =>
+      buildRoutes({
+        hono,
+        controllers: [DuplicateRouteController, DuplicateRouteController],
+        resolver: createResolver(),
+        lifecycle: new LifecycleManager(),
+        invocationHooks: {},
+      }),
+    ).toThrow(
+      'Duplicate HTTP invocation hook key "POST /duplicate/create DuplicateRouteController.create"',
+    );
+  });
+
+  it('rejects undefined hook params before controller default parameters run', async () => {
+    let defaultRan = false;
+    const defaultBody = (): unknown => {
+      defaultRan = true;
+      throw new Error('default parameter should not run');
+    };
+
+    @Controller('/undefined-param')
+    class UndefinedParamController {
+      @Post('/create')
+      create(data = defaultBody()) {
+        return data;
+      }
+    }
+
+    const hono = new Hono({ strict: false });
+    hono.onError((err) => Response.json({ message: err.message }, { status: 500 }));
+    buildRoutes({
+      hono,
+      controllers: [UndefinedParamController],
+      resolver: createResolver(),
+      lifecycle: new LifecycleManager(),
+      invocationHooks: {
+        'POST /undefined-param/create UndefinedParamController.create': async () => [undefined],
+      },
+    });
+
+    const res = await hono.fetch(
+      new Request('http://localhost/undefined-param/create', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'from-body' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    expect(defaultRan).toBe(false);
+    expect(await res.json()).toEqual({
+      message:
+        'HTTP invocation hook "POST /undefined-param/create UndefinedParamController.create" returned undefined parameter at index 0; generated hooks must omit unsupported params or return a defined value.',
+    });
   });
 });
 

--- a/packages/core/src/features/http/routing/route-builder.lib.test.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.test.ts
@@ -135,7 +135,6 @@ describe('buildRoutes invocation hooks', () => {
             controllerClass: ctx.controllerClass,
             methodName: ctx.methodName,
             fullPath: ctx.route.fullPath,
-            requestMethod: ctx.c.req.method,
           });
           return [{ name: 'from-hook' }];
         },
@@ -157,7 +156,6 @@ describe('buildRoutes invocation hooks', () => {
         controllerClass: HookedController,
         methodName: 'create',
         fullPath: '/hooked/create',
-        requestMethod: 'POST',
       },
     ]);
   });

--- a/packages/core/src/features/http/routing/route-builder.lib.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.ts
@@ -19,7 +19,13 @@ import type {
   MiddlewareInput,
 } from '../middleware/middleware.types';
 import { setHonoContext } from '../request';
-import { hasParsedBody, parseRequestBody, setBody, setPathParams } from '../request/injection';
+import {
+  body,
+  hasParsedBody,
+  parseRequestBody,
+  setBody,
+  setPathParams,
+} from '../request/injection';
 import { joinPath } from './path-utils.lib';
 import type { ControllerClass, HttpMethod } from './routing-metadata.lib';
 import {
@@ -43,12 +49,32 @@ type HonoRouter = {
   readonly delete: (path: string, ...handlers: (FunctionMiddleware | RouteHandler)[]) => unknown;
 };
 
-type Route = {
+export type Route = {
   readonly method: HttpMethod;
   readonly fullPath: string;
   readonly methodName: string | symbol;
   readonly controllerClass: ControllerClass;
+  readonly hook: string;
 };
+
+export type HttpInvocationHookContext = {
+  readonly controllerClass: ControllerClass;
+  readonly methodName: string | symbol;
+  readonly c: Context<Env, string, Input>;
+  readonly route: Route;
+  readonly body: typeof body;
+};
+
+export type HttpInvocationHook = (
+  ctx: HttpInvocationHookContext,
+) => readonly unknown[] | Promise<readonly unknown[]>;
+
+const getHttpInvocationHookKey = (
+  method: HttpMethod,
+  fullPath: string,
+  controllerClass: ControllerClass,
+  methodName: string | symbol,
+): string => `${method} ${fullPath} ${controllerClass.name}.${String(methodName)}`;
 
 /** @throws {ZeltDecoratorUsageError | ZeltLifecycleStateError} */
 export const collectRoutes = (controllers: readonly ControllerClass[]): readonly Route[] => {
@@ -63,28 +89,41 @@ export const collectRoutes = (controllers: readonly ControllerClass[]): readonly
       });
     }
     for (const r of getRouteMetadata(cls)) {
+      const fullPath = joinPath(meta.basePath, r.path);
       routes.push({
         method: r.method,
-        fullPath: joinPath(meta.basePath, r.path),
+        fullPath,
         methodName: r.methodName,
         controllerClass: cls,
+        hook: getHttpInvocationHookKey(r.method, fullPath, cls, r.methodName),
       });
     }
   }
   return routes;
 };
 
+type ResolvedHandler = {
+  readonly callDefault: () => unknown;
+  readonly callWithParams: (params: readonly unknown[]) => unknown;
+};
+
 /** @throws {ZeltLifecycleStateError | ZeltRouteConfigurationError} */
-const resolveHandler = (instance: object, methodName: string | symbol): (() => unknown) => {
+const resolveHandler = (instance: object, methodName: string | symbol): ResolvedHandler => {
   // Reflect.get returns `any` for dynamic keys; pinning the local to `unknown`
   // forces narrowing before any call, keeping the handler invocation typesafe.
   const value: unknown = Reflect.get(instance, methodName);
   if (typeof value !== 'function') {
     throw new ZeltRouteConfigurationError({ reason: 'invalid_route' });
   }
-  return () => {
-    const result: unknown = value.call(instance);
-    return result;
+  return {
+    callDefault: () => {
+      const result: unknown = value.call(instance);
+      return result;
+    },
+    callWithParams: (params) => {
+      const result: unknown = Reflect.apply(value, instance, params);
+      return result;
+    },
   };
 };
 
@@ -182,6 +221,7 @@ type RouteBuilderContext = {
   readonly resolver: ResolverHandle;
   readonly lifecycle: LifecycleManager;
   readonly instanceCache: Map<ControllerClass, object>;
+  readonly invocationHooks?: Readonly<Record<string, HttpInvocationHook>>;
 };
 
 /** @throws {ZeltLifecycleStateError} */
@@ -194,6 +234,28 @@ const getOrCreateInstance = (
   const instance = ctx.resolver.get(controllerClass);
   ctx.instanceCache.set(controllerClass, instance);
   return instance;
+};
+
+const assertDefinedHookParams = (hookKey: string, params: readonly unknown[]): void => {
+  const undefinedIndex = params.indexOf(undefined);
+  if (undefinedIndex !== -1) {
+    throw new Error(
+      `HTTP invocation hook "${hookKey}" returned undefined parameter at index ${undefinedIndex}; generated hooks must omit unsupported params or return a defined value.`,
+    );
+  }
+};
+
+const collectDuplicateHookKeys = (routes: readonly Route[]): readonly string[] => {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const route of routes) {
+    if (seen.has(route.hook)) {
+      duplicates.add(route.hook);
+      continue;
+    }
+    seen.add(route.hook);
+  }
+  return [...duplicates];
 };
 
 /** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError | BadRequestException} */
@@ -210,7 +272,9 @@ const registerRoute = (hono: HonoRouter, ctx: RouteBuilderContext, route: Route)
     await ctx.lifecycle.startupPending();
 
     const invoke = resolveHandler(instance, route.methodName);
-    const result = await invoke();
+    const hook = ctx.invocationHooks?.[route.hook];
+    const result =
+      hook === undefined ? await invoke.callDefault() : await invokeHook(route, hook, c, invoke);
     if (result instanceof Response) return result;
     return c.json(result);
   };
@@ -232,22 +296,49 @@ const registerRoute = (hono: HonoRouter, ctx: RouteBuilderContext, route: Route)
   methods[route.method]();
 };
 
+const invokeHook = async (
+  route: Route,
+  hook: HttpInvocationHook,
+  c: MiddlewareContext,
+  invoke: ResolvedHandler,
+): Promise<unknown> => {
+  const params = await hook({
+    controllerClass: route.controllerClass,
+    methodName: route.methodName,
+    c,
+    route,
+    body,
+  });
+  assertDefinedHookParams(route.hook, params);
+  return invoke.callWithParams(params);
+};
+
 export type BuildRoutesOptions = {
   readonly hono: HonoRouter;
   readonly controllers: readonly ControllerClass[];
   readonly resolver: ResolverHandle;
   readonly lifecycle: LifecycleManager;
+  readonly invocationHooks?: Readonly<Record<string, HttpInvocationHook>>;
 };
 
 /** @throws {ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError | BadRequestException} */
 export const buildRoutes = (options: BuildRoutesOptions): void => {
+  const routes = collectRoutes(options.controllers);
+  if (options.invocationHooks !== undefined) {
+    const duplicateHookKeys = collectDuplicateHookKeys(routes);
+    if (duplicateHookKeys.length > 0) {
+      throw new Error(`Duplicate HTTP invocation hook key "${duplicateHookKeys[0]}"`);
+    }
+  }
+
   const ctx: RouteBuilderContext = {
     resolver: options.resolver,
     lifecycle: options.lifecycle,
     instanceCache: new Map(),
+    ...(options.invocationHooks !== undefined && { invocationHooks: options.invocationHooks }),
   };
 
-  for (const route of collectRoutes(options.controllers)) {
+  for (const route of routes) {
     registerRoute(options.hono, ctx, route);
   }
 };

--- a/packages/core/src/features/http/routing/route-builder.lib.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.ts
@@ -236,6 +236,7 @@ const getOrCreateInstance = (
   return instance;
 };
 
+/** @throws {Error} */
 const assertDefinedHookParams = (hookKey: string, params: readonly unknown[]): void => {
   const undefinedIndex = params.indexOf(undefined);
   if (undefinedIndex !== -1) {
@@ -266,7 +267,7 @@ const registerRoute = (hono: HonoRouter, ctx: RouteBuilderContext, route: Route)
     ctx.resolver,
   );
 
-  /** @throws {ZeltContextNotAvailableError | ZeltReadyFailedError | ZeltLifecycleStateError | ZeltRouteConfigurationError} */
+  /** @throws {ZeltContextNotAvailableError | ZeltReadyFailedError | ZeltLifecycleStateError | ZeltRouteConfigurationError | Error} */
   const handler = async (c: MiddlewareContext): Promise<Response> => {
     const instance = getOrCreateInstance(ctx, route.controllerClass);
     await ctx.lifecycle.startupPending();
@@ -296,6 +297,7 @@ const registerRoute = (hono: HonoRouter, ctx: RouteBuilderContext, route: Route)
   methods[route.method]();
 };
 
+/** @throws {Error} */
 const invokeHook = async (
   route: Route,
   hook: HttpInvocationHook,
@@ -321,7 +323,7 @@ export type BuildRoutesOptions = {
   readonly invocationHooks?: Readonly<Record<string, HttpInvocationHook>>;
 };
 
-/** @throws {ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError | BadRequestException} */
+/** @throws {ZeltContextNotAvailableError | ZeltDecoratorUsageError | ZeltLifecycleStateError | BadRequestException | Error} */
 export const buildRoutes = (options: BuildRoutesOptions): void => {
   const routes = collectRoutes(options.controllers);
   if (options.invocationHooks !== undefined) {

--- a/packages/core/src/features/http/routing/route-builder.lib.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.ts
@@ -60,7 +60,7 @@ export type Route = {
 export type HttpInvocationHookContext = {
   readonly controllerClass: ControllerClass;
   readonly methodName: string | symbol;
-  readonly c: Context<Env, string, Input>;
+  readonly c: unknown;
   readonly route: Route;
   readonly body: typeof body;
 };

--- a/packages/core/src/http-invocation-runtime.ts
+++ b/packages/core/src/http-invocation-runtime.ts
@@ -1,0 +1,1 @@
+export { validateBodyAsync } from './features/http/request/injection';

--- a/packages/core/src/http-invocation.ts
+++ b/packages/core/src/http-invocation.ts
@@ -1,10 +1,10 @@
-export {
-  generateHttpInvocationModule,
-  renderHttpInvocationModule,
-} from './features/http/invocation';
 export type {
   GenerateHttpInvocationModuleOptions,
   GenerateHttpInvocationModuleResult,
   RenderHttpInvocationModuleOptions,
   RuntimeImportMap,
+} from './features/http/invocation';
+export {
+  generateHttpInvocationModule,
+  renderHttpInvocationModule,
 } from './features/http/invocation';

--- a/packages/core/src/http-invocation.ts
+++ b/packages/core/src/http-invocation.ts
@@ -1,0 +1,10 @@
+export {
+  generateHttpInvocationModule,
+  renderHttpInvocationModule,
+} from './features/http/invocation';
+export type {
+  GenerateHttpInvocationModuleOptions,
+  GenerateHttpInvocationModuleResult,
+  RenderHttpInvocationModuleOptions,
+  RuntimeImportMap,
+} from './features/http/invocation';

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -10,7 +10,13 @@ const swcDecoratorPlugin = swc({
 
 export default defineConfig({
   plugins: [swcDecoratorPlugin],
-  entry: ['src/index.ts', 'src/internal-bridge/testing.ts', 'src/internal-bridge/errors.ts'],
+  entry: [
+    'src/index.ts',
+    'src/internal-bridge/testing.ts',
+    'src/internal-bridge/errors.ts',
+    'src/http-invocation.ts',
+    'src/http-invocation-runtime.ts',
+  ],
   format: ['esm', 'cjs'],
   dts: true,
   clean: true,

--- a/packages/graphql/src/generate-sdl.test.ts
+++ b/packages/graphql/src/generate-sdl.test.ts
@@ -190,6 +190,25 @@ describe('generateSdlForResolvers', () => {
 }`);
   });
 
+  it('records invocation hook keys for root fields with args schemas', async () => {
+    const runtime = await generateGraphqlRuntimeForResolvers([ArgsUserResolver], {
+      tsconfig: resolve(__dirname, '../tsconfig.json'),
+      schemaAdapter: testSchemaAdapter,
+      schemaResolver: testSchemaResolver,
+    });
+
+    expect(runtime.bindings['Query']?.['userById']).toEqual({
+      resolver: 'ArgsUserResolver',
+      method: 'userById',
+      hook: 'Query.userById',
+    });
+    expect(runtime.bindings['Mutation']?.['renameUser']).toEqual({
+      resolver: 'ArgsUserResolver',
+      method: 'renameUser',
+      hook: 'Mutation.renameUser',
+    });
+  });
+
   it('records runtime enum mappings for root fields returning string literal unions', async () => {
     const runtime = await generateGraphqlRuntimeForResolvers([EnumRootResolver], {
       tsconfig: resolve(__dirname, '../tsconfig.json'),

--- a/packages/graphql/src/gql-args-node-sample.d.ts
+++ b/packages/graphql/src/gql-args-node-sample.d.ts
@@ -1,0 +1,6 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
+export const NodeGetUserInput: StandardSchemaV1<
+  Readonly<Record<string, unknown>>,
+  { readonly id: string }
+>;

--- a/packages/graphql/src/gql-args-node-sample.js
+++ b/packages/graphql/src/gql-args-node-sample.js
@@ -1,0 +1,5 @@
+import * as v from 'valibot';
+
+export const NodeGetUserInput = v.object({
+  id: v.pipe(v.string(), v.minLength(1)),
+});

--- a/packages/graphql/src/graphql-plugin.lib.ts
+++ b/packages/graphql/src/graphql-plugin.lib.ts
@@ -215,7 +215,8 @@ const buildInvocationHooksObjectLiteral = (
   return `  "invocationHooks": {\n${entries.join(',\n')}\n  }`;
 };
 
-const buildRuntimeHelperModule = (): string => `const fallbackGraphqlArgsValidationError = class GraphqlArgsValidationError extends Error {
+const buildRuntimeHelperModule =
+  (): string => `const fallbackGraphqlArgsValidationError = class GraphqlArgsValidationError extends Error {
   constructor(issues) {
     super(\`GraphQL args validation failed: \${issues.map((issue) => issue.message).join('; ')}\`);
     this.name = 'GraphqlArgsValidationError';
@@ -265,9 +266,7 @@ const buildRuntimeModule = (
     return `${imports}export const graphqlRuntime = ${runtimeJson};\n`;
   }
   const trimmed = runtimeJson.replace(/\n}$/, '');
-  return `${imports}export const graphqlRuntime = ${trimmed},\n${objectLiterals.join(
-    ',\n',
-  )}\n};\n`;
+  return `${imports}export const graphqlRuntime = ${trimmed},\n${objectLiterals.join(',\n')}\n};\n`;
 };
 
 const writeRuntimeModule = async (

--- a/packages/graphql/src/graphql-plugin.lib.ts
+++ b/packages/graphql/src/graphql-plugin.lib.ts
@@ -1,14 +1,18 @@
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, isAbsolute, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { ZeltPlugin } from '@zeltjs/cli';
 import type { ControllerClass, HttpStaticCapabilities } from '@zeltjs/core';
+import type { GraphqlArgsSchemaRef } from './analyze-gql-args.lib';
 import { getGraphqlControllerMetadata } from './graphql-metadata.lib';
 import type { GraphqlRuntimeManifest } from './graphql-runtime.lib';
 import type { GenerateSdlOptions } from './graphql-sdl-generator.lib';
-import { generateGraphqlRuntimeForResolvers } from './graphql-sdl-generator.lib';
+import {
+  generateGraphqlRuntimeForResolvers,
+  getGraphqlInvocationHookSchemaRef,
+} from './graphql-sdl-generator.lib';
 import type { GenerateSchemaFirstResolverChecksOptions } from './schema-first-resolver-checks.lib';
 import { generateSchemaFirstResolverChecks } from './schema-first-resolver-checks.lib';
 import { generateSchemaFirstGraphqlRuntimeForResolvers } from './schema-first-runtime.lib';
@@ -94,7 +98,7 @@ const toImportSpecifier = (modulePath: string): string => {
 
 const toSerializableRuntime = (
   runtime: GraphqlRuntimeManifest,
-): Omit<GraphqlRuntimeManifest, 'scalars'> => ({
+): Omit<GraphqlRuntimeManifest, 'invocationHooks' | 'scalars'> => ({
   schemaSdl: runtime.schemaSdl,
   bindings: runtime.bindings,
   ...(runtime.enumFields !== undefined && { enumFields: runtime.enumFields }),
@@ -122,13 +126,148 @@ const buildScalarObjectLiteral = (runtime: GraphqlRuntimeManifest): string | und
   return `  "scalars": {\n${entries.join(',\n')}\n  }`;
 };
 
-const buildRuntimeModule = (runtime: GraphqlRuntimeManifest): string => {
-  const imports = buildScalarImports(runtime);
+type InvocationHookLiteral = {
+  readonly key: string;
+  readonly ref: GraphqlArgsSchemaRef;
+  readonly moduleIndex: number;
+};
+
+const getLocalGraphqlArgsLibImportSpecifier = (): string => {
+  const currentPath = fileURLToPath(import.meta.url);
+  const ext = currentPath.endsWith('.ts') ? '.ts' : '.js';
+  return pathToFileURL(resolve(dirname(currentPath), `args.lib${ext}`)).href;
+};
+
+const toRuntimeHelperPath = (runtimePath: string): string => {
+  const replaced = runtimePath.replace(/\.(?:cjs|mjs|js|ts)$/, '.helper.mjs');
+  return replaced === runtimePath ? `${runtimePath}.helper.mjs` : replaced;
+};
+
+const toRelativeImportSpecifier = (fromPath: string, toPath: string): string => {
+  const raw = relative(dirname(fromPath), toPath).replaceAll('\\', '/');
+  return raw.startsWith('.') ? raw : `./${raw}`;
+};
+
+const getBindingHookKeys = (runtime: GraphqlRuntimeManifest): ReadonlySet<string> => {
+  const keys = new Set<string>();
+  for (const typeBindings of Object.values(runtime.bindings)) {
+    for (const binding of Object.values(typeBindings)) {
+      if (binding.hook === '') throw new Error('GraphQL invocation hook key must not be empty.');
+      if (binding.hook !== undefined) keys.add(binding.hook);
+    }
+  }
+  return keys;
+};
+
+/** @throws {Error} */
+const buildInvocationHookLiterals = (
+  runtime: GraphqlRuntimeManifest,
+): readonly InvocationHookLiteral[] => {
+  const hooks = runtime.invocationHooks ?? {};
+  const bindingHookKeys = getBindingHookKeys(runtime);
+  const moduleIndexes = new Map<string, number>();
+  const literals: InvocationHookLiteral[] = [];
+
+  for (const key of bindingHookKeys) {
+    const hook = hooks[key];
+    if (hook === undefined) throw new Error(`GraphQL invocation hook missing: ${key}`);
+    const ref = getGraphqlInvocationHookSchemaRef(hook);
+    if (!ref) throw new Error(`GraphQL invocation hook is not serializable: ${key}`);
+    const moduleIndex = moduleIndexes.get(ref.modulePath) ?? moduleIndexes.size;
+    moduleIndexes.set(ref.modulePath, moduleIndex);
+    literals.push({ key, ref, moduleIndex });
+  }
+
+  return literals;
+};
+
+const buildInvocationHookImports = (
+  literals: readonly InvocationHookLiteral[],
+  helperImportSpecifier: string,
+): string => {
+  if (literals.length === 0) return '';
+  const modulePaths = [...new Set(literals.map((literal) => literal.ref.modulePath))];
+  const schemaImports = modulePaths.map(
+    (modulePath, index) =>
+      `import * as graphqlArgsModule${index} from ${JSON.stringify(toImportSpecifier(modulePath))};`,
+  );
+  return [
+    `import { createGraphqlArgsValidationError } from ${JSON.stringify(helperImportSpecifier)};`,
+    ...schemaImports,
+    '',
+    '',
+  ].join('\n');
+};
+
+const buildInvocationHooksObjectLiteral = (
+  literals: readonly InvocationHookLiteral[],
+): string | undefined => {
+  if (literals.length === 0) return undefined;
+  const entries = literals.map(
+    (literal) => `    ${JSON.stringify(literal.key)}: async (ctx) => {
+      const result = await graphqlArgsModule${literal.moduleIndex}[${JSON.stringify(
+        literal.ref.exportName,
+      )}]['~standard'].validate(ctx.args);
+      if (result.issues) throw await createGraphqlArgsValidationError(result.issues);
+      return [result.value];
+    }`,
+  );
+  return `  "invocationHooks": {\n${entries.join(',\n')}\n  }`;
+};
+
+const buildRuntimeHelperModule = (): string => `const fallbackGraphqlArgsValidationError = class GraphqlArgsValidationError extends Error {
+  constructor(issues) {
+    super(\`GraphQL args validation failed: \${issues.map((issue) => issue.message).join('; ')}\`);
+    this.name = 'GraphqlArgsValidationError';
+    this.issues = issues;
+  }
+};
+
+let graphqlArgsValidationErrorConstructor;
+
+const loadGraphqlArgsValidationErrorConstructor = async () => {
+  if (graphqlArgsValidationErrorConstructor !== undefined) {
+    return graphqlArgsValidationErrorConstructor;
+  }
+  try {
+    const mod = await import(${JSON.stringify(getLocalGraphqlArgsLibImportSpecifier())});
+    graphqlArgsValidationErrorConstructor = mod.GraphqlArgsValidationError;
+  } catch {
+    graphqlArgsValidationErrorConstructor = fallbackGraphqlArgsValidationError;
+  }
+  return graphqlArgsValidationErrorConstructor;
+};
+
+export const createGraphqlArgsValidationError = async (issues) => {
+  const GraphqlArgsValidationError = await loadGraphqlArgsValidationErrorConstructor();
+  return new GraphqlArgsValidationError(issues);
+};
+`;
+
+const buildRuntimeModule = (
+  runtime: GraphqlRuntimeManifest,
+  runtimePath: string,
+  helperPath: string,
+): string => {
+  const invocationHookLiterals = buildInvocationHookLiterals(runtime);
+  const helperImportSpecifier = toRelativeImportSpecifier(runtimePath, helperPath);
+  const imports = `${buildScalarImports(runtime)}${buildInvocationHookImports(
+    invocationHookLiterals,
+    helperImportSpecifier,
+  )}`;
   const runtimeJson = JSON.stringify(toSerializableRuntime(runtime), null, 2);
+  const invocationHooksLiteral = buildInvocationHooksObjectLiteral(invocationHookLiterals);
   const scalarLiteral = buildScalarObjectLiteral(runtime);
-  if (!scalarLiteral) return `${imports}export const graphqlRuntime = ${runtimeJson};\n`;
+  const objectLiterals = [invocationHooksLiteral, scalarLiteral].flatMap((literal) =>
+    literal === undefined ? [] : [literal],
+  );
+  if (objectLiterals.length === 0) {
+    return `${imports}export const graphqlRuntime = ${runtimeJson};\n`;
+  }
   const trimmed = runtimeJson.replace(/\n}$/, '');
-  return `${imports}export const graphqlRuntime = ${trimmed},\n${scalarLiteral}\n};\n`;
+  return `${imports}export const graphqlRuntime = ${trimmed},\n${objectLiterals.join(
+    ',\n',
+  )}\n};\n`;
 };
 
 const writeRuntimeModule = async (
@@ -136,8 +275,17 @@ const writeRuntimeModule = async (
   runtime: GraphqlRuntimeManifest,
 ): Promise<boolean> => {
   const runtimePath = resolve(runtimeModule);
+  const helperPath = toRuntimeHelperPath(runtimePath);
   await mkdir(dirname(runtimePath), { recursive: true });
-  return writeIfChanged(runtimePath, buildRuntimeModule(runtime));
+  const runtimeChanged = await writeIfChanged(
+    runtimePath,
+    buildRuntimeModule(runtime, runtimePath, helperPath),
+  );
+  const helperChanged =
+    Object.keys(runtime.invocationHooks ?? {}).length > 0
+      ? await writeIfChanged(helperPath, buildRuntimeHelperModule())
+      : false;
+  return runtimeChanged || helperChanged;
 };
 
 const toRuntimeSchemaPath = (runtimeModule: string): string => {

--- a/packages/graphql/src/graphql-plugin.lib.ts
+++ b/packages/graphql/src/graphql-plugin.lib.ts
@@ -148,6 +148,7 @@ const toRelativeImportSpecifier = (fromPath: string, toPath: string): string => 
   return raw.startsWith('.') ? raw : `./${raw}`;
 };
 
+/** @throws {Error} */
 const getBindingHookKeys = (runtime: GraphqlRuntimeManifest): ReadonlySet<string> => {
   const keys = new Set<string>();
   for (const typeBindings of Object.values(runtime.bindings)) {
@@ -245,6 +246,7 @@ export const createGraphqlArgsValidationError = async (issues) => {
 };
 `;
 
+/** @throws {Error} */
 const buildRuntimeModule = (
   runtime: GraphqlRuntimeManifest,
   runtimePath: string,
@@ -269,6 +271,7 @@ const buildRuntimeModule = (
   return `${imports}export const graphqlRuntime = ${trimmed},\n${objectLiterals.join(',\n')}\n};\n`;
 };
 
+/** @throws {Error} */
 const writeRuntimeModule = async (
   runtimeModule: string,
   runtime: GraphqlRuntimeManifest,

--- a/packages/graphql/src/graphql-runtime.lib.ts
+++ b/packages/graphql/src/graphql-runtime.lib.ts
@@ -560,7 +560,10 @@ const attachUnionResolvers = (schema: GraphQLSchema, runtime: GeneratedGraphqlRu
 
 const readGraphqlArgsValidationIssues = (value: unknown): readonly unknown[] | undefined => {
   if (!(value instanceof Error)) return undefined;
-  if (!(value instanceof GraphqlArgsValidationError) && value.name !== 'GraphqlArgsValidationError') {
+  if (
+    !(value instanceof GraphqlArgsValidationError) &&
+    value.name !== 'GraphqlArgsValidationError'
+  ) {
     return undefined;
   }
   const issues = readProperty(value, 'issues');

--- a/packages/graphql/src/graphql-runtime.lib.ts
+++ b/packages/graphql/src/graphql-runtime.lib.ts
@@ -28,7 +28,18 @@ export const graphqlRequestPayloadSchema = {
 export type GeneratedGraphqlBinding = {
   readonly resolver: string;
   readonly method: string;
+  readonly hook?: string;
 };
+
+export type GraphqlInvocationHookContext = {
+  readonly parent: unknown;
+  readonly args: Readonly<Record<string, unknown>>;
+  readonly isRootField: boolean;
+};
+
+export type GraphqlInvocationHook = (
+  ctx: GraphqlInvocationHookContext,
+) => readonly unknown[] | Promise<readonly unknown[]>;
 
 // GeneratedGraphqlRuntime is the runtime manifest consumed by the executor.
 // Code-first generation is one producer. Schema-first generation can produce
@@ -36,6 +47,7 @@ export type GeneratedGraphqlBinding = {
 export type GeneratedGraphqlRuntime = {
   readonly schemaSdl: string;
   readonly bindings: Record<string, Record<string, GeneratedGraphqlBinding>>;
+  readonly invocationHooks?: Readonly<Record<string, GraphqlInvocationHook>>;
   readonly enumFields?: Record<string, Record<string, Readonly<Record<string, string>>>>;
   readonly scalarRefs?: Record<
     string,
@@ -100,6 +112,13 @@ const toObject = (value: unknown): object | undefined => {
 
 const readProperty = (value: object, key: string): unknown => Reflect.get(value, key);
 
+const parseGeneratedGraphqlBindingHook = (record: object): string | undefined | false => {
+  const hook = readProperty(record, 'hook');
+  if (hook === undefined) return undefined;
+  if (typeof hook !== 'string') return false;
+  return hook.length > 0 ? hook : false;
+};
+
 const parseStringRecord = (value: unknown): Record<string, string> | undefined => {
   const record = toObject(value);
   if (!record) return undefined;
@@ -117,7 +136,9 @@ const parseGeneratedGraphqlBinding = (value: unknown): GeneratedGraphqlBinding |
   const resolver = readProperty(record, 'resolver');
   const method = readProperty(record, 'method');
   if (typeof resolver !== 'string' || typeof method !== 'string') return undefined;
-  return { resolver, method };
+  const hook = parseGeneratedGraphqlBindingHook(record);
+  if (hook === false) return undefined;
+  return { resolver, method, ...(hook !== undefined && { hook }) };
 };
 
 const parseGeneratedGraphqlBindings = (
@@ -233,6 +254,34 @@ const addOptionalRuntimeEnumFields = (
   return enumFields ? { ...runtime, enumFields } : undefined;
 };
 
+function toGraphqlInvocationHook(value: unknown): GraphqlInvocationHook;
+function toGraphqlInvocationHook(value: unknown): unknown {
+  return value;
+}
+
+const parseRuntimeInvocationHooks = (
+  value: unknown,
+): NonNullable<GeneratedGraphqlRuntime['invocationHooks']> | undefined => {
+  const record = toObject(value);
+  if (!record) return undefined;
+  const output: Record<string, GraphqlInvocationHook> = {};
+  for (const [key, hook] of Object.entries(record)) {
+    if (typeof hook !== 'function') return undefined;
+    output[key] = toGraphqlInvocationHook(hook);
+  }
+  return output;
+};
+
+const addOptionalRuntimeInvocationHooks = (
+  runtime: GeneratedGraphqlRuntime,
+  record: object,
+): GeneratedGraphqlRuntime | undefined => {
+  const invocationHooksValue = readProperty(record, 'invocationHooks');
+  if (invocationHooksValue === undefined) return runtime;
+  const invocationHooks = parseRuntimeInvocationHooks(invocationHooksValue);
+  return invocationHooks ? { ...runtime, invocationHooks } : undefined;
+};
+
 const addOptionalRuntimeScalarRefs = (
   runtime: GeneratedGraphqlRuntime,
   record: object,
@@ -270,7 +319,9 @@ const parseGeneratedGraphqlRuntime = (value: unknown): GeneratedGraphqlRuntime |
   if (!base) return undefined;
   const withEnumFields = addOptionalRuntimeEnumFields(base, record);
   if (!withEnumFields) return undefined;
-  const withScalarRefs = addOptionalRuntimeScalarRefs(withEnumFields, record);
+  const withInvocationHooks = addOptionalRuntimeInvocationHooks(withEnumFields, record);
+  if (!withInvocationHooks) return undefined;
+  const withScalarRefs = addOptionalRuntimeScalarRefs(withInvocationHooks, record);
   if (!withScalarRefs) return undefined;
   const withScalars = addOptionalRuntimeScalars(withScalarRefs, record);
   if (!withScalars) return undefined;
@@ -366,6 +417,15 @@ const createBindingResolver = (options: CreateGraphqlExecutorOptions): ResolveBi
     const cached = resolverCache.get(resolverClass);
     const instance = cached ?? (await options.resolveResolver(resolverClass));
     if (!cached) resolverCache.set(resolverClass, instance);
+
+    if (binding.hook !== undefined) {
+      const hook = options.runtime.invocationHooks?.[binding.hook];
+      if (hook === undefined) {
+        throw new Error(`GraphQL invocation hook not found: ${binding.hook}`);
+      }
+      const params = await hook({ parent, args, isRootField });
+      return callResolverMethod(instance, binding.method, params);
+    }
 
     return runWithGraphqlArgs(args, () =>
       callResolverMethod(instance, binding.method, isRootField ? [] : [parent]),
@@ -498,9 +558,19 @@ const attachUnionResolvers = (schema: GraphQLSchema, runtime: GeneratedGraphqlRu
   }
 };
 
+const readGraphqlArgsValidationIssues = (value: unknown): readonly unknown[] | undefined => {
+  if (!(value instanceof Error)) return undefined;
+  if (!(value instanceof GraphqlArgsValidationError) && value.name !== 'GraphqlArgsValidationError') {
+    return undefined;
+  }
+  const issues = readProperty(value, 'issues');
+  return Array.isArray(issues) ? issues : undefined;
+};
+
 const toValidationGraphqlError = (
   error: GraphQLError,
-  original: GraphqlArgsValidationError,
+  original: Error,
+  issues: readonly unknown[],
 ): GraphQLError =>
   new GraphQLError(error.message, {
     nodes: error.nodes ?? null,
@@ -508,13 +578,14 @@ const toValidationGraphqlError = (
     positions: error.positions ?? null,
     path: error.path ?? null,
     originalError: original,
-    extensions: { code: 'GRAPHQL_ARGS_VALIDATION_FAILED', issues: original.issues },
+    extensions: { code: 'GRAPHQL_ARGS_VALIDATION_FAILED', issues },
   });
 
 const enrichValidationError = (error: GraphQLError): GraphQLError => {
   const original = error.originalError;
-  return original instanceof GraphqlArgsValidationError
-    ? toValidationGraphqlError(error, original)
+  const issues = readGraphqlArgsValidationIssues(original);
+  return original instanceof Error && issues !== undefined
+    ? toValidationGraphqlError(error, original, issues)
     : error;
 };
 

--- a/packages/graphql/src/graphql-sdl-generator.lib.ts
+++ b/packages/graphql/src/graphql-sdl-generator.lib.ts
@@ -213,6 +213,7 @@ export const createGeneratedGraphqlArgsInvocationHook = (
   ref: GraphqlArgsSchemaRef,
   resolver?: GqlSchemaResolver,
 ): GraphqlInvocationHook => {
+  /** @throws {GraphqlArgsValidationError | Error} */
   const hook: GraphqlInvocationHook = async (ctx) => {
     const schema = await resolveArgsSchemaValue(ref, resolver);
     const result = await schema['~standard'].validate(ctx.args);

--- a/packages/graphql/src/graphql-sdl-generator.lib.ts
+++ b/packages/graphql/src/graphql-sdl-generator.lib.ts
@@ -11,8 +11,8 @@ import { getOrCreateProgram, getTypeMetadata } from '@zeltjs/decorator-metadata/
 
 import type { GqlSchemaResolver, GraphqlArgsSchemaRef } from './analyze-gql-args.lib';
 import { extractGraphqlArgsRef, resolveGraphqlArgs } from './analyze-gql-args.lib';
-import { GraphqlArgsValidationError } from './args.lib';
 import type { StandardSchemaIssue } from './args.lib';
+import { GraphqlArgsValidationError } from './args.lib';
 import { parseGqlScalar } from './gql-scalar.lib';
 import type { GraphqlOperationMetadata, GraphqlResolverClass } from './graphql-metadata.lib';
 import type { GeneratedGraphqlRuntime, GraphqlInvocationHook } from './graphql-runtime.lib';

--- a/packages/graphql/src/graphql-sdl-generator.lib.ts
+++ b/packages/graphql/src/graphql-sdl-generator.lib.ts
@@ -11,9 +11,11 @@ import { getOrCreateProgram, getTypeMetadata } from '@zeltjs/decorator-metadata/
 
 import type { GqlSchemaResolver, GraphqlArgsSchemaRef } from './analyze-gql-args.lib';
 import { extractGraphqlArgsRef, resolveGraphqlArgs } from './analyze-gql-args.lib';
+import { GraphqlArgsValidationError } from './args.lib';
+import type { StandardSchemaIssue } from './args.lib';
 import { parseGqlScalar } from './gql-scalar.lib';
 import type { GraphqlOperationMetadata, GraphqlResolverClass } from './graphql-metadata.lib';
-import type { GeneratedGraphqlRuntime } from './graphql-runtime.lib';
+import type { GeneratedGraphqlRuntime, GraphqlInvocationHook } from './graphql-runtime.lib';
 import type { GraphqlSchemaAdapter } from './json-schema-to-graphql-args.lib';
 import { renderGraphqlArgs } from './json-schema-to-graphql-args.lib';
 import type { GraphqlOutputTypeInfo, GraphqlScalarRef } from './type-to-graphql.lib';
@@ -51,7 +53,7 @@ type RootFields = {
 
 type RuntimeBindings = Record<
   string,
-  Record<string, { readonly resolver: string; readonly method: string }>
+  Record<string, { readonly resolver: string; readonly method: string; readonly hook?: string }>
 >;
 
 type RuntimeEnumFields = Record<string, Record<string, Readonly<Record<string, string>>>>;
@@ -157,6 +159,73 @@ const defaultScalarResolver: GqlSchemaResolver = async (modulePath) => {
   }
   return { ...imported };
 };
+
+type StandardSchemaValidationResult = {
+  readonly issues?: readonly StandardSchemaIssue[];
+  readonly value: unknown;
+};
+
+type StandardSchemaValue = {
+  readonly '~standard': {
+    readonly validate: (
+      args: Readonly<Record<string, unknown>>,
+    ) => StandardSchemaValidationResult | Promise<StandardSchemaValidationResult>;
+  };
+};
+
+const argsInvocationHookSchemaRefs = new WeakMap<GraphqlInvocationHook, GraphqlArgsSchemaRef>();
+
+const readObject = (value: unknown): object | undefined =>
+  typeof value === 'object' && value !== null ? value : undefined;
+
+const readProperty = (value: object, key: string): unknown => Reflect.get(value, key);
+
+function toStandardSchemaValue(value: unknown): StandardSchemaValue;
+function toStandardSchemaValue(value: unknown): unknown {
+  return value;
+}
+
+const parseStandardSchemaValue = (value: unknown): StandardSchemaValue | undefined => {
+  const record = readObject(value);
+  if (record === undefined) return undefined;
+  const standard = readObject(readProperty(record, '~standard'));
+  if (standard === undefined) return undefined;
+  return typeof readProperty(standard, 'validate') === 'function'
+    ? toStandardSchemaValue(value)
+    : undefined;
+};
+
+/** @throws {Error} */
+const resolveArgsSchemaValue = async (
+  ref: GraphqlArgsSchemaRef,
+  resolver: GqlSchemaResolver = defaultScalarResolver,
+): Promise<StandardSchemaValue> => {
+  const mod = await resolver(ref.modulePath);
+  const schema = mod[ref.exportName];
+  const parsed = parseStandardSchemaValue(schema);
+  if (parsed === undefined) {
+    throw new Error(`Export '${ref.exportName}' is not a Standard Schema`);
+  }
+  return parsed;
+};
+
+export const createGeneratedGraphqlArgsInvocationHook = (
+  ref: GraphqlArgsSchemaRef,
+  resolver?: GqlSchemaResolver,
+): GraphqlInvocationHook => {
+  const hook: GraphqlInvocationHook = async (ctx) => {
+    const schema = await resolveArgsSchemaValue(ref, resolver);
+    const result = await schema['~standard'].validate(ctx.args);
+    if (result.issues) throw new GraphqlArgsValidationError(result.issues);
+    return [result.value];
+  };
+  argsInvocationHookSchemaRefs.set(hook, ref);
+  return hook;
+};
+
+export const getGraphqlInvocationHookSchemaRef = (
+  hook: GraphqlInvocationHook,
+): GraphqlArgsSchemaRef | undefined => argsInvocationHookSchemaRefs.get(hook);
 
 const resolveRelativeModuleSpecifier = (
   sourceFile: import('typescript').SourceFile,
@@ -794,11 +863,17 @@ const addRuntimeBinding = (
   fieldName: string,
   resolverName: string,
   methodName: string,
+  hook: string | undefined,
 ): void => {
   const typeBindings = bindings[typeName] ?? {};
   const existing = typeBindings[fieldName];
-  const next = { resolver: resolverName, method: methodName };
-  if (existing && (existing.resolver !== next.resolver || existing.method !== next.method)) {
+  const next = { resolver: resolverName, method: methodName, ...(hook !== undefined && { hook }) };
+  if (
+    existing &&
+    (existing.resolver !== next.resolver ||
+      existing.method !== next.method ||
+      existing.hook !== next.hook)
+  ) {
     throw new Error(`Duplicate GraphQL runtime binding: ${typeName}.${fieldName}`);
   }
   bindings[typeName] = { ...typeBindings, [fieldName]: next };
@@ -866,6 +941,24 @@ type AnalysisState = {
   readonly typeCtx: ReturnType<typeof createGraphqlTypeContext>;
   readonly roots: RootFields;
   readonly bindings: RuntimeBindings;
+  readonly invocationHooks: Record<string, GraphqlInvocationHook>;
+};
+
+const createRootHookKey = (
+  rootTypeName: 'Query' | 'Mutation',
+  fieldName: string,
+  names: MethodTypeNames | undefined,
+): string | undefined =>
+  names?.argsSchemaRef === undefined ? undefined : `${rootTypeName}.${fieldName}`;
+
+const registerRootInvocationHook = (
+  hooks: Record<string, GraphqlInvocationHook>,
+  hookKey: string | undefined,
+  argsSchemaRef: GraphqlArgsSchemaRef | undefined,
+  options: GenerateSdlOptions,
+): void => {
+  if (hookKey === undefined || argsSchemaRef === undefined) return;
+  hooks[hookKey] = createGeneratedGraphqlArgsInvocationHook(argsSchemaRef, options.schemaResolver);
 };
 
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
@@ -878,12 +971,15 @@ const registerRootMethod = (
   kind: 'query' | 'mutation',
   names: MethodTypeNames | undefined,
   argsRendered: string,
+  options: GenerateSdlOptions,
 ): void => {
   const fields = kind === 'query' ? state.roots.query : state.roots.mutation;
   const rootTypeName = kind === 'query' ? 'Query' : 'Mutation';
+  const hookKey = createRootHookKey(rootTypeName, fieldName, names);
   addRootField(fields, fieldName, returnType, names?.returnTypeName, argsRendered, state.typeCtx);
   addEnumFieldMappingForType(state.typeCtx, rootTypeName, fieldName, returnType);
-  addRuntimeBinding(state.bindings, rootTypeName, fieldName, resolverName, methodName);
+  addRuntimeBinding(state.bindings, rootTypeName, fieldName, resolverName, methodName, hookKey);
+  registerRootInvocationHook(state.invocationHooks, hookKey, names?.argsSchemaRef, options);
 };
 
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
@@ -899,7 +995,14 @@ const registerFieldMethod = (
     throw new Error(`@ResolveField() ${resolverName}.${methodName} requires named parent type`);
   }
   addGraphqlField(state.typeCtx, names.parentTypeName, fieldName, returnType, names.returnTypeName);
-  addRuntimeBinding(state.bindings, names.parentTypeName, fieldName, resolverName, methodName);
+  addRuntimeBinding(
+    state.bindings,
+    names.parentTypeName,
+    fieldName,
+    resolverName,
+    methodName,
+    undefined,
+  );
 };
 
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
@@ -912,6 +1015,7 @@ const registerResolverMethod = (
   kind: OperationKind,
   names: MethodTypeNames | undefined,
   argsRendered: string,
+  options: GenerateSdlOptions,
 ): void => {
   if (kind === 'resolveField') {
     if (argsRendered !== '') {
@@ -931,6 +1035,7 @@ const registerResolverMethod = (
     kind,
     names,
     argsRendered,
+    options,
   );
 };
 
@@ -980,6 +1085,7 @@ const registerAnalyzedMethod = async (
     operation.kind,
     names,
     argsRendered,
+    options,
   );
 };
 
@@ -1015,6 +1121,7 @@ const analyzeResolvers = async (
     typeCtx: createGraphqlTypeContext(),
     roots: { query: new Map(), mutation: new Map() },
     bindings: {},
+    invocationHooks: {},
   };
 
   for (const resolver of resolvers) {
@@ -1027,6 +1134,9 @@ const analyzeResolvers = async (
     runtime: {
       schemaSdl,
       bindings: state.bindings,
+      ...(Object.keys(state.invocationHooks).length > 0 && {
+        invocationHooks: state.invocationHooks,
+      }),
       enumFields: buildRuntimeEnumFields(state.typeCtx),
       scalarRefs: buildRuntimeScalarRefs(state.typeCtx),
       scalars: buildRuntimeScalars(state.typeCtx),

--- a/packages/graphql/src/plugin.test.ts
+++ b/packages/graphql/src/plugin.test.ts
@@ -1,12 +1,33 @@
+import { execFile as execFileCallback } from 'node:child_process';
 import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 
+import { toJsonSchema } from '@valibot/to-json-schema';
+import type { GenericSchema } from 'valibot';
 import { describe, expect, it } from 'vitest';
+import { GraphqlArgsValidationError } from './args.lib';
+import { GetUserInput } from './gql-args-sample.lib';
+import { NodeGetUserInput } from './gql-args-node-sample.js';
 import { generateGraphqlSdl, graphqlPlugin } from './graphql-plugin.lib';
 import type { GqlOutput } from './index';
-import { gqlScalar, graphql, Query, Resolver } from './index';
+import { args, gqlScalar, graphql, Query, Resolver } from './index';
+
+function narrowToValibotSchema(value: unknown): GenericSchema;
+function narrowToValibotSchema(value: unknown): unknown {
+  return value;
+}
+
+const testSchemaAdapter = {
+  toJsonSchema: (schema: unknown) => toJsonSchema(narrowToValibotSchema(schema)),
+};
+
+const testSchemaResolver = (modulePath: string): Promise<Record<string, unknown>> =>
+  import(/* @vite-ignore */ modulePath);
+
+const execFile = promisify(execFileCallback);
 
 type ViewerPublic = {
   readonly id: string;
@@ -17,6 +38,22 @@ class ViewerResolver {
   @Query()
   viewer(): ViewerPublic {
     return { id: 'viewer' };
+  }
+}
+
+@Resolver()
+class PluginArgsResolver {
+  @Query()
+  userById(input = args(GetUserInput)): ViewerPublic {
+    return { id: input.id };
+  }
+}
+
+@Resolver()
+class PluginNodeArgsResolver {
+  @Query()
+  nodeUserById(input = args(NodeGetUserInput)): ViewerPublic {
+    return { id: input.id };
   }
 }
 
@@ -115,6 +152,93 @@ describe('graphqlPlugin', () => {
     );
     expect(imported.graphqlRuntime).toMatchObject({
       scalars: { Money: PluginMoneyScalar },
+    });
+  });
+
+  it('generates runtime helper imports for async args invocation hooks', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'zelt-graphql-runtime-args-'));
+    const runtimeModule = join(outDir, 'args-runtime.js');
+    const child = graphql({
+      path: '/graphql',
+      resolvers: [PluginArgsResolver],
+      runtimeModule,
+    });
+
+    await generateGraphqlSdl(
+      { getControllers: () => child.blueprint().getControllers() },
+      {
+        distDir: outDir,
+        tsconfig: resolve(__dirname, '../tsconfig.json'),
+        schemaAdapter: testSchemaAdapter,
+        schemaResolver: testSchemaResolver,
+      },
+    );
+
+    const imported: {
+      readonly graphqlRuntime?: {
+        readonly invocationHooks?: Record<string, unknown>;
+      };
+    } = await import(/* @vite-ignore */ `${pathToFileURL(runtimeModule).href}?t=${Date.now()}`);
+    const hook = imported.graphqlRuntime?.invocationHooks?.['Query.userById'];
+
+    expect(typeof hook).toBe('function');
+    await expect(
+      (hook as (ctx: {
+        readonly parent: unknown;
+        readonly args: Readonly<Record<string, unknown>>;
+        readonly isRootField: boolean;
+      }) => Promise<readonly unknown[]>)({
+        parent: undefined,
+        args: { id: 'user-1' },
+        isRootField: true,
+      }),
+    ).resolves.toEqual([{ id: 'user-1' }]);
+    await expect(
+      (hook as (ctx: {
+        readonly parent: unknown;
+        readonly args: Readonly<Record<string, unknown>>;
+        readonly isRootField: boolean;
+      }) => Promise<readonly unknown[]>)({
+        parent: undefined,
+        args: { id: '' },
+        isRootField: true,
+      }),
+    ).rejects.toBeInstanceOf(GraphqlArgsValidationError);
+  });
+
+  it('generates an args runtime helper that plain Node can import', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'zelt-graphql-runtime-node-'));
+    const runtimeModule = join(outDir, 'node-runtime.mjs');
+    const child = graphql({
+      path: '/graphql',
+      resolvers: [PluginNodeArgsResolver],
+      runtimeModule,
+    });
+
+    await generateGraphqlSdl(
+      { getControllers: () => child.blueprint().getControllers() },
+      {
+        distDir: outDir,
+        tsconfig: resolve(__dirname, '../tsconfig.json'),
+        schemaAdapter: testSchemaAdapter,
+      },
+    );
+
+    const runtimeUrl = pathToFileURL(runtimeModule).href;
+    const script = `
+      const mod = await import(${JSON.stringify(runtimeUrl)});
+      const hook = mod.graphqlRuntime.invocationHooks['Query.nodeUserById'];
+      const result = await hook({ parent: undefined, args: { id: 'node-user' }, isRootField: true });
+      console.log(JSON.stringify({ type: typeof hook, result }));
+    `;
+
+    await expect(
+      execFile(process.execPath, ['--input-type=module', '-e', script]),
+    ).resolves.toMatchObject({
+      stdout: `${JSON.stringify({
+        type: 'function',
+        result: [{ id: 'node-user' }],
+      })}\n`,
     });
   });
 

--- a/packages/graphql/src/plugin.test.ts
+++ b/packages/graphql/src/plugin.test.ts
@@ -9,8 +9,8 @@ import { toJsonSchema } from '@valibot/to-json-schema';
 import type { GenericSchema } from 'valibot';
 import { describe, expect, it } from 'vitest';
 import { GraphqlArgsValidationError } from './args.lib';
-import { GetUserInput } from './gql-args-sample.lib';
 import { NodeGetUserInput } from './gql-args-node-sample.js';
+import { GetUserInput } from './gql-args-sample.lib';
 import { generateGraphqlSdl, graphqlPlugin } from './graphql-plugin.lib';
 import type { GqlOutput } from './index';
 import { args, gqlScalar, graphql, Query, Resolver } from './index';
@@ -183,22 +183,26 @@ describe('graphqlPlugin', () => {
 
     expect(typeof hook).toBe('function');
     await expect(
-      (hook as (ctx: {
-        readonly parent: unknown;
-        readonly args: Readonly<Record<string, unknown>>;
-        readonly isRootField: boolean;
-      }) => Promise<readonly unknown[]>)({
+      (
+        hook as (ctx: {
+          readonly parent: unknown;
+          readonly args: Readonly<Record<string, unknown>>;
+          readonly isRootField: boolean;
+        }) => Promise<readonly unknown[]>
+      )({
         parent: undefined,
         args: { id: 'user-1' },
         isRootField: true,
       }),
     ).resolves.toEqual([{ id: 'user-1' }]);
     await expect(
-      (hook as (ctx: {
-        readonly parent: unknown;
-        readonly args: Readonly<Record<string, unknown>>;
-        readonly isRootField: boolean;
-      }) => Promise<readonly unknown[]>)({
+      (
+        hook as (ctx: {
+          readonly parent: unknown;
+          readonly args: Readonly<Record<string, unknown>>;
+          readonly isRootField: boolean;
+        }) => Promise<readonly unknown[]>
+      )({
         parent: undefined,
         args: { id: '' },
         isRootField: true,

--- a/packages/graphql/src/runtime.test.ts
+++ b/packages/graphql/src/runtime.test.ts
@@ -246,8 +246,11 @@ type ViewerPublic {
     });
 
     expect(result.data).toBeNull();
-    expect(result.errors?.[0]?.extensions?.['code']).toBe('GRAPHQL_ARGS_VALIDATION_FAILED');
-    expect(result.errors?.[0]?.extensions?.['issues']).toEqual([{ message: 'id is invalid' }]);
+    if (result.errors === undefined || result.errors[0] === undefined) {
+      throw new Error('Expected GraphQL args validation error');
+    }
+    expect(result.errors[0].extensions['code']).toBe('GRAPHQL_ARGS_VALIDATION_FAILED');
+    expect(result.errors[0].extensions['issues']).toEqual([{ message: 'id is invalid' }]);
   });
 
   it('enriches structurally compatible args validation errors thrown from an invocation hook', async () => {
@@ -301,8 +304,11 @@ type ViewerPublic {
     });
 
     expect(result.data).toBeNull();
-    expect(result.errors?.[0]?.extensions?.['code']).toBe('GRAPHQL_ARGS_VALIDATION_FAILED');
-    expect(result.errors?.[0]?.extensions?.['issues']).toEqual([
+    if (result.errors === undefined || result.errors[0] === undefined) {
+      throw new Error('Expected GraphQL args validation error');
+    }
+    expect(result.errors[0].extensions['code']).toBe('GRAPHQL_ARGS_VALIDATION_FAILED');
+    expect(result.errors[0].extensions['issues']).toEqual([
       { message: 'id is invalid from generated helper' },
     ]);
   });

--- a/packages/graphql/src/runtime.test.ts
+++ b/packages/graphql/src/runtime.test.ts
@@ -5,8 +5,13 @@ import { pathToFileURL } from 'node:url';
 import { createApp, http } from '@zeltjs/core';
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
+import { GraphqlArgsValidationError } from './args.lib';
 import type { GeneratedGraphqlRuntime } from './graphql-runtime.lib';
-import { createGraphqlExecutor, executeGraphqlRequest } from './graphql-runtime.lib';
+import {
+  createGraphqlExecutor,
+  executeGraphqlRequest,
+  loadGeneratedGraphqlRuntime,
+} from './graphql-runtime.lib';
 import { args, gqlScalar, graphql, Query, ResolveField, Resolver } from './index';
 
 type ViewerPublic = {
@@ -67,6 +72,239 @@ describe('executeGraphqlRequest', () => {
         },
       },
     });
+  });
+
+  it('uses invocation hook params before calling a root resolver', async () => {
+    type HookedUserInput = {
+      readonly id: string;
+    };
+
+    @Resolver()
+    class HookedUserResolver {
+      @Query()
+      user(input: HookedUserInput): ViewerPublic {
+        return { id: input.id };
+      }
+    }
+
+    const hookContexts: unknown[] = [];
+    const hookRuntime = {
+      schemaSdl: `type Query {
+  user(id: String!): ViewerPublic!
+}
+
+type ViewerPublic {
+  id: String!
+}
+`,
+      bindings: {
+        Query: {
+          user: { resolver: 'HookedUserResolver', method: 'user', hook: 'Query.user' },
+        },
+      },
+      invocationHooks: {
+        'Query.user': async (ctx: {
+          readonly parent: unknown;
+          readonly args: Readonly<Record<string, unknown>>;
+          readonly isRootField: boolean;
+        }): Promise<readonly unknown[]> => {
+          hookContexts.push(ctx);
+          return [{ id: `${String(ctx.args['id'])}-validated` }];
+        },
+      },
+    } satisfies GeneratedGraphqlRuntime;
+
+    const result = await executeGraphqlRequest({
+      runtime: hookRuntime,
+      resolvers: [HookedUserResolver],
+      resolveResolver: (resolver) => new resolver() as object,
+      request: { query: '{ user(id: "user-1") { id } }' },
+    });
+
+    expect(result).toEqual({
+      data: {
+        user: { id: 'user-1-validated' },
+      },
+    });
+    expect(hookContexts).toEqual([
+      {
+        parent: undefined,
+        args: { id: 'user-1' },
+        isRootField: true,
+      },
+    ]);
+  });
+
+  it('keeps args default parameter fallback when binding has no invocation hook', async () => {
+    const FallbackInput = v.object({
+      id: v.pipe(v.string(), v.minLength(1)),
+    });
+
+    @Resolver()
+    class FallbackArgsResolver {
+      @Query()
+      user(input = args(FallbackInput)): ViewerPublic {
+        return { id: input.id };
+      }
+    }
+
+    const fallbackRuntime = {
+      schemaSdl: `type Query {
+  user(id: String!): ViewerPublic!
+}
+
+type ViewerPublic {
+  id: String!
+}
+`,
+      bindings: {
+        Query: {
+          user: { resolver: 'FallbackArgsResolver', method: 'user' },
+        },
+      },
+    } satisfies GeneratedGraphqlRuntime;
+
+    const result = await executeGraphqlRequest({
+      runtime: fallbackRuntime,
+      resolvers: [FallbackArgsResolver],
+      resolveResolver: (resolver) => new resolver() as object,
+      request: { query: '{ user(id: "fallback-user") { id } }' },
+    });
+
+    expect(result).toEqual({
+      data: {
+        user: { id: 'fallback-user' },
+      },
+    });
+  });
+
+  it('rejects generated runtime bindings with an empty invocation hook name', async () => {
+    const runtimeModulePath = join(
+      tmpdir(),
+      `zelt-graphql-empty-hook-${Date.now()}-${Math.random()}.mjs`,
+    );
+    await writeFile(
+      runtimeModulePath,
+      `export const graphqlRuntime = ${JSON.stringify({
+        schemaSdl: `type Query {
+  viewer: ViewerPublic!
+}
+
+type ViewerPublic {
+  id: String!
+}
+`,
+        bindings: {
+          Query: {
+            viewer: { resolver: 'RuntimeViewerResolver', method: 'viewer', hook: '' },
+          },
+        },
+      })};\n`,
+      'utf8',
+    );
+
+    await expect(loadGeneratedGraphqlRuntime(runtimeModulePath)).rejects.toThrow(
+      /GraphQL runtime module must export graphqlRuntime/,
+    );
+  });
+
+  it('enriches GraphqlArgsValidationError thrown from an invocation hook', async () => {
+    @Resolver()
+    class HookValidationResolver {
+      @Query()
+      user(input: ViewerPublic): ViewerPublic {
+        return input;
+      }
+    }
+
+    const validationRuntime = {
+      schemaSdl: `type Query {
+  user(id: String!): ViewerPublic!
+}
+
+type ViewerPublic {
+  id: String!
+}
+`,
+      bindings: {
+        Query: {
+          user: { resolver: 'HookValidationResolver', method: 'user', hook: 'Query.user' },
+        },
+      },
+      invocationHooks: {
+        'Query.user': (): readonly unknown[] => {
+          throw new GraphqlArgsValidationError([{ message: 'id is invalid' }]);
+        },
+      },
+    } satisfies GeneratedGraphqlRuntime;
+
+    const result = await executeGraphqlRequest({
+      runtime: validationRuntime,
+      resolvers: [HookValidationResolver],
+      resolveResolver: (resolver) => new resolver() as object,
+      request: { query: '{ user(id: "") { id } }' },
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.errors?.[0]?.extensions?.['code']).toBe('GRAPHQL_ARGS_VALIDATION_FAILED');
+    expect(result.errors?.[0]?.extensions?.['issues']).toEqual([{ message: 'id is invalid' }]);
+  });
+
+  it('enriches structurally compatible args validation errors thrown from an invocation hook', async () => {
+    class GeneratedHelperGraphqlArgsValidationError extends Error {
+      readonly issues = [{ message: 'id is invalid from generated helper' }];
+
+      constructor() {
+        super('GraphQL args validation failed: id is invalid from generated helper');
+        this.name = 'GraphqlArgsValidationError';
+      }
+    }
+
+    @Resolver()
+    class StructuralHookValidationResolver {
+      @Query()
+      user(input: ViewerPublic): ViewerPublic {
+        return input;
+      }
+    }
+
+    const validationRuntime = {
+      schemaSdl: `type Query {
+  user(id: String!): ViewerPublic!
+}
+
+type ViewerPublic {
+  id: String!
+}
+`,
+      bindings: {
+        Query: {
+          user: {
+            resolver: 'StructuralHookValidationResolver',
+            method: 'user',
+            hook: 'Query.user',
+          },
+        },
+      },
+      invocationHooks: {
+        'Query.user': (): readonly unknown[] => {
+          throw new GeneratedHelperGraphqlArgsValidationError();
+        },
+      },
+    } satisfies GeneratedGraphqlRuntime;
+
+    const result = await executeGraphqlRequest({
+      runtime: validationRuntime,
+      resolvers: [StructuralHookValidationResolver],
+      resolveResolver: (resolver) => new resolver() as object,
+      request: { query: '{ user(id: "") { id } }' },
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.errors?.[0]?.extensions?.['code']).toBe('GRAPHQL_ARGS_VALIDATION_FAILED');
+    expect(result.errors?.[0]?.extensions?.['issues']).toEqual([
+      { message: 'id is invalid from generated helper' },
+    ]);
   });
 });
 

--- a/packages/graphql/src/schema-first-runtime.lib.ts
+++ b/packages/graphql/src/schema-first-runtime.lib.ts
@@ -361,6 +361,7 @@ const findResolveFieldOwner = (index: SchemaFirstSdlIndex, fieldName: string): s
   throw new Error(`Schema-first binding is ambiguous for @ResolveField(): ${fieldName}`);
 };
 
+/** @throws {Error} */
 const registerRootOperation = (
   bindings: RuntimeBindings,
   invocationHooks: RuntimeInvocationHooks,

--- a/packages/graphql/src/schema-first-runtime.lib.ts
+++ b/packages/graphql/src/schema-first-runtime.lib.ts
@@ -1,15 +1,32 @@
+import { dirname, resolve } from 'node:path';
+
 import type { ClassMetadata, MethodInfo } from '@zeltjs/decorator-metadata/inspect';
-import { getTypeMetadata } from '@zeltjs/decorator-metadata/inspect';
+import { getOrCreateProgram, getTypeMetadata } from '@zeltjs/decorator-metadata/inspect';
 import type { ObjectTypeDefinitionNode } from 'graphql';
 import { Kind, parse } from 'graphql';
 
+import type { GraphqlArgsSchemaRef } from './analyze-gql-args.lib';
+import { extractGraphqlArgsRef } from './analyze-gql-args.lib';
 import type { GraphqlOperationMetadata, GraphqlResolverClass } from './graphql-metadata.lib';
-import type { GeneratedGraphqlBinding, GraphqlRuntimeManifest } from './graphql-runtime.lib';
+import type {
+  GeneratedGraphqlBinding,
+  GraphqlInvocationHook,
+  GraphqlRuntimeManifest,
+} from './graphql-runtime.lib';
+import { createGeneratedGraphqlArgsInvocationHook } from './graphql-sdl-generator.lib';
 
 type SchemaFirstRuntimeOptions = {
   readonly schemaSdl: string;
   readonly tsconfig?: string;
 };
+
+type TS = typeof import('typescript');
+type TSClassDeclaration = import('typescript').ClassDeclaration;
+type TSMethodDeclaration = import('typescript').MethodDeclaration;
+type TSSourceFile = import('typescript').SourceFile;
+type TSCallExpression = import('typescript').CallExpression;
+type TSExpression = import('typescript').Expression;
+type TSImportDeclaration = import('typescript').ImportDeclaration;
 
 type SchemaFirstSdlIndex = {
   readonly queryFields: ReadonlySet<string>;
@@ -18,6 +35,13 @@ type SchemaFirstSdlIndex = {
 };
 
 type RuntimeBindings = GraphqlRuntimeManifest['bindings'];
+
+type RuntimeInvocationHooks = Record<string, GraphqlInvocationHook>;
+
+type ResolverClassNode = {
+  readonly classNode: TSClassDeclaration;
+  readonly ts: TS;
+};
 
 function toInspectableClass(cls: GraphqlResolverClass): new (...args: unknown[]) => object;
 function toInspectableClass(cls: GraphqlResolverClass): unknown {
@@ -64,6 +88,233 @@ const getOperationMetadata = (method: MethodInfo): GraphqlOperationMetadata | un
   return undefined;
 };
 
+const findClassDeclaration = (
+  sourceFile: import('typescript').SourceFile,
+  className: string,
+  ts: TS,
+): TSClassDeclaration | undefined => {
+  let found: TSClassDeclaration | undefined;
+
+  const visit = (node: import('typescript').Node): void => {
+    if (found) return;
+    if (ts.isClassDeclaration(node) && node.name?.text === className) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
+};
+
+const findMethodDeclaration = (
+  classNode: TSClassDeclaration,
+  methodName: string,
+  ts: TS,
+): TSMethodDeclaration | undefined => {
+  for (const member of classNode.members) {
+    if (ts.isMethodDeclaration(member) && member.name.getText() === methodName) return member;
+  }
+  return undefined;
+};
+
+const resolveRelativeModuleSpecifier = (sourceFile: TSSourceFile, specifier: string): string => {
+  if (!specifier.startsWith('.')) return specifier;
+  const resolved = resolve(dirname(sourceFile.fileName), specifier);
+  return resolved.endsWith('.ts') || resolved.endsWith('.js') || resolved.endsWith('.mjs')
+    ? resolved
+    : `${resolved}.ts`;
+};
+
+const findExportNameInElements = (
+  elements: readonly import('typescript').ImportSpecifier[],
+  localName: string,
+): string | undefined => {
+  for (const elem of elements) {
+    if (elem.name.text !== localName) continue;
+    return elem.propertyName?.text ?? elem.name.text;
+  }
+  return undefined;
+};
+
+const resolveImportedName = (
+  importDecl: TSImportDeclaration,
+  localName: string,
+  ts: TS,
+): string | undefined => {
+  const namedBindings = importDecl.importClause?.namedBindings;
+  if (!namedBindings || !ts.isNamedImports(namedBindings)) return undefined;
+  return findExportNameInElements(namedBindings.elements, localName);
+};
+
+const findIdentifierImport = (
+  sourceFile: TSSourceFile,
+  localName: string,
+  ts: TS,
+): GraphqlArgsSchemaRef | undefined => {
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+    const exportName = resolveImportedName(stmt, localName, ts);
+    if (!exportName) continue;
+    return {
+      modulePath: resolveRelativeModuleSpecifier(sourceFile, stmt.moduleSpecifier.text),
+      exportName,
+    };
+  }
+  return undefined;
+};
+
+const getExportedVariableDeclarations = (
+  stmt: import('typescript').Statement,
+  ts: TS,
+): readonly import('typescript').VariableDeclaration[] | undefined => {
+  if (!ts.isVariableStatement(stmt)) return undefined;
+  const isExported = stmt.modifiers?.some(
+    (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+  );
+  return isExported ? stmt.declarationList.declarations : undefined;
+};
+
+const hasExportedLocalDeclaration = (
+  sourceFile: TSSourceFile,
+  identifierName: string,
+  ts: TS,
+): boolean => {
+  for (const stmt of sourceFile.statements) {
+    const declarations = getExportedVariableDeclarations(stmt, ts);
+    if (!declarations) continue;
+    if (
+      declarations.some((decl) => ts.isIdentifier(decl.name) && decl.name.text === identifierName)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const buildSchemaRef = (
+  call: TSCallExpression,
+  sourceFile: TSSourceFile,
+  ts: TS,
+): GraphqlArgsSchemaRef | undefined => {
+  const arg = call.arguments[0];
+  if (!arg || !ts.isIdentifier(arg)) return undefined;
+  const localName = arg.text;
+
+  const imported = findIdentifierImport(sourceFile, localName, ts);
+  if (imported) return imported;
+  if (hasExportedLocalDeclaration(sourceFile, localName, ts)) {
+    return { modulePath: sourceFile.fileName, exportName: localName };
+  }
+  return undefined;
+};
+
+const matchPropertyAccess = (
+  expression: TSExpression | undefined,
+  propertyName: string,
+  ts: TS,
+): TSExpression | undefined => {
+  if (expression === undefined || !ts.isPropertyAccessExpression(expression)) return undefined;
+  return expression.name.text === propertyName ? expression.expression : undefined;
+};
+
+const matchSchemaFirstArgsCall = (
+  init: import('typescript').Expression | undefined,
+  rootTypeName: 'Query' | 'Mutation',
+  fieldName: string,
+  ts: TS,
+): TSCallExpression | undefined => {
+  if (!init || !ts.isCallExpression(init)) return undefined;
+  const fieldAccess = matchPropertyAccess(init.expression, 'args', ts);
+  const rootAccess = matchPropertyAccess(fieldAccess, fieldName, ts);
+  const gqlIdentifier = matchPropertyAccess(rootAccess, rootTypeName, ts);
+  if (gqlIdentifier === undefined || !ts.isIdentifier(gqlIdentifier)) return undefined;
+  if (gqlIdentifier.text !== 'Gql') return undefined;
+  return init;
+};
+
+/** @throws {Error} */
+const extractSchemaFirstGraphqlArgsRef = (
+  methodNode: TSMethodDeclaration,
+  sourceFile: TSSourceFile,
+  rootTypeName: 'Query' | 'Mutation',
+  fieldName: string,
+  ts: TS,
+): GraphqlArgsSchemaRef | undefined => {
+  for (const param of methodNode.parameters) {
+    const call = matchSchemaFirstArgsCall(param.initializer, rootTypeName, fieldName, ts);
+    if (!call) continue;
+    const ref = buildSchemaRef(call, sourceFile, ts);
+    if (!ref) {
+      const paramName = ts.isIdentifier(param.name) ? param.name.text : '<unknown>';
+      throw new Error(
+        `Gql.${rootTypeName}.${fieldName}.args() detected on parameter '${paramName}' but schema reference could not be resolved`,
+      );
+    }
+    return ref;
+  }
+  return undefined;
+};
+
+/** @throws {Error | UnsupportedTypeScriptVersionError} */
+const findResolverClassNode = async (
+  resolver: GraphqlResolverClass,
+  metadata: ClassMetadata,
+  options: SchemaFirstRuntimeOptions,
+): Promise<ResolverClassNode | undefined> => {
+  if (!metadata.pos) return undefined;
+
+  const programResult = await getOrCreateProgram(resolve(options.tsconfig ?? 'tsconfig.json'));
+  if (programResult.isErr()) {
+    throw new Error(`Failed to load TypeScript program: ${programResult.error.message}`);
+  }
+
+  const { program, ts } = programResult.value;
+  const sourceFile = program.getSourceFile(metadata.pos.sourceFile);
+  if (!sourceFile) return undefined;
+
+  const classNode = findClassDeclaration(sourceFile, resolver.name, ts);
+  return classNode ? { classNode, ts } : undefined;
+};
+
+const getRootTypeName = (
+  kind: GraphqlOperationMetadata['kind'],
+): 'Query' | 'Mutation' | undefined => {
+  if (kind === 'query') return 'Query';
+  if (kind === 'mutation') return 'Mutation';
+  return undefined;
+};
+
+/** @throws {Error} */
+const getMethodArgsSchemaRef = (
+  found: ResolverClassNode | undefined,
+  methodName: string,
+  operation: GraphqlOperationMetadata,
+): GraphqlArgsSchemaRef | undefined => {
+  if (!found) return undefined;
+  const methodNode = findMethodDeclaration(found.classNode, methodName, found.ts);
+  if (!methodNode) return undefined;
+  const rootTypeName = getRootTypeName(operation.kind);
+  if (rootTypeName !== undefined) {
+    const schemaFirstRef = extractSchemaFirstGraphqlArgsRef(
+      methodNode,
+      found.classNode.getSourceFile(),
+      rootTypeName,
+      operation.fieldName ?? methodName,
+      found.ts,
+    );
+    if (schemaFirstRef) return schemaFirstRef;
+  }
+  return extractGraphqlArgsRef(methodNode, found.classNode.getSourceFile(), found.ts);
+};
+
+const getRootFields = (
+  index: SchemaFirstSdlIndex,
+  rootTypeName: 'Query' | 'Mutation',
+): ReadonlySet<string> => (rootTypeName === 'Query' ? index.queryFields : index.mutationFields);
+
 /** @throws {Error} */
 const addRuntimeBinding = (
   bindings: RuntimeBindings,
@@ -73,7 +324,12 @@ const addRuntimeBinding = (
 ): void => {
   const typeBindings = bindings[typeName] ?? {};
   const existing = typeBindings[fieldName];
-  if (existing && (existing.resolver !== binding.resolver || existing.method !== binding.method)) {
+  if (
+    existing &&
+    (existing.resolver !== binding.resolver ||
+      existing.method !== binding.method ||
+      existing.hook !== binding.hook)
+  ) {
     throw new Error(`Duplicate GraphQL runtime binding: ${typeName}.${fieldName}`);
   }
   bindings[typeName] = { ...typeBindings, [fieldName]: binding };
@@ -105,26 +361,54 @@ const findResolveFieldOwner = (index: SchemaFirstSdlIndex, fieldName: string): s
   throw new Error(`Schema-first binding is ambiguous for @ResolveField(): ${fieldName}`);
 };
 
+const registerRootOperation = (
+  bindings: RuntimeBindings,
+  invocationHooks: RuntimeInvocationHooks,
+  fields: ReadonlySet<string>,
+  rootTypeName: 'Query' | 'Mutation',
+  resolverName: string,
+  methodName: string,
+  fieldName: string,
+  argsSchemaRef: GraphqlArgsSchemaRef | undefined,
+): void => {
+  requireRootField(fields, rootTypeName, fieldName);
+  const hook = argsSchemaRef === undefined ? undefined : `${rootTypeName}.${fieldName}`;
+  const binding = {
+    resolver: resolverName,
+    method: methodName,
+    ...(hook !== undefined && { hook }),
+  };
+  addRuntimeBinding(bindings, rootTypeName, fieldName, binding);
+  if (hook === undefined || argsSchemaRef === undefined) return;
+  invocationHooks[hook] = createGeneratedGraphqlArgsInvocationHook(argsSchemaRef);
+};
+
 /** @throws {Error} */
 const registerOperation = (
   bindings: RuntimeBindings,
+  invocationHooks: RuntimeInvocationHooks,
   index: SchemaFirstSdlIndex,
   resolverName: string,
   methodName: string,
   operation: GraphqlOperationMetadata,
+  argsSchemaRef: GraphqlArgsSchemaRef | undefined,
 ): void => {
   const fieldName = operation.fieldName ?? methodName;
+  const rootTypeName = getRootTypeName(operation.kind);
+  if (rootTypeName !== undefined) {
+    registerRootOperation(
+      bindings,
+      invocationHooks,
+      getRootFields(index, rootTypeName),
+      rootTypeName,
+      resolverName,
+      methodName,
+      fieldName,
+      argsSchemaRef,
+    );
+    return;
+  }
   const binding = { resolver: resolverName, method: methodName };
-  if (operation.kind === 'query') {
-    requireRootField(index.queryFields, 'Query', fieldName);
-    addRuntimeBinding(bindings, 'Query', fieldName, binding);
-    return;
-  }
-  if (operation.kind === 'mutation') {
-    requireRootField(index.mutationFields, 'Mutation', fieldName);
-    addRuntimeBinding(bindings, 'Mutation', fieldName, binding);
-    return;
-  }
   addRuntimeBinding(bindings, findResolveFieldOwner(index, fieldName), fieldName, binding);
 };
 
@@ -144,6 +428,7 @@ const requireRootBindings = (
 /** @throws {Error | UnsupportedTypeScriptVersionError} */
 const registerResolver = async (
   bindings: RuntimeBindings,
+  invocationHooks: RuntimeInvocationHooks,
   index: SchemaFirstSdlIndex,
   resolver: GraphqlResolverClass,
   options: SchemaFirstRuntimeOptions,
@@ -159,11 +444,20 @@ const registerResolver = async (
   }
 
   const metadata: ClassMetadata = metadataResult.value;
+  const found = await findResolverClassNode(resolver, metadata, options);
   for (const method of metadata.methods) {
     if (typeof method.name !== 'string') continue;
     const operation = getOperationMetadata(method);
     if (!operation) continue;
-    registerOperation(bindings, index, resolver.name, method.name, operation);
+    registerOperation(
+      bindings,
+      invocationHooks,
+      index,
+      resolver.name,
+      method.name,
+      operation,
+      getMethodArgsSchemaRef(found, method.name, operation),
+    );
   }
 };
 
@@ -174,13 +468,15 @@ export const generateSchemaFirstGraphqlRuntimeForResolvers = async (
 ): Promise<GraphqlRuntimeManifest> => {
   const index = buildSdlIndex(options.schemaSdl);
   const bindings: RuntimeBindings = {};
+  const invocationHooks: RuntimeInvocationHooks = {};
   for (const resolver of resolvers) {
-    await registerResolver(bindings, index, resolver, options);
+    await registerResolver(bindings, invocationHooks, index, resolver, options);
   }
   requireRootBindings(index.queryFields, bindings, 'Query');
   requireRootBindings(index.mutationFields, bindings, 'Mutation');
   return {
     schemaSdl: options.schemaSdl,
     bindings,
+    ...(Object.keys(invocationHooks).length > 0 && { invocationHooks }),
   };
 };

--- a/packages/graphql/src/schema-first-runtime.lib.ts
+++ b/packages/graphql/src/schema-first-runtime.lib.ts
@@ -246,6 +246,7 @@ const extractSchemaFirstGraphqlArgsRef = (
   for (const param of methodNode.parameters) {
     const call = matchSchemaFirstArgsCall(param.initializer, rootTypeName, fieldName, ts);
     if (!call) continue;
+    if (call.arguments.length === 0) return undefined;
     const ref = buildSchemaRef(call, sourceFile, ts);
     if (!ref) {
       const paramName = ts.isIdentifier(param.name) ? param.name.text : '<unknown>';

--- a/packages/graphql/src/schema-first-runtime.test.ts
+++ b/packages/graphql/src/schema-first-runtime.test.ts
@@ -1,7 +1,9 @@
 import { resolve } from 'node:path';
 
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { describe, expect, it } from 'vitest';
-import { readGraphqlArgs } from './args.lib';
+import { readGraphqlArgs, validateGraphqlArgs } from './args.lib';
+import { GetUserInput } from './gql-args-sample.lib';
 import { executeGraphqlRequest } from './graphql-runtime.lib';
 import { Query, Resolver } from './index';
 import { generateSchemaFirstGraphqlRuntimeForResolvers } from './schema-first-runtime.lib';
@@ -23,6 +25,26 @@ class SchemaFirstStorefrontResolver {
 class SchemaFirstNamedStorefrontResolver {
   @Query('product')
   findProduct(input = readGraphqlArgs<{ readonly id: string }>()): Product {
+    return { id: input.id, name: 'Desk Lamp' };
+  }
+}
+
+namespace Gql {
+  export namespace Query {
+    export namespace product {
+      export function args<Schema extends StandardSchemaV1>(
+        schema: Schema,
+      ): StandardSchemaV1.InferOutput<Schema> {
+        return validateGraphqlArgs(schema);
+      }
+    }
+  }
+}
+
+@Resolver()
+class SchemaFirstArgsStorefrontResolver {
+  @Query()
+  product(input = Gql.Query.product.args(GetUserInput)): Product {
     return { id: input.id, name: 'Desk Lamp' };
   }
 }
@@ -78,6 +100,20 @@ type Product {
       resolver: 'SchemaFirstNamedStorefrontResolver',
       method: 'findProduct',
     });
+  });
+
+  it('records invocation hook keys for root bindings with args schemas', async () => {
+    const runtime = await generateSchemaFirstGraphqlRuntimeForResolvers(
+      [SchemaFirstArgsStorefrontResolver],
+      { schemaSdl, tsconfig },
+    );
+
+    expect(runtime.bindings['Query']?.['product']).toEqual({
+      resolver: 'SchemaFirstArgsStorefrontResolver',
+      method: 'product',
+      hook: 'Query.product',
+    });
+    expect(typeof runtime.invocationHooks?.['Query.product']).toBe('function');
   });
 
   it('fails clearly when a root method does not match the schema field', async () => {

--- a/packages/graphql/src/schema-first-runtime.test.ts
+++ b/packages/graphql/src/schema-first-runtime.test.ts
@@ -32,12 +32,22 @@ class SchemaFirstNamedStorefrontResolver {
 namespace Gql {
   export namespace Query {
     export namespace product {
+      export function args(): { readonly id: string };
       export function args<Schema extends StandardSchemaV1>(
         schema: Schema,
-      ): StandardSchemaV1.InferOutput<Schema> {
-        return validateGraphqlArgs(schema);
+      ): StandardSchemaV1.InferOutput<Schema>;
+      export function args(schema?: StandardSchemaV1): { readonly id: string } | unknown {
+        return schema ? validateGraphqlArgs(schema) : readGraphqlArgs<{ readonly id: string }>();
       }
     }
+  }
+}
+
+@Resolver()
+class SchemaFirstGeneratedArgsStorefrontResolver {
+  @Query()
+  product(input = Gql.Query.product.args()): Product {
+    return { id: input.id, name: 'Desk Lamp' };
   }
 }
 
@@ -100,6 +110,19 @@ type Product {
       resolver: 'SchemaFirstNamedStorefrontResolver',
       method: 'findProduct',
     });
+  });
+
+  it('does not require invocation hooks for generated schema-first args helpers without schemas', async () => {
+    const runtime = await generateSchemaFirstGraphqlRuntimeForResolvers(
+      [SchemaFirstGeneratedArgsStorefrontResolver],
+      { schemaSdl, tsconfig },
+    );
+
+    expect(runtime.bindings['Query']?.['product']).toEqual({
+      resolver: 'SchemaFirstGeneratedArgsStorefrontResolver',
+      method: 'product',
+    });
+    expect(runtime.invocationHooks).toBeUndefined();
   });
 
   it('records invocation hook keys for root bindings with args schemas', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,15 @@ importers:
 
   packages/cli:
     dependencies:
+      '@rollup/plugin-swc':
+        specifier: 0.4.0
+        version: 0.4.0(@swc/core@1.15.33)(rollup@4.60.4)
+      '@swc/core':
+        specifier: 1.15.33
+        version: 1.15.33
+      '@zeltjs/core':
+        specifier: workspace:*
+        version: link:../core
       chokidar:
         specifier: 5.0.0
         version: 5.0.0


### PR DESCRIPTION
## Summary
- add generated invocation hooks for GraphQL args so resolvers keep non-Promise argument DX
- add HTTP invocation hook runtime/generator support for body and validated parameters
- integrate CLI build/dev artifact generation with a thin .zelt registry and stale artifact checks
- bundle build-time HTTP hook artifacts as executable .mjs with decorator transform, while dev keeps .ts/tsx artifacts
- expose validateBodyAsync only through @zeltjs/core/http-invocation-runtime

## Verification
- pnpm exec vitest --run packages/graphql/src/generate-sdl.test.ts packages/graphql/src/plugin.test.ts packages/graphql/src/schema-first-runtime.test.ts packages/graphql/src/runtime.test.ts packages/graphql/src/args.test.ts
- pnpm exec vitest --run packages/core/src/features/http/routing/route-builder.lib.test.ts packages/core/src/features/http/request/validated.test.ts packages/core/src/features/http/invocation/generate-http-invocation.test.ts packages/core/src/features/http/http-invocation-registry.lib.test.ts packages/cli/src/http-invocation-artifacts.lib.test.ts
- pnpm --dir packages/core exec vitest run src/features/http/invocation/generate-http-invocation.test.ts
- pnpm --filter @zeltjs/core typecheck
- pnpm --filter @zeltjs/cli typecheck
- pnpm --filter @zeltjs/graphql typecheck
- pnpm --filter @zeltjs/core build
- pnpm --filter @zeltjs/cli build
- pnpm knip
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784196041&installation_id=133048706&pr_number=280&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F280&signature=306e5a8853e18ebb1202433c7aa9ecde658568b70662de7cbe4f64aa5f96f475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HTTPインボケーション用のフック生成・レジストリからの動的ロードに対応し、ルートごとのパラメータ検証を拡張。
  * GraphQLの引数検証をinvocation hook経由で実行し、フィールド単位のenforcementを強化。
* **Tests**
  * HTTP/GraphQLのフック生成・実行・エラー系テストを追加。
* **Chores**
  * 公開エントリの追加、ビルド/テスト設定（ESLint/knip/Vitest/tsdown）や型スキャン除外を更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->