### PR TITLE
feat: expose raw request body helper

### DIFF
--- a/packages/core/src/features/http/request-injection.lib.ts
+++ b/packages/core/src/features/http/request-injection.lib.ts
@@ -1,7 +1,13 @@
 import { createContextKey, getInternal, setInternal } from '../../kernel';
 import type { FunctionMiddleware } from './middleware/middleware.types';
 import { setHonoContext } from './request';
-import { parseRequestBody, setBody, setPathParams } from './request/injection';
+import {
+  parseRequestBody,
+  readRequestBody,
+  setBody,
+  setBodyRaw,
+  setPathParams,
+} from './request/injection';
 
 const REQUEST_INJECTED = createContextKey<true>('zelt:request-injected');
 
@@ -19,6 +25,7 @@ export const createRequestInjectionMiddleware = (): FunctionMiddleware => {
     }
     setInternal(REQUEST_INJECTED, true);
     setHonoContext(c);
+    setBodyRaw(await readRequestBody(c));
     setBody(await parseRequestBody(c));
     setPathParams(c.req.param());
     await next();

--- a/packages/core/src/features/http/request/injection/body.lib.test.ts
+++ b/packages/core/src/features/http/request/injection/body.lib.test.ts
@@ -4,7 +4,7 @@ import { http } from '../../http.feature';
 import { Controller } from '../../routing/controller.decorator';
 import { Post } from '../../routing/http-method.decorator';
 
