### PR TITLE
Support feature namespaces

### DIFF
--- a/docs/superpowers/specs/2026-06-20-feature-namespace-design.md
+++ b/docs/superpowers/specs/2026-06-20-feature-namespace-design.md
@@ -174,6 +174,7 @@ Reserved namespace checks still apply to names that would overwrite app-level
 runtime methods or JavaScript object semantics, such as:
 
 - `features`
+- `createRuntime`
 - `get`
 - `hasFeature`
 - `getFeatureEntries`

--- a/docs/superpowers/specs/2026-06-20-feature-namespace-design.md
+++ b/docs/superpowers/specs/2026-06-20-feature-namespace-design.md
@@ -1,0 +1,200 @@
+# Feature Namespace Design
+
+## Context
+
+Zelt currently exposes feature capabilities by `Feature.key`. That key is also
+used to reject duplicate features in `createApp()`.
+
+This works for one instance per feature shape, but it blocks cases where the
+same feature module should be configured more than once. The motivating case is
+HTTP: an application may need a public API server and a private API server in
+the same runtime, each with its own controllers and listen port.
+
+The desired user API is:
+
+```ts
+const publicHttp = http({
+  controllers: [PublicController],
+});
+
+const privateHttp = http({
+  name: 'private' as const,
+  controllers: [PrivateController],
+});
+
+const app = createApp([publicHttp, privateHttp]);
+const nodeApp = await onNode(app);
+
+await nodeApp.http.listen({ port: 3000 });
+await nodeApp.private.listen({ port: 3001 });
+```
+
+## Decision
+
+`Feature.key` is the feature instance namespace exposed on the app object. It is
+not a feature kind.
+
+Feature kind checks continue to use feature classes, such as `HttpFeature`.
+`kind` is not introduced because the current design already uses `instanceof`
+for feature class checks and does not need a second discriminator.
+
+The core feature system supports multiple instances of the same feature class.
+Each instance must resolve to a unique namespace key across the whole app.
+
+## Namespace Rules
+
+Every feature instance has exactly one namespace key.
+
+Built-in features provide a default or fixed namespace:
+
+- `http()` resolves to `http`
+- `command()` uses the fixed namespace `commands`
+- `scheduler()` uses the fixed namespace `schedulers`
+
+Namespace uniqueness is global to the app. Feature class does not affect the
+collision rule.
+
+These are invalid:
+
+```ts
+createApp([
+  http({ controllers: [A] }),
+  http({ controllers: [B] }),
+]);
+```
+
+Both HTTP features resolve to the namespace `http`.
+
+```ts
+createApp([
+  http({ name: 'admin', controllers: [A] }),
+  customFeature({ key: 'admin' }),
+]);
+```
+
+Both features expose the namespace `admin`.
+
+## Core API
+
+Remove `getFeatureCapabilities()`.
+
+Single-capability lookup is ambiguous once the same feature class may have
+multiple instances. Keeping the old API would make it too easy for adapters and
+user code to accidentally operate on only one instance.
+
+Add `getFeatureEntries()`.
+
+```ts
+type FeatureEntry<TFeature extends ConfiguredFeature> = {
+  readonly key: TFeature['key'];
+  readonly feature: TFeature;
+  readonly capabilities: FeatureReadyCapabilities<TFeature>;
+};
+
+runtimeApp.getFeatureEntries(HttpFeature);
+```
+
+The method returns all entries whose feature instance matches the requested
+feature class. The existing `hasFeature(FeatureClass)` method can remain because
+it answers only whether at least one matching feature exists.
+
+`NamespacedCaps` and static blueprint aggregation continue to use `feature.key`
+as the object property name.
+
+## Built-In Feature Policy
+
+The core layer supports multi-instance feature modules.
+
+Each feature implementation decides whether to expose naming.
+
+Initial policy:
+
+- `http` supports `name`, because multiple HTTP surfaces in one process are a
+  known use case.
+- `command` remains a singleton feature with fixed namespace `commands`.
+- `scheduler` remains a singleton feature with fixed namespace `schedulers`.
+
+This keeps command and scheduler simple until a concrete multi-instance use case
+exists. They still fit the core model because their fixed key naturally causes a
+namespace collision if configured more than once.
+
+## Adapter API
+
+Node and Bun adapters should stop promoting HTTP server methods to the root app
+object.
+
+HTTP capabilities remain under their namespace, and adapters enrich each HTTP
+namespace with runtime-specific server methods.
+
+Node:
+
+```ts
+await nodeApp.http.listen({ port: 3000 });
+await nodeApp.private.listen({ port: 3001 });
+```
+
+Bun:
+
+```ts
+const server = bunApp.http.serve({ port: 3000 });
+```
+
+Remove root-level aliases such as:
+
+```ts
+nodeApp.listen(...)
+bunApp.serve(...)
+```
+
+This makes all feature capabilities consistently accessible only through their
+namespace:
+
+```ts
+nodeApp.http.listen(...)
+nodeApp.private.listen(...)
+nodeApp.commands.execCommand(...)
+nodeApp.schedulers.startScheduler(...)
+```
+
+## Lifecycle
+
+Each HTTP namespace can create its own server handle. Shutting down an app should
+stop all adapter-managed servers before shutting down the runtime.
+
+Individual server handles may still expose a server-specific close or shutdown
+operation, but app-level shutdown remains the operation that disposes the shared
+runtime.
+
+## Error Handling
+
+Duplicate namespace errors should describe the namespace collision, not a
+feature-kind collision.
+
+Reserved namespace checks still apply to names that would overwrite app-level
+runtime methods or JavaScript object semantics, such as:
+
+- `features`
+- `get`
+- `hasFeature`
+- `getFeatureEntries`
+- `shutdown`
+- `__proto__`
+- `constructor`
+- `prototype`
+
+## Testing
+
+Tests should cover:
+
+- Two HTTP features with distinct names expose distinct app namespaces.
+- Two unnamed HTTP features fail because both resolve to `http`.
+- Different feature classes with the same namespace fail.
+- `getFeatureEntries(HttpFeature)` returns all HTTP feature entries.
+- `getFeatureEntries(CommandFeature)` returns command entries.
+- `getFeatureCapabilities()` no longer exists in runtime and static app types.
+- Node adapter exposes `listen()` under each HTTP namespace.
+- Node adapter no longer exposes root `listen()`.
+- Bun adapter exposes `serve()` under each HTTP namespace.
+- Bun adapter no longer exposes root `serve()`.
+- Existing command and scheduler singletons still work through `commands` and
+  `schedulers`.

--- a/examples/drizzle-todo/src/node.ts
+++ b/examples/drizzle-todo/src/node.ts
@@ -4,5 +4,5 @@ import { app } from './app';
 
 const nodeApp = await onNode(app);
 
-const { address } = await nodeApp.listen(3000);
+const { address } = await nodeApp.http.listen(3000);
 console.log(`Server running at http://localhost:${address.port}`);

--- a/examples/hello/src/node.ts
+++ b/examples/hello/src/node.ts
@@ -4,5 +4,5 @@ import { app } from './app';
 
 const nodeApp = await onNode(app);
 
-const { address } = await nodeApp.listen(3000);
+const { address } = await nodeApp.http.listen(3000);
 console.log(`Server running at http://localhost:${address.port}`);

--- a/packages/adapter-bun/src/on-bun.test.ts
+++ b/packages/adapter-bun/src/on-bun.test.ts
@@ -80,6 +80,7 @@ class CustomHttpFeature extends HttpFeature<typeof HTTP_FEATURE_KEY> {
   }
 
   override readonly shutdown = async (): Promise<void> => {
+    // Test-only override: records that RuntimeApp delegates shutdown to HttpFeature subclasses.
     this.onShutdown();
   };
 }

--- a/packages/adapter-bun/src/on-bun.test.ts
+++ b/packages/adapter-bun/src/on-bun.test.ts
@@ -16,6 +16,7 @@ import { onBun } from './on-bun';
 
 const originalBun = globalThis.Bun;
 const servedFetches: ((request: Request) => Promise<Response>)[] = [];
+const servedServers: { readonly stop: ReturnType<typeof vi.fn> }[] = [];
 const serveMock = vi.fn(
   (options: {
     readonly fetch: (request: Request) => Promise<Response>;
@@ -23,11 +24,13 @@ const serveMock = vi.fn(
     readonly hostname?: string;
   }) => {
     servedFetches.push(options.fetch);
-    return {
+    const server = {
       hostname: options.hostname,
       port: options.port,
       stop: vi.fn(),
     };
+    servedServers.push(server);
+    return server;
   },
 );
 
@@ -40,6 +43,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   servedFetches.length = 0;
+  servedServers.length = 0;
   serveMock.mockClear();
 });
 
