### PR TITLE
feat: add Cloudflare request bindings

### DIFF
--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -35,6 +35,7 @@
     "@zeltjs/core": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "catalog:",
     "@cloudflare/workers-types": "4.20250523.0"
   },
   "volta": {

--- a/packages/adapter-cloudflare-workers/src/cloudflare-bindings.service.ts
+++ b/packages/adapter-cloudflare-workers/src/cloudflare-bindings.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@zeltjs/core';
+
+import { getCloudflareRuntimeContext } from './cloudflare-runtime-context.lib';
+
+@Injectable()
+export class CloudflareBindingsService {
+  /** @throws {ZeltContextNotAvailableError} */
+  get<K extends keyof Env>(key: K): Env[K] {
+    return getCloudflareRuntimeContext().env[key];
+  }
+}
+
+export { CloudflareBindingsService as CloudflareBindings };

--- a/packages/adapter-cloudflare-workers/src/cloudflare-bindings.service.ts
+++ b/packages/adapter-cloudflare-workers/src/cloudflare-bindings.service.ts
@@ -9,5 +9,3 @@ export class CloudflareBindingsService {
     return getCloudflareRuntimeContext().env[key];
   }
 }
-
-export { CloudflareBindingsService as CloudflareBindings };

--- a/packages/adapter-cloudflare-workers/src/cloudflare-bindings.test.ts
+++ b/packages/adapter-cloudflare-workers/src/cloudflare-bindings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { CloudflareBindings } from './cloudflare-bindings.service';
+import { CloudflareBindings } from './index';
 
 declare global {
   interface Env {

--- a/packages/adapter-cloudflare-workers/src/cloudflare-bindings.test.ts
+++ b/packages/adapter-cloudflare-workers/src/cloudflare-bindings.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { CloudflareBindings } from './cloudflare-bindings.service';
+
+declare global {
+  interface Env {
+    DB: D1Database;
+    CACHE: KVNamespace;
+  }
+}
+
+describe('CloudflareBindings', () => {
+  it('throws outside request handling', () => {
+    const bindings = new CloudflareBindings();
+
+    expect(() => bindings.get('DB')).toThrow(/outside entry execution/);
+  });
+
+  it('types binding keys from generated Env', () => {
+    const assertTypes = (bindings: CloudflareBindings) => {
+      expectTypeOf(bindings.get('DB')).toEqualTypeOf<D1Database>();
+      expectTypeOf(bindings.get('CACHE')).toEqualTypeOf<KVNamespace>();
+      // @ts-expect-error NOT_FOUND is not generated from Wrangler bindings.
+      bindings.get('NOT_FOUND');
+    };
+
+    expect(assertTypes).toBeTypeOf('function');
+  });
+});

--- a/packages/adapter-cloudflare-workers/src/cloudflare-bindings.test.ts
+++ b/packages/adapter-cloudflare-workers/src/cloudflare-bindings.test.ts
@@ -13,7 +13,9 @@ describe('CloudflareBindings', () => {
   it('throws outside request handling', () => {
     const bindings = new CloudflareBindings();
 
-    expect(() => bindings.get('DB')).toThrow(/outside entry execution/);
+    expect(() => bindings.get('DB')).toThrow(
+      /CloudflareBindings\.get\(\) called outside entry execution/,
+    );
   });
 
   it('types binding keys from generated Env', () => {

--- a/packages/adapter-cloudflare-workers/src/cloudflare-runtime-context.lib.ts
+++ b/packages/adapter-cloudflare-workers/src/cloudflare-runtime-context.lib.ts
@@ -1,0 +1,30 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { ZeltContextNotAvailableError } from '@zeltjs/core';
+
+export type CloudflareRuntimeContext = {
+  readonly env: Env;
+  readonly ctx: ExecutionContext;
+};
+
+const storage = new AsyncLocalStorage<CloudflareRuntimeContext>();
+
+/** @throws {ZeltContextNotAvailableError} */
+export const getCloudflareRuntimeContext = (): CloudflareRuntimeContext => {
+  const context = storage.getStore();
+  if (!context) {
+    throw new ZeltContextNotAvailableError({
+      primitive: 'cloudflareBindings',
+      requiredContext: 'entry',
+    });
+  }
+  return context;
+};
+
+export const runWithCloudflareRuntimeContext = <T>(
+  context: CloudflareRuntimeContext,
+  fn: () => T,
+): T => storage.run(context, fn);
+
+declare global {
+  interface Env {}
+}

--- a/packages/adapter-cloudflare-workers/src/cloudflare-runtime-context.lib.ts
+++ b/packages/adapter-cloudflare-workers/src/cloudflare-runtime-context.lib.ts
@@ -13,7 +13,7 @@ export const getCloudflareRuntimeContext = (): CloudflareRuntimeContext => {
   const context = storage.getStore();
   if (!context) {
     throw new ZeltContextNotAvailableError({
-      primitive: 'cloudflareBindings',
+      primitive: 'CloudflareBindings.get',
       requiredContext: 'entry',
     });
   }

--- a/packages/adapter-cloudflare-workers/src/index.ts
+++ b/packages/adapter-cloudflare-workers/src/index.ts
@@ -1,4 +1,4 @@
-export { CloudflareBindings } from './cloudflare-bindings.service';
+export { CloudflareBindingsService as CloudflareBindings } from './cloudflare-bindings.service';
 export { CloudflareWorkersEnvAdaptor } from './cloudflare-workers-env.adaptor';
 export type { CloudflareWorkersApp, CloudflareWorkersOptions } from './on-cloudflare-workers';
 export { onCloudflareWorkers } from './on-cloudflare-workers';

--- a/packages/adapter-cloudflare-workers/src/index.ts
+++ b/packages/adapter-cloudflare-workers/src/index.ts
@@ -1,3 +1,4 @@
+export { CloudflareBindings } from './cloudflare-bindings.service';
 export { CloudflareWorkersEnvAdaptor } from './cloudflare-workers-env.adaptor';
 export type { CloudflareWorkersApp, CloudflareWorkersOptions } from './on-cloudflare-workers';
 export { onCloudflareWorkers } from './on-cloudflare-workers';

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
@@ -1,8 +1,7 @@
 import { Controller, createApp, EnvAdaptor, Get, http, inject } from '@zeltjs/core';
 import { describe, expect, it, vi } from 'vitest';
-
-import { CloudflareBindings } from './cloudflare-bindings.service';
 import { CloudflareWorkersEnvAdaptor } from './cloudflare-workers-env.adaptor';
+import { CloudflareBindings } from './index';
 import { onCloudflareWorkers } from './on-cloudflare-workers';
 
 declare global {

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.test.ts
@@ -1,8 +1,16 @@
-import { Controller, createApp, EnvAdaptor, Get, http } from '@zeltjs/core';
+import { Controller, createApp, EnvAdaptor, Get, http, inject } from '@zeltjs/core';
 import { describe, expect, it, vi } from 'vitest';
 
+import { CloudflareBindings } from './cloudflare-bindings.service';
 import { CloudflareWorkersEnvAdaptor } from './cloudflare-workers-env.adaptor';
 import { onCloudflareWorkers } from './on-cloudflare-workers';
+
+declare global {
+  interface Env {
+    DB: D1Database;
+    CACHE: KVNamespace;
+  }
+}
 
 @Controller('/hello')
 class HelloController {
@@ -11,6 +19,26 @@ class HelloController {
     return { message: 'hello from workers' };
   }
 }
+
+@Controller('/bindings')
+class BindingsController {
+  constructor(private readonly bindings = inject(CloudflareBindings)) {}
+
+  @Get('/db')
+  db() {
+    return { same: this.bindings.get('DB') === mockD1 };
+  }
+}
+
+const mockD1 = {
+  prepare: vi.fn(),
+} as unknown as D1Database;
+
+const mockCache = {
+  get: vi.fn(),
+} as unknown as KVNamespace;
+
+const createMockEnv = (): Env => ({ DB: mockD1, CACHE: mockCache });
 
 const createMockExecutionContext = () =>
   ({
@@ -35,7 +63,11 @@ describe('onCloudflareWorkers', () => {
     const workersApp = await onCloudflareWorkers(app);
     const ctx = createMockExecutionContext();
 
-    const res = await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    const res = await workersApp.fetch(
+      new Request('https://example.com/hello/'),
+      createMockEnv(),
+      ctx,
+    );
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ message: 'hello from workers' });
@@ -71,9 +103,9 @@ describe('onCloudflareWorkers', () => {
     const ctx = createMockExecutionContext();
 
     const workersApp = await onCloudflareWorkers(app);
-    await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
-    await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
-    await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    await workersApp.fetch(new Request('https://example.com/hello/'), createMockEnv(), ctx);
+    await workersApp.fetch(new Request('https://example.com/hello/'), createMockEnv(), ctx);
+    await workersApp.fetch(new Request('https://example.com/hello/'), createMockEnv(), ctx);
 
     expect(readySpy).toHaveBeenCalledTimes(1);
   });
@@ -83,7 +115,7 @@ describe('onCloudflareWorkers', () => {
     const workersApp = await onCloudflareWorkers(app);
     const ctx = createMockExecutionContext();
 
-    await workersApp.fetch(new Request('https://example.com/hello/'), {}, ctx);
+    await workersApp.fetch(new Request('https://example.com/hello/'), createMockEnv(), ctx);
 
     expect(ctx.waitUntil).toHaveBeenCalled();
   });
@@ -110,5 +142,20 @@ describe('onCloudflareWorkers', () => {
 
     const env = await workersApp.get(EnvAdaptor);
     expect(env.get).toBeTypeOf('function');
+  });
+
+  it('provides Cloudflare bindings through DI during request handling', async () => {
+    const app = createApp([http({ controllers: [BindingsController] })]);
+    const workersApp = await onCloudflareWorkers(app);
+    const ctx = createMockExecutionContext();
+
+    const res = await workersApp.fetch(
+      new Request('https://example.com/bindings/db'),
+      createMockEnv(),
+      ctx,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ same: true });
   });
 });

--- a/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.ts
+++ b/packages/adapter-cloudflare-workers/src/on-cloudflare-workers.ts
@@ -4,7 +4,7 @@ import type {
   HttpCapabilities,
   RuntimeApp,
 } from '@zeltjs/core';
-
+import { runWithCloudflareRuntimeContext } from './cloudflare-runtime-context.lib';
 import { CloudflareWorkersEnvAdaptor } from './cloudflare-workers-env.adaptor';
 
 export type CloudflareWorkersOptions = {
@@ -21,7 +21,7 @@ type HttpApp = {
 
 export type CloudflareWorkersApp = {
   readonly get: HttpRuntimeApp['get'];
-  readonly fetch: (request: Request, env: unknown, ctx: ExecutionContext) => Promise<Response>;
+  readonly fetch: (request: Request, env: Env, ctx: ExecutionContext) => Promise<Response>;
   readonly shutdown: () => Promise<void>;
 };
 
@@ -34,12 +34,10 @@ export const onCloudflareWorkers = async (
     warmup: options.warmup ?? false,
   });
 
-  const fetch = async (
-    request: Request,
-    _env: unknown,
-    ctx: ExecutionContext,
-  ): Promise<Response> => {
-    const response = readyApp.http.fetch(request);
+  const fetch = async (request: Request, env: Env, ctx: ExecutionContext): Promise<Response> => {
+    const response = runWithCloudflareRuntimeContext({ env, ctx }, () =>
+      readyApp.http.fetch(request),
+    );
     ctx.waitUntil(response.then(() => {}));
     return response;
   };

--- a/packages/adapter-cloudflare-workers/tsconfig.json
+++ b/packages/adapter-cloudflare-workers/tsconfig.json
@@ -10,7 +10,7 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "experimentalDecorators": true,
     "erasableSyntaxOnly": false,
-    "types": ["@cloudflare/workers-types"]
+    "types": ["@cloudflare/workers-types", "node"]
   },
   "include": ["src/**/*"],
   "references": [{ "path": "../core" }]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 4.20250523.0
         version: 4.20250523.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.17
 
   packages/adapter-electron:
     dependencies:


### PR DESCRIPTION
## Summary
- add injectable CloudflareBindings for typed request-scoped Workers bindings
- store Cloudflare env and ExecutionContext per request in the Workers adapter
- add runtime and type-safety coverage for binding access

## Verification
- pnpm run precommit
- pnpm knip

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784556020&installation_id=133048706&pr_number=287&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F287&signature=b83b853a11e8210c47ac193fbb4a3e227b23979b75609711a49a9abc14145ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->