-import { body } from './body.lib';
+import { body, bodyRaw } from './body.lib';
 
 describe('body', () => {
   it('provides json body synchronously as default parameter', async () => {
@@ -47,6 +47,31 @@ describe('body', () => {
       }),
     );
     expect(await res.json()).toEqual({ doubled: 42 });
+  });
+
+  it('provides raw json body synchronously', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/json')
+      json() {
+        return { parsed: body(), raw: bodyRaw() };
+      }
+    }
+
+    const raw = '{ "value": 21, "sig": "preserve whitespace" }';
+    const app = createApp([http({ controllers: [TestController] })]);
+    const readyApp = await app.createRuntime();
+    const res = await readyApp.http.fetch(
+      new Request('http://localhost/json', {
+        method: 'POST',
+        body: raw,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    expect(await res.json()).toEqual({
+      parsed: { sig: 'preserve whitespace', value: 21 },
+      raw,
+    });
   });
 
   it('provides form body synchronously as default parameter', async () => {

--- a/packages/core/src/features/http/request/injection/body.lib.test.ts
+++ b/packages/core/src/features/http/request/injection/body.lib.test.ts
@@ -97,6 +97,29 @@ describe('body', () => {
     expect(await res.json()).toEqual({ receivedName: 'John' });
   });
 
+  it('throws when raw multipart body is requested', async () => {
+    @Controller('/')
+    class TestController {
+      @Post('/form')
+      form() {
+        return { raw: bodyRaw() };
+      }
+    }
+
+    const app = createApp([http({ controllers: [TestController] })]);
+    const formData = new FormData();
+    formData.append('name', 'John');
+
+    const readyApp = await app.createRuntime();
+    const res = await readyApp.http.fetch(
+      new Request('http://localhost/form', {
+        method: 'POST',
+        body: formData,
+      }),
+    );
+    expect(res.status).toBe(415);
+  });
+
   it('provides text body synchronously as default parameter', async () => {
     @Controller('/')
     class TestController {

--- a/packages/core/src/features/http/request/injection/body.lib.test.ts
+++ b/packages/core/src/features/http/request/injection/body.lib.test.ts
@@ -54,7 +54,7 @@ describe('body', () => {
     class TestController {
       @Post('/json')
       json() {
-        return { parsed: body(), raw: bodyRaw() };
+        return { raw: bodyRaw(), parsed: body() };
       }
     }
 

--- a/packages/core/src/features/http/request/injection/body.lib.ts
+++ b/packages/core/src/features/http/request/injection/body.lib.ts
@@ -42,7 +42,6 @@ export const readRequestBody = async (c: Pick<Context, 'req'>): Promise<string |
 
   if (
     !contentType.includes('application/json') &&
-    !contentType.includes('multipart/form-data') &&
     !contentType.includes('application/x-www-form-urlencoded') &&
     !contentType.startsWith('text/')
   ) {
@@ -125,9 +124,13 @@ const getBodyRaw = (): RawBody => {
   return ctx;
 };
 
-/** @throws {ZeltContextNotAvailableError} */
-export const bodyRaw = (): string | undefined => {
-  return getBodyRaw().val;
+/** @throws {ZeltContextNotAvailableError | UnsupportedMediaTypeException} */
+export const bodyRaw = (): string => {
+  const raw = getBodyRaw().val;
+  if (raw === undefined) {
+    throw new UnsupportedMediaTypeException({ expected: 'raw', actual: getBody().type });
+  }
+  return raw;
 };
 
 /** @throws {ZeltContextNotAvailableError | UnsupportedMediaTypeException} */

--- a/packages/core/src/features/http/request/injection/body.lib.ts
+++ b/packages/core/src/features/http/request/injection/body.lib.ts
@@ -11,16 +11,24 @@ import { BadRequestException, UnsupportedMediaTypeException } from '../../http.e
 type FormBody = Record<string, string | File | (string | File)[]>;
 
 export type ParsedBody =
-  | { raw?: string; type: 'json'; val: unknown }
-  | { raw?: string; type: 'form'; val: FormBody }
-  | { raw?: string; type: 'text'; val: string }
-  | { raw?: string; type: 'none'; val: undefined };
+  | { type: 'json'; val: unknown }
+  | { type: 'form'; val: FormBody }
+  | { type: 'text'; val: string }
+  | { type: 'none'; val: undefined };
+
+type RawBody = { val: string | undefined };
 
 const BODY_CONTEXT = createContextKey<ParsedBody>('zelt:body');
+const BODY_RAW_CONTEXT = createContextKey<RawBody>('zelt:body-raw');
 
 /** @throws {ZeltContextNotAvailableError} */
 export const setBody = (body: ParsedBody): void => {
   setInternal(BODY_CONTEXT, body);
+};
+
+/** @throws {ZeltContextNotAvailableError} */
+export const setBodyRaw = (body: string | undefined): void => {
+  setInternal(BODY_RAW_CONTEXT, { val: body });
 };
 
 // Lets injection middlewares at different router levels avoid re-reading the
@@ -29,32 +37,40 @@ export const setBody = (body: ParsedBody): void => {
 export const hasParsedBody = (): boolean => getInternal(BODY_CONTEXT) !== undefined;
 
 /** @throws {BadRequestException} */
+export const readRequestBody = async (c: Pick<Context, 'req'>): Promise<string | undefined> => {
+  const contentType = c.req.header('content-type') ?? '';
+
+  if (
+    !contentType.includes('application/json') &&
+    !contentType.includes('multipart/form-data') &&
+    !contentType.includes('application/x-www-form-urlencoded') &&
+    !contentType.startsWith('text/')
+  ) {
+    return undefined;
+  }
+
+  return c.req.raw
+    .clone()
+    .text()
+    .catch((e: Error) => {
+      throw new BadRequestException({ reason: `Invalid body: ${e.message}` });
+    });
+};
+
+/** @throws {BadRequestException} */
 const parseJsonBody = async (c: Pick<Context, 'req'>): Promise<ParsedBody> => {
-  const raw = await c.req.text().catch((e: Error) => {
+  const val = await c.req.json<unknown>().catch((e: Error) => {
     throw new BadRequestException({ reason: `Invalid JSON: ${e.message}` });
   });
-  let val: unknown;
-  try {
-    val = JSON.parse(raw);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    throw new BadRequestException({ reason: `Invalid JSON: ${message}` });
-  }
-  return { raw, type: 'json', val };
+  return { type: 'json', val };
 };
 
 /** @throws {BadRequestException} */
 const parseFormBody = async (c: Pick<Context, 'req'>): Promise<ParsedBody> => {
-  const raw = await c.req.raw
-    .clone()
-    .text()
-    .catch((e: Error) => {
-      throw new BadRequestException({ reason: `Invalid form data: ${e.message}` });
-    });
   const val: FormBody = await c.req.parseBody({ all: true }).catch((e: Error) => {
     throw new BadRequestException({ reason: `Invalid form data: ${e.message}` });
   });
-  return { raw, type: 'form', val };
+  return { type: 'form', val };
 };
 
 /** @throws {BadRequestException} */
@@ -62,7 +78,7 @@ const parseTextBody = async (c: Pick<Context, 'req'>): Promise<ParsedBody> => {
   const raw = await c.req.text().catch((e: Error) => {
     throw new BadRequestException({ reason: `Invalid text body: ${e.message}` });
   });
-  return { raw, type: 'text', val: raw };
+  return { type: 'text', val: raw };
 };
 
 /** @throws {BadRequestException} */
@@ -99,8 +115,19 @@ const getBody = (): ParsedBody => {
 };
 
 /** @throws {ZeltContextNotAvailableError} */
+const getBodyRaw = (): RawBody => {
+  const ctx = getInternal(BODY_RAW_CONTEXT);
+  if (!ctx)
+    throw new ZeltContextNotAvailableError({
+      primitive: 'bodyRaw',
+      requiredContext: 'entry',
+    });
+  return ctx;
+};
+
+/** @throws {ZeltContextNotAvailableError} */
 export const bodyRaw = (): string | undefined => {
-  return getBody().raw;
+  return getBodyRaw().val;
 };
 
 /** @throws {ZeltContextNotAvailableError | UnsupportedMediaTypeException} */

--- a/packages/core/src/features/http/request/injection/body.lib.ts
+++ b/packages/core/src/features/http/request/injection/body.lib.ts
@@ -11,10 +11,10 @@ import { BadRequestException, UnsupportedMediaTypeException } from '../../http.e
 type FormBody = Record<string, string | File | (string | File)[]>;
 
 export type ParsedBody =
-  | { type: 'json'; val: unknown }
-  | { type: 'form'; val: FormBody }
-  | { type: 'text'; val: string }
-  | { type: 'none'; val: undefined };
+  | { raw?: string; type: 'json'; val: unknown }
+  | { raw?: string; type: 'form'; val: FormBody }
+  | { raw?: string; type: 'text'; val: string }
+  | { raw?: string; type: 'none'; val: undefined };
 
 const BODY_CONTEXT = createContextKey<ParsedBody>('zelt:body');
 
@@ -29,31 +29,59 @@ export const setBody = (body: ParsedBody): void => {
 export const hasParsedBody = (): boolean => getInternal(BODY_CONTEXT) !== undefined;
 
 /** @throws {BadRequestException} */
+const parseJsonBody = async (c: Pick<Context, 'req'>): Promise<ParsedBody> => {
+  const raw = await c.req.text().catch((e: Error) => {
+    throw new BadRequestException({ reason: `Invalid JSON: ${e.message}` });
+  });
+  let val: unknown;
+  try {
+    val = JSON.parse(raw);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new BadRequestException({ reason: `Invalid JSON: ${message}` });
+  }
+  return { raw, type: 'json', val };
+};
+
+/** @throws {BadRequestException} */
+const parseFormBody = async (c: Pick<Context, 'req'>): Promise<ParsedBody> => {
+  const raw = await c.req.raw
+    .clone()
+    .text()
+    .catch((e: Error) => {
+      throw new BadRequestException({ reason: `Invalid form data: ${e.message}` });
+    });
+  const val: FormBody = await c.req.parseBody({ all: true }).catch((e: Error) => {
+    throw new BadRequestException({ reason: `Invalid form data: ${e.message}` });
+  });
+  return { raw, type: 'form', val };
+};
+
+/** @throws {BadRequestException} */
+const parseTextBody = async (c: Pick<Context, 'req'>): Promise<ParsedBody> => {
+  const raw = await c.req.text().catch((e: Error) => {
+    throw new BadRequestException({ reason: `Invalid text body: ${e.message}` });
+  });
+  return { raw, type: 'text', val: raw };
+};
+
+/** @throws {BadRequestException} */
 export const parseRequestBody = async (c: Pick<Context, 'req'>): Promise<ParsedBody> => {
   const contentType = c.req.header('content-type') ?? '';
 
   if (contentType.includes('application/json')) {
-    const val = await c.req.json<unknown>().catch((e: Error) => {
-      throw new BadRequestException({ reason: `Invalid JSON: ${e.message}` });
-    });
-    return { type: 'json', val };
+    return parseJsonBody(c);
   }
 
   if (
     contentType.includes('multipart/form-data') ||
     contentType.includes('application/x-www-form-urlencoded')
   ) {
-    const val: FormBody = await c.req.parseBody({ all: true }).catch((e: Error) => {
-      throw new BadRequestException({ reason: `Invalid form data: ${e.message}` });
-    });
-    return { type: 'form', val };
+    return parseFormBody(c);
   }
 
   if (contentType.startsWith('text/')) {
-    const val = await c.req.text().catch((e: Error) => {
-      throw new BadRequestException({ reason: `Invalid text body: ${e.message}` });
-    });
-    return { type: 'text', val };
+    return parseTextBody(c);
   }
 
   return { type: 'none', val: undefined };
@@ -68,6 +96,11 @@ const getBody = (): ParsedBody => {
       requiredContext: 'entry',
     });
   return ctx;
+};
+
+/** @throws {ZeltContextNotAvailableError} */
+export const bodyRaw = (): string | undefined => {
+  return getBody().raw;
 };
 
 /** @throws {ZeltContextNotAvailableError | UnsupportedMediaTypeException} */

--- a/packages/core/src/features/http/request/injection/index.ts
+++ b/packages/core/src/features/http/request/injection/index.ts
@@ -1,5 +1,13 @@
 export type { ParsedBody } from './body.lib';
-export { body, bodyRaw, hasParsedBody, parseRequestBody, setBody } from './body.lib';
+export {
+  body,
+  bodyRaw,
+  hasParsedBody,
+  parseRequestBody,
+  readRequestBody,
+  setBody,
+  setBodyRaw,
+} from './body.lib';
 export { cookie } from './cookie.lib';
 export type { RequestContextSchema } from './get-context.lib';
 export { getContext, setContext } from './get-context.lib';

--- a/packages/core/src/features/http/request/injection/index.ts
+++ b/packages/core/src/features/http/request/injection/index.ts
@@ -1,5 +1,5 @@
 export type { ParsedBody } from './body.lib';
-export { body, hasParsedBody, parseRequestBody, setBody } from './body.lib';
+export { body, bodyRaw, hasParsedBody, parseRequestBody, setBody } from './body.lib';
 export { cookie } from './cookie.lib';
 export type { RequestContextSchema } from './get-context.lib';
 export { getContext, setContext } from './get-context.lib';

--- a/packages/core/src/features/http/routing/route-builder.lib.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.ts
@@ -19,7 +19,14 @@ import type {
   MiddlewareInput,
 } from '../middleware/middleware.types';
 import { setHonoContext } from '../request';
-import { hasParsedBody, parseRequestBody, setBody, setPathParams } from '../request/injection';
+import {
+  hasParsedBody,
+  parseRequestBody,
+  readRequestBody,
+  setBody,
+  setBodyRaw,
+  setPathParams,
+} from '../request/injection';
 import { joinPath } from './path-utils.lib';
 import type { ControllerClass, HttpMethod } from './routing-metadata.lib';
 import {
@@ -165,6 +172,7 @@ const createInjectionMiddleware = (): FunctionMiddleware => {
     const run = async (): Promise<void> => {
       setHonoContext(c);
       if (!hasParsedBody()) {
+        setBodyRaw(await readRequestBody(c));
         setBody(await parseRequestBody(c));
       }
       setPathParams(c.req.param());

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,6 +127,7 @@ export {
 export type { RequestContextSchema } from './features/http/request/injection';
 export {
   body,
+  bodyRaw,
   cookie,
   getContext,
   header,


### PR DESCRIPTION
## Summary
- Add a synchronous bodyRaw() request helper for raw payload access
- Preserve raw JSON text while keeping parsed body() behavior
- Export bodyRaw() from the public request helper surface

## Verification
- pnpm run precommit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784547905&installation_id=133048706&pr_number=285&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F285&signature=737f82369adbcc99da70a0d0e9b548f0f636de74dc2be73ac1dedfcb6cd4fa6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * リクエストボディの生の形式（パースされていない状態）にアクセスできるようになりました。パース済みのボディと生のボディの両方を同時に取得することが可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->