@@ -68,9 +72,16 @@ class FakeHttpLikeFeature extends Feature<
 }
 
 class CustomHttpFeature extends HttpFeature<typeof HTTP_FEATURE_KEY> {
-  constructor(opts: HttpModuleOptions<typeof HTTP_FEATURE_KEY>) {
+  constructor(
+    opts: HttpModuleOptions<typeof HTTP_FEATURE_KEY>,
+    private readonly onShutdown: () => void = () => {},
+  ) {
     super(opts, HTTP_FEATURE_KEY);
   }
+
+  override readonly shutdown = async (): Promise<void> => {
+    this.onShutdown();
+  };
 }
 
 describe('onBun return types', () => {
@@ -171,8 +182,9 @@ describe('onBun return types', () => {
       }
     }
 
+    const shutdown = vi.fn();
     const bunApp = await onBun(
-      createApp([new CustomHttpFeature({ controllers: [SubclassController] })]),
+      createApp([new CustomHttpFeature({ controllers: [SubclassController] }, shutdown)]),
     );
 
     expectTypeOf(bunApp).not.toHaveProperty('serve');
@@ -182,6 +194,7 @@ describe('onBun return types', () => {
     expect(bunApp.hasFeature(HttpFeature)).toBe(true);
 
     await bunApp.shutdown();
+    expect(shutdown).toHaveBeenCalledOnce();
   });
 
   it('adds serve for each named HTTP namespace', async () => {
@@ -227,5 +240,24 @@ describe('onBun return types', () => {
     await publicHandle.shutdown();
     await privateHandle.shutdown();
     await bunApp.shutdown();
+  });
+
+  it('app shutdown stops served servers through the HTTP feature shutdown hook', async () => {
+    @Controller('/')
+    class AppShutdownController {
+      @Get('/')
+      get() {
+        return {};
+      }
+    }
+
+    const bunApp = await onBun(createApp([http({ controllers: [AppShutdownController] })]));
+    bunApp.http.serve({ port: 3000 });
+    const server = servedServers[0];
+    if (!server) throw new Error('expected Bun.serve server');
+
+    await bunApp.shutdown();
+
+    expect(server.stop).toHaveBeenCalledOnce();
   });
 });

--- a/packages/adapter-bun/src/on-bun.test.ts
+++ b/packages/adapter-bun/src/on-bun.test.ts
@@ -1,3 +1,4 @@
+import type { HttpModuleOptions } from '@zeltjs/core';
 import {
   Command,
   Controller,
@@ -6,23 +7,22 @@ import {
   createApp,
   Feature,
   Get,
+  HTTP_FEATURE_KEY,
   HttpFeature,
   http,
 } from '@zeltjs/core';
 import { afterAll, beforeAll, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
-
-import type { ServerHandle } from './on-bun';
 import { onBun } from './on-bun';
 
 const originalBun = globalThis.Bun;
-let servedFetch: ((request: Request) => Promise<Response>) | undefined;
+const servedFetches: ((request: Request) => Promise<Response>)[] = [];
 const serveMock = vi.fn(
   (options: {
     readonly fetch: (request: Request) => Promise<Response>;
     readonly port?: number;
     readonly hostname?: string;
   }) => {
-    servedFetch = options.fetch;
+    servedFetches.push(options.fetch);
     return {
       hostname: options.hostname,
       port: options.port,
@@ -39,7 +39,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  servedFetch = undefined;
+  servedFetches.length = 0;
   serveMock.mockClear();
 });
 
@@ -67,7 +67,11 @@ class FakeHttpLikeFeature extends Feature<
   });
 }
 
-class CustomHttpFeature extends HttpFeature {}
+class CustomHttpFeature extends HttpFeature<typeof HTTP_FEATURE_KEY> {
+  constructor(opts: HttpModuleOptions<typeof HTTP_FEATURE_KEY>) {
+    super(opts, HTTP_FEATURE_KEY);
+  }
+}
 
 describe('onBun return types', () => {
   it('narrows adapter methods from configured features and keeps feature capabilities working', async () => {
@@ -82,18 +86,20 @@ describe('onBun return types', () => {
     const httpFeature = http({ controllers: [TestController] });
     const httpOnly = await onBun(createApp([httpFeature]));
 
-    expectTypeOf(httpOnly).toHaveProperty('serve');
+    expectTypeOf(httpOnly).not.toHaveProperty('serve');
+    expectTypeOf(httpOnly.http).toHaveProperty('serve');
     expectTypeOf(httpOnly).not.toHaveProperty('execCommand');
     expect(httpOnly.hasFeature(HttpFeature)).toBe(true);
 
     const directResponse = await httpOnly.http.fetch(new Request('http://localhost/'));
     await expect(directResponse.json()).resolves.toEqual({ ok: true });
 
-    const handle = httpOnly.serve({ hostname: '127.0.0.1', port: 4321 });
+    const handle = httpOnly.http.serve({ hostname: '127.0.0.1', port: 4321 });
     expect(serveMock).toHaveBeenCalledWith(
       expect.objectContaining({ hostname: '127.0.0.1', port: 4321 }),
     );
     expect(handle.address).toEqual({ hostname: '127.0.0.1', port: 4321 });
+    const servedFetch = servedFetches[0];
     if (!servedFetch) throw new Error('expected Bun.serve fetch');
     const servedResponse = await servedFetch(new Request('http://localhost/'));
     await expect(servedResponse.json()).resolves.toEqual({ ok: true });
@@ -124,7 +130,8 @@ describe('onBun return types', () => {
 
     const full = await onBun(createApp([httpFeature, commandFeature]));
 
-    expectTypeOf(full).toHaveProperty('serve');
+    expectTypeOf(full).not.toHaveProperty('serve');
+    expectTypeOf(full.http).toHaveProperty('serve');
     expectTypeOf(full).toHaveProperty('commands');
 
     const fullResult = await full.commands.execCommand(['test']);
@@ -133,16 +140,11 @@ describe('onBun return types', () => {
     await full.shutdown();
   });
 
-  it('keeps serve optional for widened HttpFeature arrays', async () => {
+  it('does not expose root serve for widened HttpFeature arrays', async () => {
     const maybeHttpFeatures: readonly HttpFeature[] = [];
     const maybeHttpApp = await onBun(createApp(maybeHttpFeatures));
 
-    expectTypeOf(maybeHttpApp)
-      .toHaveProperty('serve')
-      .toEqualTypeOf<
-        | ((options?: { readonly port?: number; readonly hostname?: string }) => ServerHandle)
-        | undefined
-      >();
+    expectTypeOf(maybeHttpApp).not.toHaveProperty('serve');
     expect('serve' in maybeHttpApp).toBe(false);
 
     await maybeHttpApp.shutdown();
@@ -154,6 +156,7 @@ describe('onBun return types', () => {
     expectTypeOf(bunApp).not.toHaveProperty('serve');
     expect('http' in bunApp).toBe(true);
     expect('serve' in bunApp).toBe(false);
+    expect('serve' in bunApp.http).toBe(false);
     expect(bunApp.hasFeature(HttpFeature)).toBe(false);
 
     await bunApp.shutdown();
@@ -172,10 +175,57 @@ describe('onBun return types', () => {
       createApp([new CustomHttpFeature({ controllers: [SubclassController] })]),
     );
 
-    expectTypeOf(bunApp).toHaveProperty('serve');
-    expect('serve' in bunApp).toBe(true);
+    expectTypeOf(bunApp).not.toHaveProperty('serve');
+    expectTypeOf(bunApp.http).toHaveProperty('serve');
+    expect('serve' in bunApp).toBe(false);
+    expect('serve' in bunApp.http).toBe(true);
     expect(bunApp.hasFeature(HttpFeature)).toBe(true);
 
+    await bunApp.shutdown();
+  });
+
+  it('adds serve for each named HTTP namespace', async () => {
+    @Controller('/')
+    class PublicController {
+      @Get('/public')
+      getPublic() {
+        return { scope: 'public' };
+      }
+    }
+
+    @Controller('/')
+    class PrivateController {
+      @Get('/private')
+      getPrivate() {
+        return { scope: 'private' };
+      }
+    }
+
+    const bunApp = await onBun(
+      createApp([
+        http({ controllers: [PublicController] }),
+        http({ name: 'private' as const, controllers: [PrivateController] }),
+      ]),
+    );
+
+    const publicHandle = bunApp.http.serve({ port: 3000 });
+    const privateHandle = bunApp.private.serve({ port: 3001 });
+
+    expect('serve' in bunApp).toBe(false);
+    expect(publicHandle.address.port).toBe(3000);
+    expect(privateHandle.address.port).toBe(3001);
+
+    const publicFetch = servedFetches[0];
+    const privateFetch = servedFetches[1];
+    if (!publicFetch || !privateFetch) throw new Error('expected Bun.serve fetches');
+
+    expect((await publicFetch(new Request('http://localhost/public'))).status).toBe(200);
+    expect((await publicFetch(new Request('http://localhost/private'))).status).toBe(404);
+    expect((await privateFetch(new Request('http://localhost/private'))).status).toBe(200);
+    expect((await privateFetch(new Request('http://localhost/public'))).status).toBe(404);
+
+    await publicHandle.shutdown();
+    await privateHandle.shutdown();
     await bunApp.shutdown();
   });
 });

--- a/packages/adapter-bun/src/on-bun.ts
+++ b/packages/adapter-bun/src/on-bun.ts
@@ -64,36 +64,9 @@ type BunAppForFeatures<F extends readonly ConfiguredFeature[]> = RuntimeApp<F> &
   EnvironmentBunAppPart &
   BunNamespacedCapabilities<F>;
 
-type BunServer = ReturnType<typeof Bun.serve>;
-
-type ServerRegistry = {
-  readonly add: (server: BunServer) => void;
-  readonly close: (server: BunServer) => Promise<void>;
-  readonly closeAll: () => Promise<void>;
-};
-
-const createServerRegistry = (): ServerRegistry => {
-  const servers = new Set<BunServer>();
-
-  const close = async (server: BunServer): Promise<void> => {
-    if (!servers.delete(server)) return;
-    await server.stop();
-  };
-
-  return {
-    add: (server) => {
-      servers.add(server);
-    },
-    close,
-    closeAll: async () => {
-      await Promise.all([...servers].map((server) => close(server)));
-    },
-  };
-};
-
 const createServeForHttp = (
   appFetch: (request: Request) => Promise<Response>,
-  serverRegistry: ServerRegistry,
+  registerShutdown: (callback: () => Promise<void>) => () => Promise<void>,
 ): ((options?: ServeOptions) => ServerHandle) => {
   return (options?: ServeOptions): ServerHandle => {
     const port = options?.port ?? 3000;
@@ -104,11 +77,9 @@ const createServeForHttp = (
       port,
       hostname,
     });
-    serverRegistry.add(server);
-
-    const shutdown = async (): Promise<void> => {
-      await serverRegistry.close(server);
-    };
+    const shutdown = registerShutdown(async () => {
+      await server.stop();
+    });
 
     return {
       address: { port: server.port ?? port, hostname: server.hostname ?? hostname },
@@ -123,7 +94,6 @@ const createBunApp = (
   readyApp: RuntimeApp<readonly ConfiguredFeature[]>,
   shutdown: () => Promise<void>,
   args: readonly string[],
-  serverRegistry: ServerRegistry,
 ): BunApp => {
   const base: RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentBunAppPart = {
     ...readyApp,
@@ -137,7 +107,9 @@ const createBunApp = (
     Object.defineProperty(bunApp, entry.key, {
       value: {
         ...entry.capabilities,
-        serve: createServeForHttp(entry.capabilities.fetch, serverRegistry),
+        serve: createServeForHttp(entry.capabilities.fetch, (callback) =>
+          entry.feature.registerShutdown(callback),
+        ),
       },
       configurable: true,
       enumerable: true,
@@ -163,8 +135,6 @@ export async function onBun<const F extends readonly ConfiguredFeature[]>(
   });
 
   const cliConfig = await readyApp.get(BunCliConfig);
-  const runtimeShutdown = readyApp.shutdown;
-  const serverRegistry = createServerRegistry();
 
   let shuttingDown = false;
   const detachSignals = (): void => {
@@ -176,8 +146,7 @@ export async function onBun<const F extends readonly ConfiguredFeature[]>(
     if (shuttingDown) return;
     shuttingDown = true;
     try {
-      await serverRegistry.closeAll();
-      await runtimeShutdown();
+      await readyApp.shutdown();
     } finally {
       detachSignals();
     }
@@ -192,5 +161,5 @@ export async function onBun<const F extends readonly ConfiguredFeature[]>(
 
   const args = getArgs();
 
-  return createBunApp(readyApp, shutdown, args, serverRegistry);
+  return createBunApp(readyApp, shutdown, args);
 }

--- a/packages/adapter-bun/src/on-bun.ts
+++ b/packages/adapter-bun/src/on-bun.ts
@@ -1,4 +1,10 @@
-import type { CommandCapabilities, ConfiguredFeature, FeatureApp, RuntimeApp } from '@zeltjs/core';
+import type {
+  CommandCapabilities,
+  ConfiguredFeature,
+  FeatureApp,
+  FeatureReadyCapabilities,
+  RuntimeApp,
+} from '@zeltjs/core';
 import { HttpFeature } from '@zeltjs/core';
 
 import { BunCliConfig } from './bun-cli.config';
@@ -35,33 +41,59 @@ type HttpBunAppPart = {
   readonly serve: (options?: ServeOptions) => ServerHandle;
 };
 
-export type HttpBunApp = BunAppBase & RuntimeApp<readonly [HttpFeature]> & HttpBunAppPart;
+type BunFeatureCapabilities<TFeature extends ConfiguredFeature> =
+  FeatureReadyCapabilities<TFeature> &
+    (TFeature extends HttpFeature<string> ? HttpBunAppPart : unknown);
+
+type BunNamespacedCapabilities<F extends readonly ConfiguredFeature[]> = {
+  readonly [TFeature in F[number] as TFeature['key']]: BunFeatureCapabilities<TFeature>;
+};
+
+export type HttpBunApp = BunAppBase &
+  RuntimeApp<readonly [HttpFeature]> & {
+    readonly http: RuntimeApp<readonly [HttpFeature]>['http'] & HttpBunAppPart;
+  };
 
 export type CommandBunApp = BunAppBase & { readonly commands: CommandCapabilities };
 
 export type FullBunApp = HttpBunApp & CommandBunApp;
 
-export type BunApp = (RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentBunAppPart) &
-  Partial<HttpBunAppPart>;
-
-type HasFeatureClass<F extends readonly ConfiguredFeature[], TFeature extends ConfiguredFeature> =
-  Extract<F[number], TFeature> extends never ? false : true;
-
-type WithFeatureClass<
-  F extends readonly ConfiguredFeature[],
-  TFeature extends ConfiguredFeature,
-  TPart extends object,
-> = HasFeatureClass<F, TFeature> extends true ? TPart : unknown;
+export type BunApp = RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentBunAppPart;
 
 type BunAppForFeatures<F extends readonly ConfiguredFeature[]> = RuntimeApp<F> &
   EnvironmentBunAppPart &
-  (number extends F['length']
-    ? Partial<HttpBunAppPart>
-    : WithFeatureClass<F, HttpFeature, HttpBunAppPart>);
+  BunNamespacedCapabilities<F>;
+
+type BunServer = ReturnType<typeof Bun.serve>;
+
+type ServerRegistry = {
+  readonly add: (server: BunServer) => void;
+  readonly close: (server: BunServer) => Promise<void>;
+  readonly closeAll: () => Promise<void>;
+};
+
+const createServerRegistry = (): ServerRegistry => {
+  const servers = new Set<BunServer>();
+
+  const close = async (server: BunServer): Promise<void> => {
+    if (!servers.delete(server)) return;
+    await server.stop();
+  };
+
+  return {
+    add: (server) => {
+      servers.add(server);
+    },
+    close,
+    closeAll: async () => {
+      await Promise.all([...servers].map((server) => close(server)));
+    },
+  };
+};
 
 const createServeForHttp = (
   appFetch: (request: Request) => Promise<Response>,
-  appShutdown: () => Promise<void>,
+  serverRegistry: ServerRegistry,
 ): ((options?: ServeOptions) => ServerHandle) => {
   return (options?: ServeOptions): ServerHandle => {
     const port = options?.port ?? 3000;
@@ -72,10 +104,10 @@ const createServeForHttp = (
       port,
       hostname,
     });
+    serverRegistry.add(server);
 
     const shutdown = async (): Promise<void> => {
-      await server.stop();
-      await appShutdown();
+      await serverRegistry.close(server);
     };
 
     return {
@@ -91,6 +123,7 @@ const createBunApp = (
   readyApp: RuntimeApp<readonly ConfiguredFeature[]>,
   shutdown: () => Promise<void>,
   args: readonly string[],
+  serverRegistry: ServerRegistry,
 ): BunApp => {
   const base: RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentBunAppPart = {
     ...readyApp,
@@ -98,12 +131,20 @@ const createBunApp = (
     shutdown,
   };
 
-  const httpCaps = readyApp.getFeatureCapabilities(HttpFeature);
-  if (!httpCaps) return base;
-  return {
-    ...base,
-    serve: createServeForHttp(httpCaps.fetch, shutdown),
-  };
+  const bunApp: BunApp = { ...base };
+
+  for (const entry of readyApp.getFeatureEntries(HttpFeature)) {
+    Object.defineProperty(bunApp, entry.key, {
+      value: {
+        ...entry.capabilities,
+        serve: createServeForHttp(entry.capabilities.fetch, serverRegistry),
+      },
+      configurable: true,
+      enumerable: true,
+    });
+  }
+
+  return bunApp;
 };
 
 export function onBun<const F extends readonly ConfiguredFeature[]>(
@@ -123,6 +164,7 @@ export async function onBun<const F extends readonly ConfiguredFeature[]>(
 
   const cliConfig = await readyApp.get(BunCliConfig);
   const runtimeShutdown = readyApp.shutdown;
+  const serverRegistry = createServerRegistry();
 
   let shuttingDown = false;
   const detachSignals = (): void => {
@@ -134,6 +176,7 @@ export async function onBun<const F extends readonly ConfiguredFeature[]>(
     if (shuttingDown) return;
     shuttingDown = true;
     try {
+      await serverRegistry.closeAll();
       await runtimeShutdown();
     } finally {
       detachSignals();
@@ -149,5 +192,5 @@ export async function onBun<const F extends readonly ConfiguredFeature[]>(
 
   const args = getArgs();
 
-  return createBunApp(readyApp, shutdown, args);
+  return createBunApp(readyApp, shutdown, args, serverRegistry);
 }

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -80,6 +80,7 @@ class CustomHttpFeature extends HttpFeature<typeof HTTP_FEATURE_KEY> {
   }
 
   override readonly shutdown = async (): Promise<void> => {
+    // Test-only override: records that RuntimeApp delegates shutdown to HttpFeature subclasses.
     this.onShutdown();
   };
 }

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -1,4 +1,9 @@
-import type { CommandCapabilities, HttpCapabilities, SchedulerCapabilities } from '@zeltjs/core';
+import type {
+  CommandCapabilities,
+  HttpCapabilities,
+  HttpModuleOptions,
+  SchedulerCapabilities,
+} from '@zeltjs/core';
 import {
   args,
   Command,
@@ -10,6 +15,7 @@ import {
   EnvAdaptor,
   Feature,
   Get,
+  HTTP_FEATURE_KEY,
   HttpFeature,
   http,
   Scheduled,
@@ -32,15 +38,19 @@ import type { NodeApp, ServerHandle } from './on-node';
 import { onNode } from './on-node';
 import { ProcessEnvAdaptor } from './process-env.adaptor';
 
-type HttpNodeApp = NodeApp & { readonly http: HttpCapabilities } & {
+type HttpNodeCapabilities = HttpCapabilities & {
   readonly listen: (
     portOrOptions?: number | { readonly port?: number; readonly hostname?: string },
   ) => Promise<ServerHandle>;
 };
+type HttpNodeApp = NodeApp & { readonly http: HttpNodeCapabilities };
 type CommandNodeApp = NodeApp & { readonly commands: CommandCapabilities };
 type SchedulerNodeAppPart = { readonly schedulers: SchedulerCapabilities };
 
-const isHttpNodeApp = (app: NodeApp): app is HttpNodeApp => 'listen' in app;
+const isHttpNodeApp = (app: NodeApp): app is HttpNodeApp => {
+  const httpPart = app['http'];
+  return httpPart !== undefined && 'listen' in httpPart;
+};
 const isCommandNodeApp = (app: NodeApp): app is CommandNodeApp => 'commands' in app;
 const hasScheduler = (app: NodeApp): app is NodeApp & SchedulerNodeAppPart => 'schedulers' in app;
 
@@ -61,7 +71,11 @@ class FakeHttpLikeFeature extends Feature<
   });
 }
 
-class CustomHttpFeature extends HttpFeature {}
+class CustomHttpFeature extends HttpFeature<typeof HTTP_FEATURE_KEY> {
+  constructor(opts: HttpModuleOptions<typeof HTTP_FEATURE_KEY>) {
+    super(opts, HTTP_FEATURE_KEY);
+  }
+}
 
 describe('onNode return types', () => {
   it('narrows adapter methods from configured features and keeps feature capabilities working', async () => {
@@ -76,7 +90,8 @@ describe('onNode return types', () => {
     const httpFeature = http({ controllers: [ReturnTypeController] });
     const httpOnly = await onNode(createApp([httpFeature]));
 
-    expectTypeOf(httpOnly).toHaveProperty('listen');
+    expectTypeOf(httpOnly).not.toHaveProperty('listen');
+    expectTypeOf(httpOnly.http).toHaveProperty('listen');
     expectTypeOf(httpOnly).not.toHaveProperty('execCommand');
     expectTypeOf(httpOnly).not.toHaveProperty('startScheduler');
     expect(httpOnly.hasFeature(HttpFeature)).toBe(true);
@@ -132,7 +147,8 @@ describe('onNode return types', () => {
 
     const full = await onNode(createApp([httpFeature, commandFeature, schedulerFeature]));
 
-    expectTypeOf(full).toHaveProperty('listen');
+    expectTypeOf(full).not.toHaveProperty('listen');
+    expectTypeOf(full.http).toHaveProperty('listen');
     expectTypeOf(full).toHaveProperty('commands');
     expectTypeOf(full).toHaveProperty('schedulers');
 
@@ -145,18 +161,10 @@ describe('onNode return types', () => {
     await full.shutdown();
   });
 
-  it('keeps listen optional for widened HttpFeature arrays', async () => {
+  it('does not expose root listen for widened HttpFeature arrays', async () => {
     const maybeHttpFeatures: readonly HttpFeature[] = [];
     const maybeHttpApp = await onNode(createApp(maybeHttpFeatures));
 
-    expectTypeOf(maybeHttpApp)
-      .toHaveProperty('listen')
-      .toEqualTypeOf<
-        | ((
-            portOrOptions?: number | { readonly port?: number; readonly hostname?: string },
-          ) => Promise<ServerHandle>)
-        | undefined
-      >();
     expect('listen' in maybeHttpApp).toBe(false);
 
     await maybeHttpApp.shutdown();
@@ -168,6 +176,7 @@ describe('onNode return types', () => {
     expectTypeOf(nodeApp).not.toHaveProperty('listen');
     expect('http' in nodeApp).toBe(true);
     expect('listen' in nodeApp).toBe(false);
+    expect('listen' in nodeApp.http).toBe(false);
     expect(nodeApp.hasFeature(HttpFeature)).toBe(false);
 
     await nodeApp.shutdown();
@@ -186,8 +195,10 @@ describe('onNode return types', () => {
       createApp([new CustomHttpFeature({ controllers: [SubclassController] })]),
     );
 
-    expectTypeOf(nodeApp).toHaveProperty('listen');
-    expect('listen' in nodeApp).toBe(true);
+    expectTypeOf(nodeApp).not.toHaveProperty('listen');
+    expectTypeOf(nodeApp.http).toHaveProperty('listen');
+    expect('listen' in nodeApp).toBe(false);
+    expect('listen' in nodeApp.http).toBe(true);
     expect(nodeApp.hasFeature(HttpFeature)).toBe(true);
 
     await nodeApp.shutdown();
@@ -200,7 +211,7 @@ describe('onNode with HTTP', () => {
 
   afterEach(async () => {
     await handle?.shutdown();
-    if (!handle) await nodeApp?.shutdown();
+    await nodeApp?.shutdown();
     handle = undefined;
     nodeApp = undefined;
   });
@@ -219,7 +230,7 @@ describe('onNode with HTTP', () => {
 
     expect(isHttpNodeApp(nodeApp)).toBe(true);
     if (!isHttpNodeApp(nodeApp)) throw new Error('expected listen');
-    handle = await nodeApp.listen(0);
+    handle = await nodeApp.http.listen(0);
 
     expect(handle.address.port).toBeGreaterThan(0);
     expect(handle.shutdown).toBeTypeOf('function');
@@ -242,11 +253,60 @@ describe('onNode with HTTP', () => {
     nodeApp = await onNode(app);
 
     if (!isHttpNodeApp(nodeApp)) throw new Error('expected listen');
-    handle = await nodeApp.listen(0);
+    handle = await nodeApp.http.listen(0);
 
     expect(handle.address.port).toBeGreaterThan(0);
     const res = await fetch(`http://localhost:${handle.address.port}/`);
     expect(res.status).toBe(200);
+  });
+
+  it('listens on each named HTTP namespace independently', async () => {
+    @Controller('/')
+    class PublicController {
+      @Get('/public')
+      getPublic() {
+        return { scope: 'public' };
+      }
+    }
+
+    @Controller('/')
+    class PrivateController {
+      @Get('/private')
+      getPrivate() {
+        return { scope: 'private' };
+      }
+    }
+
+    const app = createApp([
+      http({ controllers: [PublicController] }),
+      http({ name: 'private' as const, controllers: [PrivateController] }),
+    ]);
+    const namedNodeApp = await onNode(app);
+
+    const publicHandle = await namedNodeApp.http.listen(0);
+    const privateHandle = await namedNodeApp.private.listen(0);
+
+    try {
+      expect('listen' in namedNodeApp).toBe(false);
+
+      const publicOk = await fetch(`http://localhost:${publicHandle.address.port}/public`);
+      expect(publicOk.status).toBe(200);
+      await expect(publicOk.json()).resolves.toEqual({ scope: 'public' });
+
+      const publicMiss = await fetch(`http://localhost:${publicHandle.address.port}/private`);
+      expect(publicMiss.status).toBe(404);
+
+      const privateOk = await fetch(`http://localhost:${privateHandle.address.port}/private`);
+      expect(privateOk.status).toBe(200);
+      await expect(privateOk.json()).resolves.toEqual({ scope: 'private' });
+
+      const privateMiss = await fetch(`http://localhost:${privateHandle.address.port}/public`);
+      expect(privateMiss.status).toBe(404);
+    } finally {
+      await publicHandle.shutdown();
+      await privateHandle.shutdown();
+      await namedNodeApp.shutdown();
+    }
   });
 
   it('calls app.createRuntime() during onNode', async () => {
@@ -266,7 +326,7 @@ describe('onNode with HTTP', () => {
     expect(readySpy).toHaveBeenCalledOnce();
 
     if (!isHttpNodeApp(nodeApp)) throw new Error('expected listen');
-    handle = await nodeApp.listen(0);
+    handle = await nodeApp.http.listen(0);
     const res = await fetch(`http://localhost:${handle.address.port}/health/`);
     const body: { status: string } = await res.json();
     expect(body.status).toBe('ok');
@@ -297,7 +357,7 @@ describe('onNode with HTTP', () => {
     nodeApp = await onNode(app);
 
     if (!isHttpNodeApp(nodeApp)) throw new Error('expected listen');
-    handle = await nodeApp.listen(0);
+    handle = await nodeApp.http.listen(0);
 
     const res = await fetch(`http://localhost:${handle.address.port}/`);
     expect(res.status).toBe(200);
@@ -316,7 +376,7 @@ describe('onNode with HTTP', () => {
     nodeApp = await onNode(app);
 
     if (!isHttpNodeApp(nodeApp)) throw new Error('expected listen');
-    handle = await nodeApp.listen(0);
+    handle = await nodeApp.http.listen(0);
     const { port } = handle.address;
 
     await handle.shutdown();

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -72,9 +72,16 @@ class FakeHttpLikeFeature extends Feature<
 }
 
 class CustomHttpFeature extends HttpFeature<typeof HTTP_FEATURE_KEY> {
-  constructor(opts: HttpModuleOptions<typeof HTTP_FEATURE_KEY>) {
+  constructor(
+    opts: HttpModuleOptions<typeof HTTP_FEATURE_KEY>,
+    private readonly onShutdown: () => void = () => {},
+  ) {
     super(opts, HTTP_FEATURE_KEY);
   }
+
+  override readonly shutdown = async (): Promise<void> => {
+    this.onShutdown();
+  };
 }
 
 describe('onNode return types', () => {
@@ -191,8 +198,9 @@ describe('onNode return types', () => {
       }
     }
 
+    const shutdown = vi.fn();
     const nodeApp = await onNode(
-      createApp([new CustomHttpFeature({ controllers: [SubclassController] })]),
+      createApp([new CustomHttpFeature({ controllers: [SubclassController] }, shutdown)]),
     );
 
     expectTypeOf(nodeApp).not.toHaveProperty('listen');
@@ -202,6 +210,7 @@ describe('onNode return types', () => {
     expect(nodeApp.hasFeature(HttpFeature)).toBe(true);
 
     await nodeApp.shutdown();
+    expect(shutdown).toHaveBeenCalledOnce();
   });
 });
 
@@ -380,6 +389,29 @@ describe('onNode with HTTP', () => {
     const { port } = handle.address;
 
     await handle.shutdown();
+    handle = undefined;
+
+    await expect(fetch(`http://localhost:${port}/`)).rejects.toThrow();
+  });
+
+  it('app shutdown stops listening servers through the HTTP feature shutdown hook', async () => {
+    @Controller('/')
+    class AppShutdownController {
+      @Get('/')
+      get() {
+        return {};
+      }
+    }
+
+    const app = createApp([http({ controllers: [AppShutdownController] })]);
+    nodeApp = await onNode(app);
+
+    if (!isHttpNodeApp(nodeApp)) throw new Error('expected listen');
+    handle = await nodeApp.http.listen(0);
+    const { port } = handle.address;
+
+    await nodeApp.shutdown();
+    nodeApp = undefined;
     handle = undefined;
 
     await expect(fetch(`http://localhost:${port}/`)).rejects.toThrow();

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -1,6 +1,11 @@
 import type { ServerType } from '@hono/node-server';
 import { serve } from '@hono/node-server';
-import type { ConfiguredFeature, FeatureApp, RuntimeApp } from '@zeltjs/core';
+import type {
+  ConfiguredFeature,
+  FeatureApp,
+  FeatureReadyCapabilities,
+  RuntimeApp,
+} from '@zeltjs/core';
 import { HttpFeature } from '@zeltjs/core';
 
 import { NodeCliConfig } from './node-cli.config';
@@ -31,27 +36,53 @@ type HttpNodeAppPart = {
   readonly listen: (portOrOptions?: number | ListenOptions) => Promise<ServerHandle>;
 };
 
-export type NodeApp = (RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentNodeAppPart) &
-  Partial<HttpNodeAppPart>;
+type NodeFeatureCapabilities<TFeature extends ConfiguredFeature> =
+  FeatureReadyCapabilities<TFeature> &
+    (TFeature extends HttpFeature<string> ? HttpNodeAppPart : unknown);
 
-type HasFeatureClass<F extends readonly ConfiguredFeature[], TFeature extends ConfiguredFeature> =
-  Extract<F[number], TFeature> extends never ? false : true;
+type NodeNamespacedCapabilities<F extends readonly ConfiguredFeature[]> = {
+  readonly [TFeature in F[number] as TFeature['key']]: NodeFeatureCapabilities<TFeature>;
+};
 
-type WithFeatureClass<
-  F extends readonly ConfiguredFeature[],
-  TFeature extends ConfiguredFeature,
-  TPart extends object,
-> = HasFeatureClass<F, TFeature> extends true ? TPart : unknown;
+export type NodeApp = RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentNodeAppPart;
 
 type NodeAppForFeatures<F extends readonly ConfiguredFeature[]> = RuntimeApp<F> &
   EnvironmentNodeAppPart &
-  (number extends F['length']
-    ? Partial<HttpNodeAppPart>
-    : WithFeatureClass<F, HttpFeature, HttpNodeAppPart>);
+  NodeNamespacedCapabilities<F>;
+
+type ServerRegistry = {
+  readonly add: (server: ServerType) => void;
+  readonly close: (server: ServerType) => Promise<void>;
+  readonly closeAll: () => Promise<void>;
+};
+
+const closeServer = (server: ServerType): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+
+const createServerRegistry = (): ServerRegistry => {
+  const servers = new Set<ServerType>();
+
+  const close = async (server: ServerType): Promise<void> => {
+    if (!servers.delete(server)) return;
+    await closeServer(server);
+  };
+
+  return {
+    add: (server) => {
+      servers.add(server);
+    },
+    close,
+    closeAll: async () => {
+      await Promise.all([...servers].map((server) => close(server)));
+    },
+  };
+};
 
 const createListenForHttp = (
   appFetch: (request: Request) => Promise<Response>,
-  appShutdown: () => Promise<void>,
+  serverRegistry: ServerRegistry,
 ): ((portOrOptions?: number | ListenOptions) => Promise<ServerHandle>) => {
   return async (portOrOptions?: number | ListenOptions): Promise<ServerHandle> => {
     const listenOptions: ListenOptions =
@@ -66,14 +97,12 @@ const createListenForHttp = (
         resolve({ port: info.port, address: info.address }),
       );
     });
+    serverRegistry.add(server);
 
     const address = await serverReady;
 
     const shutdown = async (): Promise<void> => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((err) => (err ? reject(err) : resolve()));
-      });
-      await appShutdown();
+      await serverRegistry.close(server);
     };
 
     return { address, shutdown };
@@ -86,6 +115,7 @@ const createNodeApp = (
   readyApp: RuntimeApp<readonly ConfiguredFeature[]>,
   shutdown: () => Promise<void>,
   args: readonly string[],
+  serverRegistry: ServerRegistry,
 ): NodeApp => {
   const base: RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentNodeAppPart = {
     ...readyApp,
@@ -93,12 +123,20 @@ const createNodeApp = (
     shutdown,
   };
 
-  const httpCaps = readyApp.getFeatureCapabilities(HttpFeature);
-  if (!httpCaps) return base;
-  return {
-    ...base,
-    listen: createListenForHttp(httpCaps.fetch, shutdown),
-  };
+  const nodeApp: NodeApp = { ...base };
+
+  for (const entry of readyApp.getFeatureEntries(HttpFeature)) {
+    Object.defineProperty(nodeApp, entry.key, {
+      value: {
+        ...entry.capabilities,
+        listen: createListenForHttp(entry.capabilities.fetch, serverRegistry),
+      },
+      configurable: true,
+      enumerable: true,
+    });
+  }
+
+  return nodeApp;
 };
 
 export function onNode<const F extends readonly ConfiguredFeature[]>(
@@ -118,6 +156,7 @@ export async function onNode<const F extends readonly ConfiguredFeature[]>(
 
   const cliConfig = await readyApp.get(NodeCliConfig);
   const runtimeShutdown = readyApp.shutdown;
+  const serverRegistry = createServerRegistry();
 
   let shuttingDown = false;
   const detachSignals = (): void => {
@@ -129,6 +168,7 @@ export async function onNode<const F extends readonly ConfiguredFeature[]>(
     if (shuttingDown) return;
     shuttingDown = true;
     try {
+      await serverRegistry.closeAll();
       await runtimeShutdown();
     } finally {
       detachSignals();
@@ -144,5 +184,5 @@ export async function onNode<const F extends readonly ConfiguredFeature[]>(
 
   const args = getArgs();
 
-  return createNodeApp(readyApp, shutdown, args);
+  return createNodeApp(readyApp, shutdown, args, serverRegistry);
 }

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -50,39 +50,14 @@ type NodeAppForFeatures<F extends readonly ConfiguredFeature[]> = RuntimeApp<F> 
   EnvironmentNodeAppPart &
   NodeNamespacedCapabilities<F>;
 
-type ServerRegistry = {
-  readonly add: (server: ServerType) => void;
-  readonly close: (server: ServerType) => Promise<void>;
-  readonly closeAll: () => Promise<void>;
-};
-
 const closeServer = (server: ServerType): Promise<void> =>
   new Promise<void>((resolve, reject) => {
     server.close((err) => (err ? reject(err) : resolve()));
   });
 
-const createServerRegistry = (): ServerRegistry => {
-  const servers = new Set<ServerType>();
-
-  const close = async (server: ServerType): Promise<void> => {
-    if (!servers.delete(server)) return;
-    await closeServer(server);
-  };
-
-  return {
-    add: (server) => {
-      servers.add(server);
-    },
-    close,
-    closeAll: async () => {
-      await Promise.all([...servers].map((server) => close(server)));
-    },
-  };
-};
-
 const createListenForHttp = (
   appFetch: (request: Request) => Promise<Response>,
-  serverRegistry: ServerRegistry,
+  registerShutdown: (callback: () => Promise<void>) => () => Promise<void>,
 ): ((portOrOptions?: number | ListenOptions) => Promise<ServerHandle>) => {
   return async (portOrOptions?: number | ListenOptions): Promise<ServerHandle> => {
     const listenOptions: ListenOptions =
@@ -97,13 +72,9 @@ const createListenForHttp = (
         resolve({ port: info.port, address: info.address }),
       );
     });
-    serverRegistry.add(server);
+    const shutdown = registerShutdown(() => closeServer(server));
 
     const address = await serverReady;
-
-    const shutdown = async (): Promise<void> => {
-      await serverRegistry.close(server);
-    };
 
     return { address, shutdown };
   };
@@ -115,7 +86,6 @@ const createNodeApp = (
   readyApp: RuntimeApp<readonly ConfiguredFeature[]>,
   shutdown: () => Promise<void>,
   args: readonly string[],
-  serverRegistry: ServerRegistry,
 ): NodeApp => {
   const base: RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentNodeAppPart = {
     ...readyApp,
@@ -129,7 +99,9 @@ const createNodeApp = (
     Object.defineProperty(nodeApp, entry.key, {
       value: {
         ...entry.capabilities,
-        listen: createListenForHttp(entry.capabilities.fetch, serverRegistry),
+        listen: createListenForHttp(entry.capabilities.fetch, (callback) =>
+          entry.feature.registerShutdown(callback),
+        ),
       },
       configurable: true,
       enumerable: true,
@@ -155,8 +127,6 @@ export async function onNode<const F extends readonly ConfiguredFeature[]>(
   });
 
   const cliConfig = await readyApp.get(NodeCliConfig);
-  const runtimeShutdown = readyApp.shutdown;
-  const serverRegistry = createServerRegistry();
 
   let shuttingDown = false;
   const detachSignals = (): void => {
@@ -168,8 +138,7 @@ export async function onNode<const F extends readonly ConfiguredFeature[]>(
     if (shuttingDown) return;
     shuttingDown = true;
     try {
-      await serverRegistry.closeAll();
-      await runtimeShutdown();
+      await readyApp.shutdown();
     } finally {
       detachSignals();
     }
@@ -184,5 +153,5 @@ export async function onNode<const F extends readonly ConfiguredFeature[]>(
 
   const args = getArgs();
 
-  return createNodeApp(readyApp, shutdown, args, serverRegistry);
+  return createNodeApp(readyApp, shutdown, args);
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -115,7 +115,7 @@ const app = createApp({
 });
 
 const nodeApp = await onNode(app);
-const server = await nodeApp.listen({ port: 3000 });
+const server = await nodeApp.http.listen({ port: 3000 });
 console.log(`Server running at http://localhost:${server.address.port}`);
 ```
 
@@ -127,12 +127,12 @@ Same application code, different adapters:
 // Node.js
 import { onNode } from '@zeltjs/adapter-node';
 const nodeApp = await onNode(app);
-await nodeApp.listen({ port: 3000 });
+await nodeApp.http.listen({ port: 3000 });
 
 // Bun
 import { onBun } from '@zeltjs/adapter-bun';
 const bunApp = await onBun(app);
-bunApp.serve({ port: 3000 });
+bunApp.http.serve({ port: 3000 });
 
 // Cloudflare Workers
 import { onCloudflareWorkers } from '@zeltjs/adapter-cloudflare-workers';

--- a/packages/core/src/app/create-app.lib.test.ts
+++ b/packages/core/src/app/create-app.lib.test.ts
@@ -47,6 +47,22 @@ class OtherFeature extends Feature<'otherFeature', { readonly other: () => strin
   realize = () => ({ other: () => 'no' });
 }
 
+class NamedTypedFeature<TKey extends string> extends Feature<
+  TKey,
+  { readonly value: () => string }
+> {
+  constructor(
+    readonly key: TKey,
+    private readonly result: string,
+  ) {
+    super();
+  }
+
+  featureClasses = () => [];
+  blueprint = () => ({});
+  realize = () => ({ value: () => this.result });
+}
+
 const duplicateStaticCapabilities = vi.fn(() => ({}));
 
 class DuplicateA extends Feature<'dup', { readonly a: () => string }> {
@@ -167,20 +183,42 @@ describe('createApp', () => {
     const app = createApp([new TypedFeature()]);
 
     expect(app.hasFeature(TypedFeature)).toBe(true);
-
-    expect(app.getFeatureCapabilities(TypedFeature)).toBeUndefined();
+    expectTypeOf(app).not.toHaveProperty('getFeatureCapabilities');
+    expectTypeOf(app).not.toHaveProperty('getFeatureEntries');
   });
 
-  it('hasFeature narrows RuntimeApp by feature class', async () => {
+  it('returns runtime feature entries by feature class', async () => {
     const app = createApp([new TypedFeature()]);
     const readyApp = await app.createRuntime();
 
     expect(readyApp.hasFeature(TypedFeature)).toBe(true);
 
-    const caps = readyApp.getFeatureCapabilities(TypedFeature);
-    expect(caps).toBeDefined();
-    expectTypeOf(caps?.value).toEqualTypeOf<(() => string) | undefined>();
-    expect(caps?.value()).toBe('ok');
+    const entries = readyApp.getFeatureEntries(TypedFeature);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.key).toBe('typed');
+    expect(entries[0]?.feature).toBeInstanceOf(TypedFeature);
+    expect(entries[0]?.capabilities.value()).toBe('ok');
+    expectTypeOf(entries[0]?.capabilities.value).toEqualTypeOf<(() => string) | undefined>();
+
+    await readyApp.shutdown();
+  });
+
+  it('returns all matching runtime feature entries for a feature class', async () => {
+    const app = createApp([
+      new NamedTypedFeature('alpha', 'a'),
+      new NamedTypedFeature('beta', 'b'),
+      new OtherFeature(),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    const entries = readyApp.getFeatureEntries(NamedTypedFeature);
+
+    expect(entries.map((entry) => [entry.key, entry.capabilities.value()])).toEqual([
+      ['alpha', 'a'],
+      ['beta', 'b'],
+    ]);
+    expectTypeOf(readyApp.alpha.value).toEqualTypeOf<() => string>();
+    expectTypeOf(readyApp.beta.value).toEqualTypeOf<() => string>();
 
     await readyApp.shutdown();
   });
@@ -192,10 +230,10 @@ describe('createApp', () => {
     expect(readyApp.hasFeature(UserFeature)).toBe(true);
     expect(readyApp.hasFeature(OtherFeature)).toBe(false);
 
-    const caps = readyApp.getFeatureCapabilities(UserFeature);
-    expect(caps).toBeDefined();
-    expectTypeOf(caps?.run).toEqualTypeOf<(() => number) | undefined>();
-    expect(caps?.run()).toBe(123);
+    const entries = readyApp.getFeatureEntries(UserFeature);
+    expect(entries).toHaveLength(1);
+    expectTypeOf(entries[0]?.capabilities.run).toEqualTypeOf<(() => number) | undefined>();
+    expect(entries[0]?.capabilities.run()).toBe(123);
 
     await readyApp.shutdown();
   });
@@ -204,7 +242,7 @@ describe('createApp', () => {
     duplicateStaticCapabilities.mockClear();
 
     expect(() => createApp([new DuplicateA(), new DuplicateB()])).toThrow(
-      /Duplicate feature key: dup/,
+      /Duplicate feature namespace: dup/,
     );
     expect(duplicateStaticCapabilities).not.toHaveBeenCalled();
   });
@@ -213,7 +251,7 @@ describe('createApp', () => {
     reservedStaticCapabilities.mockClear();
 
     expect(() => createApp([new ReservedCreateRuntimeFeature()])).toThrow(
-      /Reserved feature key: createRuntime/,
+      /Reserved feature namespace: createRuntime/,
     );
     expect(reservedStaticCapabilities).not.toHaveBeenCalled();
   });
@@ -224,7 +262,7 @@ describe('createApp', () => {
     'prototype',
   ])('rejects feature key reserved by JavaScript object semantics: %s', (key) => {
     expect(() => createApp([createEmptyFeature(key)])).toThrow(
-      new RegExp(`Reserved feature key: ${key}`),
+      new RegExp(`Reserved feature namespace: ${key}`),
     );
   });
 });

--- a/packages/core/src/app/create-app.lib.test.ts
+++ b/packages/core/src/app/create-app.lib.test.ts
@@ -63,6 +63,22 @@ class ShutdownFeature<TKey extends string> extends Feature<TKey, Record<never, n
   };
 }
 
+class AsyncShutdownFeature<TKey extends string> extends Feature<TKey, Record<never, never>> {
+  constructor(
+    readonly key: TKey,
+    private readonly onShutdown: () => Promise<void>,
+  ) {
+    super();
+  }
+
+  featureClasses = () => [];
+  blueprint = () => ({});
+  realize = () => ({});
+  override readonly shutdown = async (): Promise<void> => {
+    await this.onShutdown();
+  };
+}
+
 class NamedTypedFeature<TKey extends string> extends Feature<
   TKey,
   { readonly value: () => string }
@@ -170,6 +186,20 @@ describe('createApp', () => {
 
     expect(shutdownA).toHaveBeenCalledOnce();
     expect(shutdownB).toHaveBeenCalledOnce();
+  });
+
+  it('runtime shutdown waits for every feature shutdown hook before reporting failures', async () => {
+    const delayedShutdown = vi.fn(() => new Promise<void>((resolve) => setTimeout(resolve, 10)));
+    const app = createApp([
+      new AsyncShutdownFeature('failing', async () => {
+        throw new Error('feature shutdown failed');
+      }),
+      new AsyncShutdownFeature('delayed', delayedShutdown),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    await expect(readyApp.shutdown()).rejects.toThrow(AggregateError);
+    expect(delayedShutdown).toHaveResolved();
   });
 
   it('createRuntime() accepts config overrides', async () => {

--- a/packages/core/src/app/create-app.lib.test.ts
+++ b/packages/core/src/app/create-app.lib.test.ts
@@ -47,6 +47,22 @@ class OtherFeature extends Feature<'otherFeature', { readonly other: () => strin
   realize = () => ({ other: () => 'no' });
 }
 
+class ShutdownFeature<TKey extends string> extends Feature<TKey, Record<never, never>> {
+  constructor(
+    readonly key: TKey,
+    private readonly onShutdown: () => void,
+  ) {
+    super();
+  }
+
+  featureClasses = () => [];
+  blueprint = () => ({});
+  realize = () => ({});
+  override readonly shutdown = async (): Promise<void> => {
+    this.onShutdown();
+  };
+}
+
 class NamedTypedFeature<TKey extends string> extends Feature<
   TKey,
   { readonly value: () => string }
@@ -137,6 +153,23 @@ describe('createApp', () => {
 
     await a.shutdown();
     await b.shutdown();
+  });
+
+  it('runtime shutdown calls each feature shutdown hook', async () => {
+    const shutdownA = vi.fn();
+    const shutdownB = vi.fn();
+    const app = createApp([
+      new ShutdownFeature('a', shutdownA),
+      createEmptyFeature('middle'),
+      new ShutdownFeature('b', shutdownB),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    await readyApp.shutdown();
+    await readyApp.shutdown();
+
+    expect(shutdownA).toHaveBeenCalledOnce();
+    expect(shutdownB).toHaveBeenCalledOnce();
   });
 
   it('createRuntime() accepts config overrides', async () => {

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -107,10 +107,10 @@ const warmupFeatureClasses = async (
 /** @throws {AggregateError | ZeltLifecycleStateError} */
 const shutdownFeatures = async (features: readonly ConfiguredFeature[]): Promise<void> => {
   const results = await Promise.allSettled(features.map((feature) => feature.shutdown?.()));
-  const errors = results.flatMap((result) => {
-    if (result.status === 'fulfilled') return [];
-    return [result.reason];
-  });
+  const errors: unknown[] = [];
+  for (const result of results) {
+    if (result.status === 'rejected') errors.push(result.reason);
+  }
   if (errors.length > 0) {
     throw new AggregateError(errors, 'One or more feature shutdown hooks failed');
   }

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -104,6 +104,10 @@ const warmupFeatureClasses = async (
   }
 };
 
+const shutdownFeatures = async (features: readonly ConfiguredFeature[]): Promise<void> => {
+  await Promise.all(features.map((feature) => feature.shutdown?.()));
+};
+
 const registerConfigs = (
   configRegistry: ConfigRegistry,
   configs: readonly ConfigClass<object>[] | undefined,
@@ -124,6 +128,56 @@ const hasFeature = (
   return features.some((feature) => feature instanceof featureClass);
 };
 
+/** @throws {ZeltLifecycleStateError | ZeltReadyFailedError} */
+const createRuntimeApp = async <const F extends readonly ConfiguredFeature[]>(
+  features: F,
+  baseConfigs: readonly ConfigClass<object>[] | undefined,
+  runtimeOptions: CreateRuntimeOptions | undefined,
+): Promise<RuntimeApp<F>> => {
+  const container = new Container();
+  const runtime = container.get(AppBootstrap);
+  const configRegistry = container.get(ConfigRegistry);
+
+  registerConfigs(configRegistry, baseConfigs, undefined);
+  registerConfigs(configRegistry, runtimeOptions?.configs, runtimeOptions?.fallbackConfigs);
+  runtime.applyRegisteredConfigs();
+
+  const readyResult = await runtime.ready();
+  const caps = await realizeNamespacedCapabilities(readyResult, features);
+
+  if (runtimeOptions?.warmup) {
+    await warmupFeatureClasses(readyResult, features);
+  }
+
+  let shuttingDown = false;
+  /** @throws {ZeltLifecycleStateError} */
+  const shutdown = async (): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    try {
+      await shutdownFeatures(features);
+    } finally {
+      await runtime.shutdown();
+    }
+  };
+
+  const readyApp: RuntimeApp<F> = {
+    ...caps.object,
+    features,
+    hasFeature: (featureClass) => hasFeature(features, featureClass),
+    getFeatureEntries: (featureClass) =>
+      unsafeGetKeyedValueEntriesForClass(features, caps.map, featureClass).map((entry) => ({
+        key: entry.key,
+        feature: entry.item,
+        capabilities: entry.value,
+      })),
+    get: readyResult.get,
+    shutdown,
+  };
+
+  return attachContainer(readyApp, container);
+};
+
 /** @throws {ZeltAppConfigurationError | ZeltDecoratorUsageError | ZeltReadyFailedError | ZeltLifecycleStateError} */
 export const createApp = <const F extends readonly ConfiguredFeature[]>(
   features: F,
@@ -136,40 +190,8 @@ export const createApp = <const F extends readonly ConfiguredFeature[]>(
 
   const app = {
     ...staticCaps,
-    createRuntime: async (runtimeOptions?: CreateRuntimeOptions): Promise<RuntimeApp<F>> => {
-      const container = new Container();
-
-      const runtime = container.get(AppBootstrap);
-      const configRegistry = container.get(ConfigRegistry);
-
-      registerConfigs(configRegistry, baseConfigs, undefined);
-      registerConfigs(configRegistry, runtimeOptions?.configs, runtimeOptions?.fallbackConfigs);
-      runtime.applyRegisteredConfigs();
-
-      const readyResult = await runtime.ready();
-
-      const caps = await realizeNamespacedCapabilities(readyResult, features);
-
-      if (runtimeOptions?.warmup) {
-        await warmupFeatureClasses(readyResult, features);
-      }
-
-      const readyApp: RuntimeApp<F> = {
-        ...caps.object,
-        features,
-        hasFeature: (featureClass) => hasFeature(features, featureClass),
-        getFeatureEntries: (featureClass) =>
-          unsafeGetKeyedValueEntriesForClass(features, caps.map, featureClass).map((entry) => ({
-            key: entry.key,
-            feature: entry.item,
-            capabilities: entry.value,
-          })),
-        get: readyResult.get,
-        shutdown: () => runtime.shutdown(),
-      };
-
-      return attachContainer(readyApp, container);
-    },
+    createRuntime: (runtimeOptions?: CreateRuntimeOptions): Promise<RuntimeApp<F>> =>
+      createRuntimeApp(features, baseConfigs, runtimeOptions),
   };
 
   return {

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -1,7 +1,7 @@
 import { Container } from '@needle-di/core';
 import type { KeyedValues } from '@zeltjs/unsafe-type-lib';
 import {
-  unsafeGetKeyedValueForClass,
+  unsafeGetKeyedValueEntriesForClass,
   unsafeKeyedValues,
   unsafeObjectFromNonEmptyKeyedValuesSync,
 } from '@zeltjs/unsafe-type-lib';
@@ -13,7 +13,7 @@ import { ConfigRegistry } from './config-registry.lib';
 import type {
   ConfiguredFeature,
   FeatureClass,
-  FeatureReadyCapabilities,
+  FeatureEntry,
   NamespacedCaps,
   ServiceResolver,
   StaticNamespacedCaps,
@@ -33,18 +33,15 @@ export type CreateRuntimeOptions = {
 export type App<F extends readonly ConfiguredFeature[]> = {
   readonly features: Readonly<F>;
   readonly hasFeature: (featureClass: FeatureClass) => boolean;
-  readonly getFeatureCapabilities: <TFeatureClass extends FeatureClass>(
-    featureClass: TFeatureClass,
-  ) => undefined;
   readonly createRuntime: (options?: CreateRuntimeOptions) => Promise<RuntimeApp<F>>;
 } & StaticNamespacedCaps<F>;
 
 export type RuntimeApp<F extends readonly ConfiguredFeature[]> = {
   readonly features: Readonly<F>;
   readonly hasFeature: (featureClass: FeatureClass) => boolean;
-  readonly getFeatureCapabilities: <TFeatureClass extends FeatureClass>(
+  readonly getFeatureEntries: <TFeatureClass extends FeatureClass>(
     featureClass: TFeatureClass,
-  ) => FeatureReadyCapabilities<InstanceType<TFeatureClass>> | undefined;
+  ) => readonly FeatureEntry<InstanceType<TFeatureClass>>[];
   readonly get: <T extends object>(cls: new (...args: never[]) => T) => Promise<T>;
   readonly shutdown: () => Promise<void>;
 } & NamespacedCaps<F>;
@@ -57,7 +54,7 @@ const reservedFeatureKeys = new Set([
   'constructor',
   'features',
   'get',
-  'getFeatureCapabilities',
+  'getFeatureEntries',
   'hasFeature',
   'prototype',
   'shutdown',
@@ -161,8 +158,12 @@ export const createApp = <const F extends readonly ConfiguredFeature[]>(
         ...caps.object,
         features,
         hasFeature: (featureClass) => hasFeature(features, featureClass),
-        getFeatureCapabilities: (featureClass) =>
-          unsafeGetKeyedValueForClass(features, caps.map, featureClass),
+        getFeatureEntries: (featureClass) =>
+          unsafeGetKeyedValueEntriesForClass(features, caps.map, featureClass).map((entry) => ({
+            key: entry.key,
+            feature: entry.item,
+            capabilities: entry.value,
+          })),
         get: readyResult.get,
         shutdown: () => runtime.shutdown(),
       };
@@ -175,6 +176,5 @@ export const createApp = <const F extends readonly ConfiguredFeature[]>(
     ...app,
     features,
     hasFeature: (featureClass) => hasFeature(features, featureClass),
-    getFeatureCapabilities: () => undefined,
   };
 };

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -104,8 +104,16 @@ const warmupFeatureClasses = async (
   }
 };
 
+/** @throws {AggregateError | ZeltLifecycleStateError} */
 const shutdownFeatures = async (features: readonly ConfiguredFeature[]): Promise<void> => {
-  await Promise.all(features.map((feature) => feature.shutdown?.()));
+  const results = await Promise.allSettled(features.map((feature) => feature.shutdown?.()));
+  const errors = results.flatMap((result) => {
+    if (result.status === 'fulfilled') return [];
+    return [result.reason];
+  });
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'One or more feature shutdown hooks failed');
+  }
 };
 
 const registerConfigs = (

--- a/packages/core/src/app/feature.types.test.ts
+++ b/packages/core/src/app/feature.types.test.ts
@@ -1,6 +1,11 @@
 import { describe, expectTypeOf, it } from 'vitest';
 
-import type { ConfiguredFeature, NamespacedCaps, StaticNamespacedCaps } from './index';
+import type {
+  ConfiguredFeature,
+  FeatureEntry,
+  NamespacedCaps,
+  StaticNamespacedCaps,
+} from './index';
 
 type MockHttpReadyCaps = { readonly fetch: (req: Request) => Promise<Response> };
 type MockHttpStaticCaps = { readonly getMetadata: () => object };
@@ -43,5 +48,14 @@ describe('Feature type utilities', () => {
     type MockSchedulerFeature = ConfiguredFeature<'scheduler', MockSchedulerCaps>;
     type Result = StaticNamespacedCaps<readonly [MockHttpFeature, MockSchedulerFeature]>;
     expectTypeOf<Result>().toEqualTypeOf<{ readonly http: MockHttpStaticCaps }>();
+  });
+
+  it('FeatureEntry preserves feature key and ready capabilities', () => {
+    type Result = FeatureEntry<MockHttpFeature>;
+    expectTypeOf<Result>().toEqualTypeOf<{
+      readonly key: MockHttpFeature['key'];
+      readonly feature: MockHttpFeature;
+      readonly capabilities: MockHttpReadyCaps;
+    }>();
   });
 });

--- a/packages/core/src/app/feature.types.ts
+++ b/packages/core/src/app/feature.types.ts
@@ -38,6 +38,12 @@ export type FeatureReadyCapabilities<TFeature extends ConfiguredFeature> = Keyed
   'realize'
 >;
 
+export type FeatureEntry<TFeature extends ConfiguredFeature> = {
+  readonly key: TFeature['key'];
+  readonly feature: TFeature;
+  readonly capabilities: FeatureReadyCapabilities<TFeature>;
+};
+
 export type FeatureCaps<TFeature extends ConfiguredFeature> = {
   readonly [TKey in TFeature['key']]: TFeature extends ConfiguredFeature<
     TFeature['key'],

--- a/packages/core/src/app/feature.types.ts
+++ b/packages/core/src/app/feature.types.ts
@@ -21,7 +21,7 @@ export abstract class Feature<
   abstract featureClasses(): readonly FeatureManagedClass[];
   abstract blueprint(): TStaticCaps;
   abstract realize(resolver: ServiceResolver): TReadyCaps | Promise<TReadyCaps>;
-  shutdown?(): void | Promise<void>;
+  declare shutdown?: () => void | Promise<void>;
 }
 
 export type ConfiguredFeature<

--- a/packages/core/src/app/feature.types.ts
+++ b/packages/core/src/app/feature.types.ts
@@ -21,6 +21,7 @@ export abstract class Feature<
   abstract featureClasses(): readonly FeatureManagedClass[];
   abstract blueprint(): TStaticCaps;
   abstract realize(resolver: ServiceResolver): TReadyCaps | Promise<TReadyCaps>;
+  shutdown?(): void | Promise<void>;
 }
 
 export type ConfiguredFeature<

--- a/packages/core/src/app/index.ts
+++ b/packages/core/src/app/index.ts
@@ -12,6 +12,7 @@ export type {
   ConfiguredFeature,
   FeatureCaps,
   FeatureClass,
+  FeatureEntry,
   FeatureManagedClass,
   FeatureReadyCapabilities,
   NamespacedCaps,

--- a/packages/core/src/features/http/http.feature.test.ts
+++ b/packages/core/src/features/http/http.feature.test.ts
@@ -1,5 +1,5 @@
 import { Container } from '@needle-di/core';
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { createApp } from '../../app';
 import { HttpFeature, http } from './http.feature';
@@ -104,6 +104,19 @@ describe('http feature', () => {
     expect((await readyApp.private.request('/public')).status).toBe(404);
 
     await readyApp.shutdown();
+  });
+
+  it('waits for every registered shutdown callback before reporting failures', async () => {
+    const feature = http({ controllers: [] });
+    const delayedShutdown = vi.fn(() => new Promise<void>((resolve) => setTimeout(resolve, 10)));
+
+    feature.registerShutdown(() => {
+      throw new Error('shutdown failed');
+    });
+    feature.registerShutdown(delayedShutdown);
+
+    await expect(feature.shutdown()).rejects.toThrow(AggregateError);
+    expect(delayedShutdown).toHaveResolved();
   });
 
   it('rejects duplicate resolved HTTP namespaces', () => {

--- a/packages/core/src/features/http/http.feature.test.ts
+++ b/packages/core/src/features/http/http.feature.test.ts
@@ -26,8 +26,15 @@ describe('http feature', () => {
     expect(feature.key).toBe('http');
   });
 
-  it('infers http() as HttpFeature', () => {
-    expectTypeOf(http({ controllers: [TestController] })).toEqualTypeOf<HttpFeature>();
+  it('infers unnamed http() as the default http namespace', () => {
+    expectTypeOf(http({ controllers: [TestController] })).toEqualTypeOf<HttpFeature<'http'>>();
+  });
+
+  it('uses the provided name as the feature namespace', () => {
+    const feature = http({ name: 'private' as const, controllers: [TestController] });
+
+    expect(feature.key).toBe('private');
+    expectTypeOf(feature).toEqualTypeOf<HttpFeature<'private'>>();
   });
 
   it('keeps feature methods callable when destructured', () => {
@@ -46,18 +53,63 @@ describe('http feature', () => {
     await readyApp.shutdown();
   });
 
-  it('hasFeature narrows RuntimeApp by HttpFeature', async () => {
+  it('returns HttpFeature entries by feature class', async () => {
     const app = createApp([http({ controllers: [TestController] })]);
     const readyApp = await app.createRuntime();
     expect(readyApp.hasFeature(HttpFeature)).toBe(true);
 
-    const caps = readyApp.getFeatureCapabilities(HttpFeature);
-    expect(caps).toBeDefined();
-    expectTypeOf(caps?.fetch).toEqualTypeOf<
+    const entries = readyApp.getFeatureEntries(HttpFeature);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.key).toBe('http');
+    expectTypeOf(entries[0]?.capabilities.fetch).toEqualTypeOf<
       ((request: Request) => Promise<Response>) | undefined
     >();
 
     await readyApp.shutdown();
+  });
+
+  it('supports multiple HttpFeature instances with distinct namespaces', async () => {
+    @Controller('/')
+    class PublicController {
+      @Get('/public')
+      getPublic() {
+        return { scope: 'public' };
+      }
+    }
+
+    @Controller('/')
+    class PrivateController {
+      @Get('/private')
+      getPrivate() {
+        return { scope: 'private' };
+      }
+    }
+
+    const app = createApp([
+      http({ controllers: [PublicController] }),
+      http({ name: 'private' as const, controllers: [PrivateController] }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    expectTypeOf(readyApp.http.fetch).toEqualTypeOf<(request: Request) => Promise<Response>>();
+    expectTypeOf(readyApp.private.fetch).toEqualTypeOf<(request: Request) => Promise<Response>>();
+    expect(readyApp.getFeatureEntries(HttpFeature).map((entry) => entry.key)).toEqual([
+      'http',
+      'private',
+    ]);
+
+    expect((await readyApp.http.request('/public')).status).toBe(200);
+    expect((await readyApp.http.request('/private')).status).toBe(404);
+    expect((await readyApp.private.request('/private')).status).toBe(200);
+    expect((await readyApp.private.request('/public')).status).toBe(404);
+
+    await readyApp.shutdown();
+  });
+
+  it('rejects duplicate resolved HTTP namespaces', () => {
+    expect(() => createApp([http({ controllers: [] }), http({ controllers: [] })])).toThrow(
+      /Duplicate feature namespace: http/,
+    );
   });
 
   it('returns a ConfiguredFeature with key "http"', () => {

--- a/packages/core/src/features/http/http.feature.ts
+++ b/packages/core/src/features/http/http.feature.ts
@@ -79,8 +79,21 @@ export class HttpFeature<TName extends string = string>
     return registered;
   }
 
+  protected readonly shutdownHttpCallbacks = async (): Promise<void> => {
+    const results = await Promise.allSettled(
+      [...this.shutdownCallbacks].map((callback) => callback()),
+    );
+    const errors = results.flatMap((result) => {
+      if (result.status === 'fulfilled') return [];
+      return [result.reason];
+    });
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'One or more HTTP shutdown callbacks failed');
+    }
+  };
+
   override readonly shutdown = async (): Promise<void> => {
-    await Promise.all([...this.shutdownCallbacks].map((callback) => callback()));
+    await this.shutdownHttpCallbacks();
   };
 
   private collectMetadata(): HttpMetadata {

--- a/packages/core/src/features/http/http.feature.ts
+++ b/packages/core/src/features/http/http.feature.ts
@@ -15,6 +15,9 @@ import { collectRoutes } from './routing';
 
 export const HTTP_FEATURE_KEY = 'http' as const;
 
+type ShutdownCallback = () => void | Promise<void>;
+type RegisteredShutdown = () => Promise<void>;
+
 /** @throws {ZeltDecoratorUsageError | ZeltReadyFailedError | ZeltLifecycleStateError} */
 export class HttpFeature<TName extends string = string>
   extends Feature<TName, HttpMountableCapabilities, HttpStaticCapabilities>
@@ -25,6 +28,7 @@ export class HttpFeature<TName extends string = string>
   private readonly opts: HttpModuleOptions<string>;
   private readonly controllers: readonly ControllerClass[];
   private readonly children: readonly HttpMountableFeatureModule[];
+  private readonly shutdownCallbacks = new Set<RegisteredShutdown>();
 
   /** @throws {ZeltDecoratorUsageError} */
   constructor(opts: HttpModuleOptions<TName>, key: TName) {
@@ -64,6 +68,19 @@ export class HttpFeature<TName extends string = string>
     const rootRouter = await service.createLocalRouter({ controllers: [] });
     Reflect.apply(rootRouter.route, rootRouter, [this.path, local]);
     return this.toCapabilities(rootRouter);
+  };
+
+  registerShutdown(callback: ShutdownCallback): RegisteredShutdown {
+    const registered = async (): Promise<void> => {
+      if (!this.shutdownCallbacks.delete(registered)) return;
+      await callback();
+    };
+    this.shutdownCallbacks.add(registered);
+    return registered;
+  }
+
+  override readonly shutdown = async (): Promise<void> => {
+    await Promise.all([...this.shutdownCallbacks].map((callback) => callback()));
   };
 
   private collectMetadata(): HttpMetadata {

--- a/packages/core/src/features/http/http.feature.ts
+++ b/packages/core/src/features/http/http.feature.ts
@@ -83,10 +83,10 @@ export class HttpFeature<TName extends string = string>
     const results = await Promise.allSettled(
       [...this.shutdownCallbacks].map((callback) => callback()),
     );
-    const errors = results.flatMap((result) => {
-      if (result.status === 'fulfilled') return [];
-      return [result.reason];
-    });
+    const errors: unknown[] = [];
+    for (const result of results) {
+      if (result.status === 'rejected') errors.push(result.reason);
+    }
     if (errors.length > 0) {
       throw new AggregateError(errors, 'One or more HTTP shutdown callbacks failed');
     }

--- a/packages/core/src/features/http/http.feature.ts
+++ b/packages/core/src/features/http/http.feature.ts
@@ -16,18 +16,21 @@ import { collectRoutes } from './routing';
 export const HTTP_FEATURE_KEY = 'http' as const;
 
 /** @throws {ZeltDecoratorUsageError | ZeltReadyFailedError | ZeltLifecycleStateError} */
-export class HttpFeature
-  extends Feature<'http', HttpMountableCapabilities, HttpStaticCapabilities>
+export class HttpFeature<TName extends string = string>
+  extends Feature<TName, HttpMountableCapabilities, HttpStaticCapabilities>
   implements HttpMountableFeatureModule
 {
-  readonly key = HTTP_FEATURE_KEY;
+  readonly key: TName;
   readonly path: string;
+  private readonly opts: HttpModuleOptions<string>;
   private readonly controllers: readonly ControllerClass[];
   private readonly children: readonly HttpMountableFeatureModule[];
 
   /** @throws {ZeltDecoratorUsageError} */
-  constructor(private readonly opts: HttpModuleOptions) {
+  constructor(opts: HttpModuleOptions<TName>, key: TName) {
     super();
+    this.opts = opts;
+    this.key = key;
     this.path = opts.path ?? '/';
     this.controllers = opts.controllers ?? [];
     this.children = opts.children ?? [];
@@ -92,7 +95,16 @@ export class HttpFeature
   }
 }
 
-export const http = (opts: HttpModuleOptions): HttpFeature => new HttpFeature(opts);
+export function http(opts: Omit<HttpModuleOptions, 'name'>): HttpFeature<typeof HTTP_FEATURE_KEY>;
+export function http<const TName extends string>(
+  opts: HttpModuleOptions<TName> & { readonly name: TName },
+): HttpFeature<TName>;
+export function http<const TName extends string>(
+  opts: HttpModuleOptions<TName>,
+): HttpFeature<TName | typeof HTTP_FEATURE_KEY> {
+  const key = opts.name ?? HTTP_FEATURE_KEY;
+  return new HttpFeature(opts, key);
+}
 export type {
   HttpCapabilities,
   HttpMountableCapabilities,

--- a/packages/core/src/features/http/http.types.ts
+++ b/packages/core/src/features/http/http.types.ts
@@ -33,7 +33,8 @@ export type HttpMountableFeatureModule = {
   readonly realize: (resolver: ServiceResolver) => Promise<HttpMountableCapabilities>;
 };
 
-export type HttpModuleOptions = {
+export type HttpModuleOptions<TName extends string = 'http'> = {
+  readonly name?: TName;
   readonly path?: string;
   readonly controllers?: readonly ControllerClass[];
   readonly middlewares?: readonly MiddlewareInput[];
@@ -43,5 +44,5 @@ export type HttpModuleOptions = {
 
 export type HttpCapabilities = Pick<HttpMountableCapabilities, 'fetch' | 'request'>;
 
-export type HttpChildOptions = HttpModuleOptions;
-export type HttpOptions = HttpModuleOptions;
+export type HttpChildOptions = HttpModuleOptions<string>;
+export type HttpOptions = HttpModuleOptions<string>;

--- a/packages/core/src/features/scheduler/scheduler-runner.lib.test.ts
+++ b/packages/core/src/features/scheduler/scheduler-runner.lib.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { RuntimeApp } from '../../app';
 import { createApp } from '../../app';
 import { http } from '../http/http.feature';
 import { Controller } from '../http/routing/controller.decorator';
 import { Get } from '../http/routing/http-method.decorator';
 import { Cron } from './schedule/cron.decorator';
 import { Scheduled } from './schedule/scheduled.decorator';
+import type { SchedulerCapabilities } from './scheduler.feature';
 import { scheduler } from './scheduler.feature';
 
 @Controller('/')
@@ -18,7 +18,7 @@ class NoopController {
 
 describe('SchedulerRunner', () => {
   let readyApp:
-    | RuntimeApp<readonly [ReturnType<typeof http>, ReturnType<typeof scheduler>]>
+    | { readonly schedulers: SchedulerCapabilities; readonly shutdown: () => Promise<void> }
     | undefined;
 
   afterEach(async () => {

--- a/packages/core/src/features/scheduler/scheduler.module.test.ts
+++ b/packages/core/src/features/scheduler/scheduler.module.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { RuntimeApp } from '../../app';
 import { createApp } from '../../app';
 import { http } from '../http/http.feature';
 import { Cron } from './schedule/cron.decorator';
 import { Scheduled } from './schedule/scheduled.decorator';
+import type { SchedulerCapabilities } from './scheduler.feature';
 import { scheduler } from './scheduler.feature';
 
 describe('createApp with schedulers', () => {
   let readyApp:
-    | RuntimeApp<readonly [ReturnType<typeof http>, ReturnType<typeof scheduler>]>
+    | { readonly schedulers: SchedulerCapabilities; readonly shutdown: () => Promise<void> }
     | undefined;
 
   afterEach(async () => {

--- a/packages/core/src/kernel/errors/error-definitions.lib.ts
+++ b/packages/core/src/kernel/errors/error-definitions.lib.ts
@@ -40,10 +40,10 @@ export const coreErrorDefinitions = {
       | { reason: 'reserved_feature_key'; details: string },
   ) => {
     if (ctx.reason === 'reserved_feature_key') {
-      return `Reserved feature key: ${ctx.details}`;
+      return `Reserved feature namespace: ${ctx.details}`;
     }
     if (ctx.reason === 'duplicate_feature_key') {
-      return `Duplicate feature key: ${ctx.details}`;
+      return `Duplicate feature namespace: ${ctx.details}`;
     }
     return `Duplicate command name: ${ctx.details}`;
   },

--- a/packages/core/src/kernel/errors/errors.test.ts
+++ b/packages/core/src/kernel/errors/errors.test.ts
@@ -129,7 +129,7 @@ describe('ZeltAppConfigurationError', () => {
       reason: 'duplicate_feature_key',
       details: 'http',
     });
-    expect(error.message).toBe('Duplicate feature key: http');
+    expect(error.message).toBe('Duplicate feature namespace: http');
   });
 
   it('formats reserved_feature_key reason correctly', () => {
@@ -137,7 +137,7 @@ describe('ZeltAppConfigurationError', () => {
       reason: 'reserved_feature_key',
       details: 'createRuntime',
     });
-    expect(error.message).toBe('Reserved feature key: createRuntime');
+    expect(error.message).toBe('Reserved feature namespace: createRuntime');
   });
 });
 

--- a/packages/unsafe-type-lib/src/index.ts
+++ b/packages/unsafe-type-lib/src/index.ts
@@ -10,11 +10,12 @@ export { UnsafeInjectionTokenWeakMap } from './injection-token-weak-map';
 export { unsafeTypedJsonParse } from './json';
 export {
   type KeyedMethodValue,
+  type KeyedValueEntry,
   type KeyedValues,
   type MapFromKeyedValues,
   type ObjectFromKeyedValues,
   type ObjectFromNonEmptyKeyedValues,
-  unsafeGetKeyedValueForClass,
+  unsafeGetKeyedValueEntriesForClass,
   unsafeKeyedValues,
   unsafeObjectFromKeyedValues,
   unsafeObjectFromKeyedValuesSync,

--- a/packages/unsafe-type-lib/src/keyed-values.ts
+++ b/packages/unsafe-type-lib/src/keyed-values.ts
@@ -25,6 +25,12 @@ export type KeyedValues<TItems extends readonly KeyedItem[], TMethod extends Pro
   readonly map: MapFromKeyedValues<TItems, TMethod>;
 };
 
+export type KeyedValueEntry<TItem extends KeyedItem, TMethod extends PropertyKey> = {
+  readonly key: TItem['key'];
+  readonly item: TItem;
+  readonly value: KeyedMethodValue<TItem, TMethod>;
+};
+
 type IsEmptyObject<T> = keyof T extends never ? true : false;
 
 export type ObjectFromNonEmptyKeyedValues<
@@ -123,7 +129,7 @@ export const unsafeKeyedValues = async <
   };
 };
 
-export const unsafeGetKeyedValueForClass = <
+export const unsafeGetKeyedValueEntriesForClass = <
   const TMethod extends PropertyKey,
   const TItems extends readonly KeyedItem[],
   const TClass extends abstract new (
@@ -133,8 +139,17 @@ export const unsafeGetKeyedValueForClass = <
   items: TItems,
   values: MapFromKeyedValues<TItems, TMethod>,
   itemClass: TClass,
-): KeyedMethodValue<InstanceType<TClass>, TMethod> | undefined => {
-  const item = items.find((candidate) => candidate instanceof itemClass);
-  if (!item) return undefined;
-  return values.get(item) as KeyedMethodValue<InstanceType<TClass>, TMethod> | undefined;
+): readonly KeyedValueEntry<InstanceType<TClass>, TMethod>[] => {
+  const entries: KeyedValueEntry<InstanceType<TClass>, TMethod>[] = [];
+
+  for (const item of items) {
+    if (!(item instanceof itemClass)) continue;
+    entries.push({
+      key: item.key,
+      item: item as InstanceType<TClass>,
+      value: values.get(item) as KeyedMethodValue<InstanceType<TClass>, TMethod>,
+    });
+  }
+
+  return entries;
 };

--- a/website/docs/getting-started/bun.mdx
+++ b/website/docs/getting-started/bun.mdx
@@ -75,7 +75,7 @@ const app = createApp([http({ controllers: [HelloController] })]);
 // ---cut---
 const bunApp = await onBun(app);
 
-const server = bunApp.serve({ port: 3000 });
+const server = bunApp.http.serve({ port: 3000 });
 console.log(`Server running at http://${server.address.hostname}:${server.address.port}`);
 ```
 
@@ -116,7 +116,7 @@ class HelloController {
 const app = createApp([http({ controllers: [HelloController] })]);
 const bunApp = await onBun(app);
 // ---cut---
-const server = bunApp.serve({
+const server = bunApp.http.serve({
   port: 8080,
   hostname: '127.0.0.1',
 });

--- a/website/docs/getting-started/node.mdx
+++ b/website/docs/getting-started/node.mdx
@@ -63,7 +63,7 @@ export const app = createApp([http({
 export default await onNode(app);
 ```
 
-The `onNode()` function prepares your app for the Node.js runtime, returning a `NodeApp` with `listen()`, `get()`, and `args` properties.
+The `onNode()` function prepares your app for the Node.js runtime, returning a `NodeApp` with `http.listen()`, `get()`, and `args` properties.
 
 ### Step 3: Start the Server
 
@@ -82,7 +82,7 @@ class HelloController {
 const app = createApp([http({ controllers: [HelloController] })]);
 const nodeApp = await onNode(app);
 // ---cut---
-const server = await nodeApp.listen({ port: 3000 });
+const server = await nodeApp.http.listen({ port: 3000 });
 console.log(`Server running at http://localhost:${server.address.port}`);
 ```
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -44,7 +44,7 @@ class HelloController {
 
 const app = createApp([http({ controllers: [HelloController] })]);
 const nodeApp = await onNode(app);
-await nodeApp.listen({ port: 3000 });
+await nodeApp.http.listen({ port: 3000 });
 ```
 
 See the [Getting Started](./getting-started) guide for a step-by-step walkthrough.

--- a/website/docs/kv-redis.md
+++ b/website/docs/kv-redis.md
@@ -167,7 +167,7 @@ import { RedisConfig } from '@zeltjs/redis';
 const app = createApp([http({ controllers: [AppController] })], { configs: [RedisConfig] });
 const nodeApp = await onNode(app);
 // ---cut---
-const handle = await nodeApp.listen({ port: 3000 });
+const handle = await nodeApp.http.listen({ port: 3000 });
 
 // Disconnects the server and runs lifecycle shutdown (Redis included)
 await handle.shutdown();

--- a/website/docs/scheduler.md
+++ b/website/docs/scheduler.md
@@ -264,7 +264,7 @@ import { createApp, Scheduled, Daily, http, scheduler } from '@zeltjs/core';
 const app = createApp([http({ controllers: [] }), scheduler([MyScheduler])]);
 // ---cut---
 const nodeApp = await onNode(app);
-const handle = await nodeApp.listen(3000);
+const handle = await nodeApp.http.listen(3000);
 
 // Start scheduled tasks
 await nodeApp.schedulers.startScheduler();

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/bun.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/bun.md
@@ -85,13 +85,13 @@ const app = createApp([http({ controllers: [HelloController] })]);
 // ---cut---
 const bunApp = await onBun(app);
 
-const server = bunApp.serve({ port: 3000 });
+const server = bunApp.http.serve({ port: 3000 });
 console.log(`Server running at http://${server.address.hostname}:${server.address.port}`);
 ```
 
 `onBun()` 関数は Bun ランタイム用にアプリを準備します。以下のオブジェクトを返します：
 
-- `serve(options?)` — `Bun.serve()` を使用して HTTP サーバーを起動
+- `http.serve(options?)` — `Bun.serve()` を使用して HTTP サーバーを起動
 - `shutdown()` — アプリケーションをグレースフルにシャットダウン
 - `get<T>(Class)` — DI コンテナからサービスを解決
 - `args` — コマンドライン引数 (`Bun.argv.slice(2)`)
@@ -110,7 +110,7 @@ bun run src/index.ts
 
 ## サーバーオプション
 
-`serve()` メソッドはポートとホスト名のオプションを受け付けます：
+`http.serve()` メソッドはポートとホスト名のオプションを受け付けます：
 
 ```typescript
 // @noErrors
@@ -126,7 +126,7 @@ class HelloController {
 const app = createApp([http({ controllers: [HelloController] })]);
 const bunApp = await onBun(app);
 // ---cut---
-const server = bunApp.serve({
+const server = bunApp.http.serve({
   port: 8080,
   hostname: '127.0.0.1',
 });

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/node.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/node.md
@@ -74,7 +74,7 @@ export const app = createApp([http({
 export default await onNode(app);
 ```
 
-The `onNode()` function prepares your app for the Node.js runtime, returning a `NodeApp` with `listen()`, `get()`, and `args` properties.
+The `onNode()` function prepares your app for the Node.js runtime, returning a `NodeApp` with `http.listen()`, `get()`, and `args` properties.
 
 ### Step 3: Start the Server
 
@@ -93,7 +93,7 @@ class HelloController {
 const app = createApp([http({ controllers: [HelloController] })]);
 const nodeApp = await onNode(app);
 // ---cut---
-const server = await nodeApp.listen({ port: 3000 });
+const server = await nodeApp.http.listen({ port: 3000 });
 console.log(`Server running at http://localhost:${server.address.port}`);
 ```
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/kv-redis.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/kv-redis.md
@@ -167,7 +167,7 @@ import { RedisConfig } from '@zeltjs/redis';
 const app = createApp([http({ controllers: [AppController] })], { configs: [RedisConfig] });
 const nodeApp = await onNode(app);
 // ---cut---
-const handle = await nodeApp.listen({ port: 3000 });
+const handle = await nodeApp.http.listen({ port: 3000 });
 
 // サーバを停止し、ライフサイクルのシャットダウン（Redis を含む）を実行
 await handle.shutdown();

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/scheduler.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/scheduler.md
@@ -264,7 +264,7 @@ import { createApp, Scheduled, Daily, http, scheduler } from '@zeltjs/core';
 const app = createApp([http({ controllers: [] }), scheduler([MyScheduler])]);
 // ---cut---
 const nodeApp = await onNode(app);
-const handle = await nodeApp.listen(3000);
+const handle = await nodeApp.http.listen(3000);
 
 // Start scheduled tasks
 await nodeApp.schedulers.startScheduler();

--- a/website/src/pages/_hero-code.mdx
+++ b/website/src/pages/_hero-code.mdx
@@ -35,7 +35,7 @@ const app = createApp([http({ controllers: [UserController] })]);
 
 // Node.js
 const node = await onNode(app);
-node.listen(3000);
+node.http.listen(3000);
 
 // Cloudflare Workers
 const workers = await onCloudflareWorkers(app);


### PR DESCRIPTION
## Summary

- Add feature namespaces so multiple HTTP features can be mounted under distinct app keys.
- Remove root HTTP adapter shortcuts in favor of namespaced APIs such as `nodeApp.http.listen()` and `nodeApp.private.listen()`.
- Route runtime shutdown through feature shutdown hooks so app shutdown does not need to know HTTP/server details.
- Update Node/Bun adapters, tests, examples, and docs for the namespaced API.

## Why

This lets applications expose separate public/private HTTP APIs on different ports while preserving feature-module boundaries. It also keeps shutdown ownership inside features instead of having adapters or the app special-case HTTP server internals.

## Validation

- `pnpm run precommit`
- `pnpm test` (`129 passed | 1 skipped`, `833 passed | 2 skipped`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784526331&installation_id=133048706&pr_number=284&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F284&signature=dc8564e8497bc2c9a977e1a78df9069b78714858be9e1a5a412797fe1c821a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * HTTP サーバ操作が名前空間で整理されました。Node.js では `nodeApp.http.listen()`、Bun では `bunApp.http.serve()` で起動します。
  * 複数の名前付き HTTP インスタンスに対応し、異なる設定で複数のサーバを並行実行できます。

* **ドキュメント**
  * API 使用例を更新し、新しい HTTP 名前空間構造に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->