### PR TITLE
Decorator metadataの位置解決をinspect層へ分離し、dist runtime契約検証を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "prepare": "pnpx lefthook install",
     "codepolicy:diff": "time codepolicy --filter=diff 2>&1 | tee codepolicy.diff.log",
     "throw-trace": "throw-trace check --exclude '**/*.test.ts' --exclude '**/dist/**' packages",
-    "verify-dist": "node scripts/verify-dist-imports.mjs"
+    "verify-dist": "node scripts/verify-dist-imports.mjs",
+    "verify-dist:runtime-contracts": "node scripts/verify-dist-runtime-contracts.mjs"
   },
   "devDependencies": {
     "@9wick/eslint-plugin-strict-type-rules": "^1.5.0",

--- a/packages/decorator-metadata/src/inspect/get-dependencies.lib.ts
+++ b/packages/decorator-metadata/src/inspect/get-dependencies.lib.ts
@@ -3,9 +3,10 @@ import { resolve } from 'node:path';
 import type { ResultAsync } from 'neverthrow';
 import { errAsync, okAsync } from 'neverthrow';
 
-import { getInternalClassMetadata, resolvePosition } from '../runtime/index';
+import { getInternalClassMetadata } from '../runtime/index';
 import { findClassAtPosition, findClassByName } from './ast.lib';
 import type { DependencyInfo, GetDependenciesOptions, InspectError } from './inspect.types';
+import { resolvePosition } from './position.lib';
 import type { ProgramCacheError } from './program-cache.lib';
 import { getOrCreateProgram } from './program-cache.lib';
 

--- a/packages/decorator-metadata/src/inspect/get-type-metadata.lib.ts
+++ b/packages/decorator-metadata/src/inspect/get-type-metadata.lib.ts
@@ -3,8 +3,8 @@ import { resolve } from 'node:path';
 import type { ResultAsync } from 'neverthrow';
 import { errAsync, okAsync } from 'neverthrow';
 
-import type { Position, StackTrace } from '../runtime/index';
-import { getInternalClassMetadata, resolvePosition } from '../runtime/index';
+import type { StackTrace } from '../runtime/index';
+import { getInternalClassMetadata } from '../runtime/index';
 import { findClassAtPosition } from './ast.lib';
 import type {
   ClassMetadata,
@@ -15,6 +15,8 @@ import type {
   PropertyInfo,
   TypeInfo,
 } from './inspect.types';
+import type { Position } from './position.lib';
+import { resolvePosition } from './position.lib';
 import type { ProgramCacheError } from './program-cache.lib';
 import { getOrCreateProgram } from './program-cache.lib';
 import { createTypeExtractor } from './type-extractor.lib';

--- a/packages/decorator-metadata/src/inspect/index.ts
+++ b/packages/decorator-metadata/src/inspect/index.ts
@@ -11,11 +11,12 @@ export type {
   InspectOptions,
   MethodInfo,
   ParamInfo,
-  Position,
   PropertyInfo,
   TypedPropertyInfo,
   TypeInfo,
 } from './inspect.types';
+export type { Position, ResolvePositionOptions } from './position.lib';
+export { resolvePosition } from './position.lib';
 export type { ProgramCacheError } from './program-cache.lib';
 export { clearProgramCache, getOrCreateProgram } from './program-cache.lib';
 export type { GetSourcePositionOptions } from './source-position.lib';

--- a/packages/decorator-metadata/src/inspect/inspect.types.ts
+++ b/packages/decorator-metadata/src/inspect/inspect.types.ts
@@ -1,4 +1,4 @@
-import type { Position } from '../runtime/index';
+import type { Position } from './position.lib';
 
 export type { Position };
 

--- a/packages/decorator-metadata/src/inspect/position.lib.ts
+++ b/packages/decorator-metadata/src/inspect/position.lib.ts
@@ -2,31 +2,18 @@ import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import type { StackTrace } from '../runtime/index';
+
 export type Position = {
   readonly sourceFile: string;
   readonly line: number;
   readonly column: number;
 };
 
-export type StackTrace = {
-  _brand: 'StackTrace';
-  readonly error: Error;
-  // Files belonging to wrapper functions (e.g. @zeltjs/core's Controller)
-  // identified by diffing the define-time stack against the call-time stack.
-  // resolvePosition treats these as framework paths so wrapper frames are
-  // skipped in favor of user code.
-  readonly wrapperFiles?: readonly string[];
-};
-
 export type ResolvePositionOptions = {
   readonly isFrameworkPath?: (path: string) => boolean;
 };
 
-// Derive this package's root by walking up to the nearest package.json so
-// framework-path detection works regardless of bundled layout (src/runtime/
-// vs dist/) or install location (workspace symlinks vs node_modules realpath).
-// Without this, decorators defined inside this package leak their own file
-// paths as "user positions" because the stack frame falls inside dist/.
 const findPackageRoot = (start: string): string => {
   let dir = dirname(start);
   while (dir !== dirname(dir)) {
@@ -51,22 +38,15 @@ const defaultIsFrameworkPath = (path: string): boolean => {
   if (normalized.includes('/node_modules/')) return true;
   if (normalized.startsWith('node:')) return true;
   if (!isWithinPackageRoot(normalized, PACKAGE_ROOT)) return false;
-  // Test files within this package are user code that exercises decorators —
-  // they must remain visible to position resolution so decorator usage inside
-  // tests reports the test file, not framework internals.
   return !isPackageTestPath(normalized, PACKAGE_ROOT);
 };
 
-// SWC, TypeScript, and Babel inject decorator helpers into transpiled output.
-// These helpers appear in user files but at synthesized positions that don't
-// correspond to any real TypeScript source line.
 const TRANSPILER_HELPER_NAMES = new Set([
-  'applyClassDecs', // SWC TC39 decorator helper
-  '__decorate', // TypeScript legacy experimentalDecorators
-  '_decorate', // Babel decorator helper
-  'applyDecs', // SWC older decorator helper
-  'applyDecs2305', // SWC versioned decorator helper
-  // SWC TC39 2022-03 member decorator helpers
+  'applyClassDecs',
+  '__decorate',
+  '_decorate',
+  'applyDecs',
+  'applyDecs2305',
   'memberDec',
   'applyMemberDec',
   'applyMemberDecs',
@@ -75,22 +55,14 @@ const TRANSPILER_HELPER_NAMES = new Set([
 ]);
 
 const isTranspilerHelperFrame = (line: string): boolean => {
-  // Property accessor frames from transpiler-generated objects show "[as name]"
-  // in V8 stack traces — these are synthesized by SWC/Babel and have no
-  // corresponding source position.
   if (line.includes('[as ')) return true;
 
   const match = line.match(/^\s+at\s+([^\s(]+)/);
   if (!match?.[1]) return false;
-  // Strip leading qualifiers like "Array.", "Object.", etc.
   const name = match[1].split('.').pop() ?? '';
   return TRANSPILER_HELPER_NAMES.has(name);
 };
 
-// V8 stack frames for ESM-loaded modules use file:// URLs while frames for
-// CommonJS/transformed modules use plain paths. Normalize to plain paths so
-// downstream consumers (PACKAGE_ROOT comparison, TypeScript Program lookup)
-// work uniformly regardless of how a module was loaded.
 const normalizeStackFilePath = (file: string): string => {
   if (!file.startsWith('file://')) return file;
   try {
@@ -128,8 +100,6 @@ const parsePositionFromStackLine = (
   return tryParseMatch(atMatch, isFrameworkPath);
 };
 
-// Returns true if the frame has no named function — just a bare file path.
-// Pattern: "    at /path/to/file.ts:line:col" (no function name before the path).
 const isAnonymousPathFrame = (line: string): boolean =>
   /^\s+at\s+\//.test(line) || /^\s+at\s+[a-zA-Z]:\\/.test(line);
 
@@ -163,23 +133,6 @@ const diffOutsidePackageFiles = (defineStack: string, callStack: string): readon
   return wrapperFiles;
 };
 
-// Diff define-time vs call-time stack: files present at definition (when
-// the wrapper called createClassDecorator) but absent at decoration (when
-// the returned decorator was applied to the class) are wrappers. User code
-// appears in both stacks, so it remains visible to resolvePosition.
-export const withWrapperFiles = (
-  defineTrace: StackTrace | undefined,
-  callTrace: StackTrace | undefined,
-): StackTrace | undefined => {
-  if (!defineTrace) return undefined;
-  const defineStack = defineTrace.error.stack;
-  const callStack = callTrace?.error.stack;
-  if (!defineStack || !callStack) return defineTrace;
-  const wrapperFiles = diffOutsidePackageFiles(defineStack, callStack);
-  if (wrapperFiles.length === 0) return defineTrace;
-  return { ...defineTrace, wrapperFiles };
-};
-
 const findFirstUserPosition = (
   stack: string,
   isFrameworkPath: (path: string) => boolean,
@@ -188,16 +141,10 @@ const findFirstUserPosition = (
   let prevWasHelperFrame = false;
   for (const line of lines) {
     if (!line) continue;
-    // Skip transpiler-generated decorator helper frames even when they appear
-    // inside user files — their line numbers map to synthesized positions in
-    // the transpiled output, not to meaningful TypeScript source locations.
     if (isTranspilerHelperFrame(line)) {
       prevWasHelperFrame = true;
       continue;
     }
-    // Anonymous continuation frames that immediately follow a transpiler helper
-    // frame are synthesized by the transpiler and do not correspond to real
-    // TypeScript source positions.
     if (prevWasHelperFrame && isAnonymousPathFrame(line)) {
       prevWasHelperFrame = true;
       continue;
@@ -209,18 +156,16 @@ const findFirstUserPosition = (
   return undefined;
 };
 
-export const captureStackTrace = (): StackTrace | undefined => {
-  if (Object.getOwnPropertyDescriptor(Error.prototype, 'stack') !== undefined) return undefined;
-  return { _brand: 'StackTrace', error: new Error() };
-};
-
 const buildIsFrameworkPath = (
   trace: StackTrace,
   options?: ResolvePositionOptions,
 ): ((path: string) => boolean) => {
   const baseIsFrameworkPath = options?.isFrameworkPath ?? defaultIsFrameworkPath;
-  const wrapperFiles = trace.wrapperFiles;
-  if (!wrapperFiles || wrapperFiles.length === 0) return baseIsFrameworkPath;
+  const defineStack = trace.error.stack;
+  const callStack = trace.callError?.stack;
+  if (!defineStack || !callStack) return baseIsFrameworkPath;
+  const wrapperFiles = diffOutsidePackageFiles(defineStack, callStack);
+  if (wrapperFiles.length === 0) return baseIsFrameworkPath;
   const wrapperSet = new Set(wrapperFiles);
   return (path) => baseIsFrameworkPath(path) || wrapperSet.has(path.replace(/\\/g, '/'));
 };

--- a/packages/decorator-metadata/src/inspect/source-position.lib.ts
+++ b/packages/decorator-metadata/src/inspect/source-position.lib.ts
@@ -1,5 +1,6 @@
-import type { Position, ResolvePositionOptions } from '../runtime/index';
-import { getInternalClassMetadata, resolvePosition } from '../runtime/index';
+import { getInternalClassMetadata } from '../runtime/index';
+import type { Position, ResolvePositionOptions } from './position.lib';
+import { resolvePosition } from './position.lib';
 
 export type GetSourcePositionOptions = ResolvePositionOptions;
 

--- a/packages/decorator-metadata/src/runtime/decorators.lib.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.lib.ts
@@ -1,7 +1,7 @@
 import { isClassConstructor, toUnknownCallable } from '@zeltjs/unsafe-type-lib';
 import { match, P } from 'ts-pattern';
 
-import { captureStackTrace, withWrapperFiles } from './position.lib';
+import { captureStackTrace, withCallStackTrace } from './trace.lib';
 import {
   aggregateMembers,
   ensureClassMeta,
@@ -212,7 +212,7 @@ export const createClassDecorator = <TProps extends object, E extends Error = Er
       const err: E | undefined = rejectIfApplied(getClassMetadata(cls)?.props ?? []);
       if (err) throw err;
     }
-    const trace = withWrapperFiles(defineTrace, captureStackTrace());
+    const trace = withCallStackTrace(defineTrace, captureStackTrace());
     recordClass(cls, trace, props);
     aggregateMembers(cls, classKey);
     afterApply?.(cls);
@@ -232,7 +232,7 @@ export const createMethodDecorator = <TProps extends object, E extends Error = E
       throw err;
     }
 
-    const trace = withWrapperFiles(defineTrace, captureStackTrace());
+    const trace = withCallStackTrace(defineTrace, captureStackTrace());
     recordMethod(info.classKey, info.name, trace, props);
     if (options?.afterApply && info.method) options.afterApply(info.method, info.name);
   });
@@ -249,7 +249,7 @@ export const createPropertyDecorator = <TProps extends object>(
   const defineTrace = captureStackTrace();
 
   return adaptPropertyContext((classKey, name) => {
-    const trace = withWrapperFiles(defineTrace, captureStackTrace());
+    const trace = withCallStackTrace(defineTrace, captureStackTrace());
     recordProperty(classKey, name, trace, props);
     options?.afterApply?.(name);
   });
@@ -271,7 +271,7 @@ export const composeClassDecorators = (...decorators: ClassDecoratorFn[]): Class
     const cls = asObject(args[0]);
     if (!cls) return undefined;
 
-    const trace = withWrapperFiles(defineTrace, captureStackTrace());
+    const trace = withCallStackTrace(defineTrace, captureStackTrace());
     if (trace) ensureClassMeta(cls, trace);
 
     for (const dec of decorators) {

--- a/packages/decorator-metadata/src/runtime/decorators.lib.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.lib.ts
@@ -1,7 +1,6 @@
 import { isClassConstructor, toUnknownCallable } from '@zeltjs/unsafe-type-lib';
 import { match, P } from 'ts-pattern';
 
-import { captureStackTrace, withCallStackTrace } from './trace.lib';
 import {
   aggregateMembers,
   ensureClassMeta,
@@ -10,6 +9,7 @@ import {
   recordMethod,
   recordProperty,
 } from './store.lib';
+import { captureStackTrace, withCallStackTrace } from './trace.lib';
 
 // =============================================================================
 // Types

--- a/packages/decorator-metadata/src/runtime/index.ts
+++ b/packages/decorator-metadata/src/runtime/index.ts
@@ -14,8 +14,6 @@ export {
   createMethodDecorator,
   createPropertyDecorator,
 } from './decorators.lib';
-export type { StackTrace } from './trace.lib';
-export { captureStackTrace, withCallStackTrace } from './trace.lib';
 export type { ClassMeta, MethodMeta, PropertyMeta } from './store.lib';
 export {
   aggregateMembers,
@@ -26,3 +24,5 @@ export {
   recordMethod,
   recordProperty,
 } from './store.lib';
+export type { StackTrace } from './trace.lib';
+export { captureStackTrace, withCallStackTrace } from './trace.lib';

--- a/packages/decorator-metadata/src/runtime/index.ts
+++ b/packages/decorator-metadata/src/runtime/index.ts
@@ -14,8 +14,8 @@ export {
   createMethodDecorator,
   createPropertyDecorator,
 } from './decorators.lib';
-export type { Position, ResolvePositionOptions, StackTrace } from './position.lib';
-export { captureStackTrace, resolvePosition, withWrapperFiles } from './position.lib';
+export type { StackTrace } from './trace.lib';
+export { captureStackTrace, withCallStackTrace } from './trace.lib';
 export type { ClassMeta, MethodMeta, PropertyMeta } from './store.lib';
 export {
   aggregateMembers,

--- a/packages/decorator-metadata/src/runtime/store.lib.ts
+++ b/packages/decorator-metadata/src/runtime/store.lib.ts
@@ -1,4 +1,4 @@
-import type { StackTrace } from './position.lib';
+import type { StackTrace } from './trace.lib';
 
 // =============================================================================
 // Public Types (no trace exposure)

--- a/packages/decorator-metadata/src/runtime/trace.lib.ts
+++ b/packages/decorator-metadata/src/runtime/trace.lib.ts
@@ -1,0 +1,19 @@
+export type StackTrace = {
+  _brand: 'StackTrace';
+  readonly error: Error;
+  readonly callError?: Error;
+};
+
+export const captureStackTrace = (): StackTrace | undefined => {
+  if (Object.getOwnPropertyDescriptor(Error.prototype, 'stack') !== undefined) return undefined;
+  return { _brand: 'StackTrace', error: new Error() };
+};
+
+export const withCallStackTrace = (
+  defineTrace: StackTrace | undefined,
+  callTrace: StackTrace | undefined,
+): StackTrace | undefined => {
+  if (!defineTrace) return undefined;
+  if (!callTrace) return defineTrace;
+  return { ...defineTrace, callError: callTrace.error };
+};

--- a/packages/decorator-metadata/src/runtime/trace.lib.ts
+++ b/packages/decorator-metadata/src/runtime/trace.lib.ts
@@ -5,8 +5,9 @@ export type StackTrace = {
 };
 
 export const captureStackTrace = (): StackTrace | undefined => {
-  if (Object.getOwnPropertyDescriptor(Error.prototype, 'stack') !== undefined) return undefined;
-  return { _brand: 'StackTrace', error: new Error() };
+  const error = new Error();
+  if (typeof error.stack !== 'string' || error.stack.length === 0) return undefined;
+  return { _brand: 'StackTrace', error };
 };
 
 export const withCallStackTrace = (

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -1,7 +1,7 @@
 /* biome-ignore-all lint/complexity/noStaticOnlyClass: test fixtures */
 import { describe, expect, it } from 'vitest';
 
-import { getSourcePosition } from '../inspect/index';
+import { getSourcePosition, resolvePosition } from '../inspect/index';
 import type { StackTrace } from '../runtime/index';
 import {
   aggregateMembers,
@@ -16,7 +16,6 @@ import {
   recordClass,
   recordMethod,
   recordProperty,
-  resolvePosition,
 } from '../runtime/index';
 
 describe('captureStackTrace and resolvePosition', () => {
@@ -72,18 +71,25 @@ describe('captureStackTrace and resolvePosition', () => {
     // Simulate what createClassDecorator does internally: a wrapper (e.g.
     // @zeltjs/core's Controller) calls into the decorator factory, so its file
     // appears in the define-time stack but not in the call-time stack. The
-    // diff is recorded as wrapperFiles and skipped during resolution.
+    // inspect compares the stored define-time stack with the call-time stack
+    // and skips wrapper files that only exist at define time.
     const wrapperFile = '/tmp/app/wrappers/controller.ts';
     const userFile = '/tmp/app/user.controller.ts';
+    const callError = new Error('mock call stack');
     const trace: StackTrace = {
       _brand: 'StackTrace',
       error: new Error('mock stack'),
-      wrapperFiles: [wrapperFile],
+      callError,
     };
     trace.error.stack = [
       'Error: mock stack',
       `    at someInternal (/some/framework/internal.ts:10:1)`,
       `    at Controller (${wrapperFile}:5:3)`,
+      `    at ${userFile}:6:1`,
+    ].join('\n');
+    callError.stack = [
+      'Error: mock call stack',
+      `    at someInternal (/some/framework/internal.ts:10:1)`,
       `    at ${userFile}:6:1`,
     ].join('\n');
 

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -37,21 +37,18 @@ describe('captureStackTrace and resolvePosition', () => {
     expect(pos?.column).toBeGreaterThan(0);
   });
 
-  it('captureStackTrace returns undefined when Error.prototype.stack is overridden', () => {
-    const originalDescriptor = Object.getOwnPropertyDescriptor(Error.prototype, 'stack');
-    Object.defineProperty(Error.prototype, 'stack', {
-      value: undefined,
-      writable: true,
-      configurable: true,
-    });
+  it('captureStackTrace returns undefined when Error instances do not expose stack strings', () => {
+    const OriginalError = Error;
+    globalThis.Error = class StacklessError extends OriginalError {
+      constructor(...args: ConstructorParameters<ErrorConstructor>) {
+        super(...args);
+        Object.defineProperty(this, 'stack', { value: undefined });
+      }
+    } as unknown as ErrorConstructor;
     try {
       expect(captureStackTrace()).toBeUndefined();
     } finally {
-      if (originalDescriptor) {
-        Object.defineProperty(Error.prototype, 'stack', originalDescriptor);
-      } else {
-        delete (Error.prototype as { stack?: unknown }).stack;
-      }
+      globalThis.Error = OriginalError;
     }
   });
 

--- a/scripts/verify-dist-runtime-contracts.mjs
+++ b/scripts/verify-dist-runtime-contracts.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { glob, readFile } from 'node:fs/promises';
+import { builtinModules } from 'node:module';
 import path from 'node:path';
 
 const ALL_NODE_BUILTINS = 'all';
@@ -11,7 +12,10 @@ const ENTRYPOINT_POLICIES = {
   '@zeltjs/core': { nodeBuiltins: ['async_hooks'] },
   '@zeltjs/core/internal-bridge/testing': { nodeBuiltins: ['async_hooks'] },
   '@zeltjs/core/internal-bridge/errors': { nodeBuiltins: [] },
-  '@zeltjs/decorator-metadata/inspect': { nodeBuiltins: ALL_NODE_BUILTINS },
+  '@zeltjs/decorator-metadata/inspect': {
+    nodeBuiltins: ALL_NODE_BUILTINS,
+    globals: ['__filename'],
+  },
   '@zeltjs/eslint-plugin': { nodeBuiltins: ALL_NODE_BUILTINS },
   '@zeltjs/graphql/codegen': { nodeBuiltins: ALL_NODE_BUILTINS },
   '@zeltjs/hono-client': { nodeBuiltins: ALL_NODE_BUILTINS },
@@ -19,43 +23,9 @@ const ENTRYPOINT_POLICIES = {
   '@zeltjs/testing/node': { nodeBuiltins: ALL_NODE_BUILTINS },
 };
 
-const NODE_BUILTINS = new Set([
-  'assert',
-  'async_hooks',
-  'buffer',
-  'child_process',
-  'cluster',
-  'console',
-  'crypto',
-  'diagnostics_channel',
-  'dns',
-  'events',
-  'fs',
-  'http',
-  'http2',
-  'https',
-  'module',
-  'net',
-  'os',
-  'path',
-  'perf_hooks',
-  'process',
-  'punycode',
-  'querystring',
-  'readline',
-  'repl',
-  'stream',
-  'string_decoder',
-  'timers',
-  'tls',
-  'tty',
-  'url',
-  'util',
-  'v8',
-  'vm',
-  'worker_threads',
-  'zlib',
-]);
+const NODE_BUILTINS = new Set(
+  builtinModules.map((moduleName) => moduleName.replace(/^node:/, '').split('/')[0]),
+);
 
 const IMPORT_EXPORT_RE = /\b(?:import|export)\s+(?:[^'"()]*?\s+from\s+)?['"]([^'"]+)['"]/g;
 const DYNAMIC_IMPORT_RE = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
@@ -83,10 +53,21 @@ const collectExportTargets = (exportValue) => {
       if (/\.(?:js|mjs|cjs)$/.test(value)) targets.push({ condition, target: value });
       return;
     }
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => visit(item, `${condition}[${index}]`));
+      return;
+    }
     if (!value || typeof value !== 'object') return;
-    if (typeof value.default === 'string') visit(value.default, condition);
-    if (value.import) visit(value.import, 'import');
-    if (value.require) visit(value.require, 'require');
+    for (const [nextCondition, nextValue] of Object.entries(value)) {
+      if (nextCondition === 'types') continue;
+      const nestedCondition =
+        nextCondition === 'default'
+          ? condition
+          : condition === 'default'
+            ? nextCondition
+            : `${condition}.${nextCondition}`;
+      visit(nextValue, nestedCondition);
+    }
   };
   visit(exportValue, 'default');
   return targets;
@@ -122,7 +103,7 @@ const findViolations = (entrypoint, file, source) => {
   const policy = ENTRYPOINT_POLICIES[entrypoint] ?? { nodeBuiltins: [] };
   const allowedNodeBuiltins = policy.nodeBuiltins;
   const allowedGlobals =
-    allowedNodeBuiltins === ALL_NODE_BUILTINS
+    policy.globals === ALL_NODE_BUILTINS
       ? ALL_NODE_BUILTINS
       : new Set(policy.globals ?? []);
   const violations = [];
@@ -187,10 +168,19 @@ const packageFiles = await Array.fromAsync(glob('packages/*/package.json'));
 const allViolations = [];
 let checkedEntrypoints = 0;
 
+if (allDistFiles.length === 0) {
+  console.error('No dist files found. Build packages before running runtime contract verification.');
+  process.exit(1);
+}
+
 for (const packageFile of packageFiles.sort()) {
   const packageJson = await readJson(packageFile);
   const packageDir = path.dirname(packageFile);
-  for (const [exportKey, exportValue] of Object.entries(packageJson.exports ?? {})) {
+  const exportsMap =
+    typeof packageJson.exports === 'string' || Array.isArray(packageJson.exports)
+      ? { '.': packageJson.exports }
+      : (packageJson.exports ?? {});
+  for (const [exportKey, exportValue] of Object.entries(exportsMap)) {
     const entrypoint = publicSpecifier(packageJson.name, exportKey);
     const targets = collectExportTargets(exportValue);
     for (const { condition, target } of targets) {
@@ -217,6 +207,11 @@ if (allViolations.length > 0) {
     console.error(`  ${violation.message}\n`);
   }
   console.error(`${allViolations.length} violation(s) across ${checkedEntrypoints} export target(s).`);
+  process.exit(1);
+}
+
+if (checkedEntrypoints === 0) {
+  console.error('No package export targets were checked. Verify package.json exports point to dist files.');
   process.exit(1);
 }
 

--- a/scripts/verify-dist-runtime-contracts.mjs
+++ b/scripts/verify-dist-runtime-contracts.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+import { glob, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ALL_NODE_BUILTINS = 'all';
+
+const ENTRYPOINT_POLICIES = {
+  '@zeltjs/adapter-node': { nodeBuiltins: ALL_NODE_BUILTINS },
+  '@zeltjs/cli': { nodeBuiltins: ALL_NODE_BUILTINS, globals: ['__dirname'] },
+  '@zeltjs/cli/config': { nodeBuiltins: ALL_NODE_BUILTINS },
+  '@zeltjs/core': { nodeBuiltins: ['async_hooks'] },
+  '@zeltjs/core/internal-bridge/testing': { nodeBuiltins: ['async_hooks'] },
+  '@zeltjs/core/internal-bridge/errors': { nodeBuiltins: [] },
+  '@zeltjs/decorator-metadata/inspect': { nodeBuiltins: ALL_NODE_BUILTINS },
+  '@zeltjs/eslint-plugin': { nodeBuiltins: ALL_NODE_BUILTINS },
+  '@zeltjs/graphql/codegen': { nodeBuiltins: ALL_NODE_BUILTINS },
+  '@zeltjs/hono-client': { nodeBuiltins: ALL_NODE_BUILTINS },
+  '@zeltjs/openapi': { nodeBuiltins: ALL_NODE_BUILTINS },
+  '@zeltjs/testing/node': { nodeBuiltins: ALL_NODE_BUILTINS },
+};
+
+const NODE_BUILTINS = new Set([
+  'assert',
+  'async_hooks',
+  'buffer',
+  'child_process',
+  'cluster',
+  'console',
+  'crypto',
+  'diagnostics_channel',
+  'dns',
+  'events',
+  'fs',
+  'http',
+  'http2',
+  'https',
+  'module',
+  'net',
+  'os',
+  'path',
+  'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  'readline',
+  'repl',
+  'stream',
+  'string_decoder',
+  'timers',
+  'tls',
+  'tty',
+  'url',
+  'util',
+  'v8',
+  'vm',
+  'worker_threads',
+  'zlib',
+]);
+
+const IMPORT_EXPORT_RE = /\b(?:import|export)\s+(?:[^'"()]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+const DYNAMIC_IMPORT_RE = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+const REQUIRE_RE = /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+const IMPORT_META_RE = /\bimport\.meta\.(dirname|filename|path)\b/g;
+const NODE_GLOBAL_RE = /\b(__dirname|__filename)\b/g;
+
+const toPosix = (value) => value.split(path.sep).join('/');
+
+const normalizeNodeBuiltin = (specifier) => {
+  const withoutPrefix = specifier.startsWith('node:') ? specifier.slice('node:'.length) : specifier;
+  const root = withoutPrefix.split('/')[0];
+  return NODE_BUILTINS.has(root) ? root : undefined;
+};
+
+const readJson = async (file) => JSON.parse(await readFile(file, 'utf8'));
+
+const publicSpecifier = (packageName, exportKey) =>
+  exportKey === '.' ? packageName : `${packageName}/${exportKey.slice(2)}`;
+
+const collectExportTargets = (exportValue) => {
+  const targets = [];
+  const visit = (value, condition) => {
+    if (typeof value === 'string') {
+      if (/\.(?:js|mjs|cjs)$/.test(value)) targets.push({ condition, target: value });
+      return;
+    }
+    if (!value || typeof value !== 'object') return;
+    if (typeof value.default === 'string') visit(value.default, condition);
+    if (value.import) visit(value.import, 'import');
+    if (value.require) visit(value.require, 'require');
+  };
+  visit(exportValue, 'default');
+  return targets;
+};
+
+const resolveRelativeModule = (fromFile, specifier) => {
+  if (!specifier.startsWith('.')) return undefined;
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  const candidates = [
+    base,
+    `${base}.js`,
+    `${base}.mjs`,
+    `${base}.cjs`,
+    path.join(base, 'index.js'),
+    path.join(base, 'index.mjs'),
+    path.join(base, 'index.cjs'),
+  ];
+  return candidates.find((candidate) => fileSet.has(path.resolve(candidate)));
+};
+
+const findSpecifiers = (source) => {
+  const specifiers = [];
+  for (const re of [IMPORT_EXPORT_RE, DYNAMIC_IMPORT_RE, REQUIRE_RE]) {
+    re.lastIndex = 0;
+    for (const match of source.matchAll(re)) {
+      if (match[1]) specifiers.push(match[1]);
+    }
+  }
+  return specifiers;
+};
+
+const findViolations = (entrypoint, file, source) => {
+  const policy = ENTRYPOINT_POLICIES[entrypoint] ?? { nodeBuiltins: [] };
+  const allowedNodeBuiltins = policy.nodeBuiltins;
+  const allowedGlobals =
+    allowedNodeBuiltins === ALL_NODE_BUILTINS
+      ? ALL_NODE_BUILTINS
+      : new Set(policy.globals ?? []);
+  const violations = [];
+
+  for (const specifier of findSpecifiers(source)) {
+    const builtin = normalizeNodeBuiltin(specifier);
+    if (
+      builtin &&
+      allowedNodeBuiltins !== ALL_NODE_BUILTINS &&
+      !allowedNodeBuiltins.includes(builtin)
+    ) {
+      violations.push({
+        file,
+        kind: 'node-builtin',
+        value: specifier,
+        message: `Node builtin "${specifier}" is not allowed for ${entrypoint}.`,
+      });
+    }
+  }
+
+  for (const match of source.matchAll(IMPORT_META_RE)) {
+    violations.push({
+      file,
+      kind: 'import-meta-location',
+      value: `import.meta.${match[1]}`,
+      message: `Runtime location API import.meta.${match[1]} is not allowed for ${entrypoint}.`,
+    });
+  }
+
+  for (const match of source.matchAll(NODE_GLOBAL_RE)) {
+    if (allowedGlobals === ALL_NODE_BUILTINS || allowedGlobals.has(match[1])) continue;
+    violations.push({
+      file,
+      kind: 'node-location-global',
+      value: match[1],
+      message: `Node location global ${match[1]} is not allowed for ${entrypoint}.`,
+    });
+  }
+
+  return violations;
+};
+
+const traceReachableFiles = async (entryFile) => {
+  const reachable = new Set();
+  const pending = [path.resolve(entryFile)];
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (!file || reachable.has(file) || !fileSet.has(file)) continue;
+    reachable.add(file);
+    const source = await readFile(file, 'utf8');
+    for (const specifier of findSpecifiers(source)) {
+      const resolved = resolveRelativeModule(file, specifier);
+      if (resolved && !reachable.has(resolved)) pending.push(resolved);
+    }
+  }
+  return reachable;
+};
+
+const allDistFiles = await Array.fromAsync(glob('packages/*/dist/**/*.{js,mjs,cjs}'));
+const fileSet = new Set(allDistFiles.map((file) => path.resolve(file)));
+const packageFiles = await Array.fromAsync(glob('packages/*/package.json'));
+const allViolations = [];
+let checkedEntrypoints = 0;
+
+for (const packageFile of packageFiles.sort()) {
+  const packageJson = await readJson(packageFile);
+  const packageDir = path.dirname(packageFile);
+  for (const [exportKey, exportValue] of Object.entries(packageJson.exports ?? {})) {
+    const entrypoint = publicSpecifier(packageJson.name, exportKey);
+    const targets = collectExportTargets(exportValue);
+    for (const { condition, target } of targets) {
+      const entryFile = path.resolve(packageDir, target);
+      if (!fileSet.has(entryFile)) continue;
+      checkedEntrypoints++;
+      const reachableFiles = await traceReachableFiles(entryFile);
+      for (const file of reachableFiles) {
+        const source = await readFile(file, 'utf8');
+        for (const violation of findViolations(entrypoint, file, source)) {
+          allViolations.push({ entrypoint, condition, ...violation });
+        }
+      }
+    }
+  }
+}
+
+if (allViolations.length > 0) {
+  console.error('Dist runtime contract violations found:\n');
+  for (const violation of allViolations) {
+    console.error(`- ${violation.entrypoint} (${violation.condition})`);
+    console.error(`  ${toPosix(path.relative(process.cwd(), violation.file))}`);
+    console.error(`  ${violation.kind}: ${violation.value}`);
+    console.error(`  ${violation.message}\n`);
+  }
+  console.error(`${allViolations.length} violation(s) across ${checkedEntrypoints} export target(s).`);
+  process.exit(1);
+}
+
+console.log(`All ${checkedEntrypoints} export target(s) satisfy their dist runtime contracts.`);


### PR DESCRIPTION
## Summary
- `decorator-metadata` の位置解決ロジックを `inspect` 側へ移し、runtime 側はトレース収集に専念する構成へ整理
- `StackTrace` に call stack を保持する形へ変更し、定義時・呼び出し時の差分から wrapper フレームを判定するよう更新
- `verify-dist:runtime-contracts` を追加し、公開エントリポイントごとの Node builtin / runtime API 利用契約を dist 生成物に対して検証可能に追加
- `inspect` の公開エクスポートを整理し、`resolvePosition` と関連型を新しい配置から再公開

## Testing
- `packages/decorator-metadata/src/test/runtime.test.ts` を更新し、定義時/呼び出し時スタック差分による位置解決を検証
- dist runtime 契約検証スクリプトを追加し、公開エントリポイントの依存制約を静的にチェックできるようにした
- Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784374882&installation_id=133048706&pr_number=282&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F282&signature=cb767d50bd4951db4861ac8e54b003225c900b4d0caa30bff74d3a2d4ad04751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ランタイムコントラクトを検証する新規スクリプトを追加しました。

* **Refactor**
  * スタックトレースと位置解決機能を再構成しました。
  * デコレータメタデータモジュール内のモジュール構成を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->