### PR TITLE
fix: export core public types

### DIFF
--- a/packages/core/src/features/http/request/index.ts
+++ b/packages/core/src/features/http/request/index.ts
@@ -1,4 +1,5 @@
 export { requestContext, setHonoContext } from './request-context.lib';
+export type { ValidationFailedContext } from './validated.exceptions';
 export {
   AsyncValidationUnsupportedException,
   ValidationFailedException,

--- a/packages/core/src/features/http/response/index.ts
+++ b/packages/core/src/features/http/response/index.ts
@@ -1,6 +1,7 @@
 export type {
   CookieOptions,
   ResponseBuilder,
+  TypedResponse,
   ZeltSSEMessage,
   ZeltSSEWriter,
   ZeltStreamWriter,

--- a/packages/core/src/features/http/response/response.lib.ts
+++ b/packages/core/src/features/http/response/response.lib.ts
@@ -3,6 +3,8 @@ import { deleteCookie, setCookie } from 'hono/cookie';
 import { stream, streamSSE, streamText } from 'hono/streaming';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
+export type { TypedResponse };
+
 export type ZeltStreamWriter = {
   readonly aborted: boolean;
   readonly closed: boolean;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export type { TypedResponse } from 'hono';
 export { HTTPException } from 'hono/http-exception';
 export type {
   App,
@@ -95,6 +96,8 @@ export type {
   ControllerClass,
   HttpChildOptions,
   HttpModuleOptions,
+  HttpMountableRouter,
+  HttpOptions,
 } from './features/http/http.types';
 // HTTP primitives
 export { currentRoles, currentUser, setUser } from './features/http/middleware/auth';
@@ -119,12 +122,16 @@ export { SecureHeadersConfig } from './features/http/middleware/secure-headers/s
 export { SecureHeadersMiddleware } from './features/http/middleware/secure-headers/secure-headers.middleware';
 export { SkipMiddleware } from './features/http/middleware/skip-middleware.decorator';
 export { UseMiddleware } from './features/http/middleware/use-middleware.decorator';
+export type { ValidationFailedContext } from './features/http/request';
 export {
   AsyncValidationUnsupportedException,
   requestContext,
   ValidationFailedException,
 } from './features/http/request';
-export type { RequestContextSchema } from './features/http/request/injection';
+export type {
+  ParsedBody,
+  RequestContextSchema,
+} from './features/http/request/injection';
 export {
   body,
   cookie,
@@ -155,7 +162,7 @@ export type {
   ZeltStreamWriter,
 } from './features/http/response';
 export { response } from './features/http/response';
-export type { ControllerRouteInfo, RouteInfo } from './features/http/routing';
+export type { ControllerRouteInfo, HttpMethod, RouteInfo } from './features/http/routing';
 export { getControllerMetadata } from './features/http/routing';
 export { Controller } from './features/http/routing/controller.decorator';
 export { Delete, Get, Patch, Post, Put } from './features/http/routing/http-method.decorator';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,3 @@
-export type { TypedResponse } from 'hono';
 export { HTTPException } from 'hono/http-exception';
 export type {
   App,
@@ -157,6 +156,7 @@ export type {
 export type {
   CookieOptions,
   ResponseBuilder,
+  TypedResponse,
   ZeltSSEMessage,
   ZeltSSEWriter,
   ZeltStreamWriter,


### PR DESCRIPTION
## Summary
- Export TypedResponse from the core package
- Export related user-facing HTTP request/routing option types from the root barrel

## Verification
- pnpm --filter @zeltjs/core typecheck
- pnpm precommit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784552378&installation_id=133048706&pr_number=286&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F286&signature=c4cfb880693ffdb349789fc8513699e8d230a7b80fb70156390aa8e742d9ce93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * HTTP機能に関連する型定義の公開APIを拡張し、利用可能な型を増やしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->