### PR TITLE
[codex] Support custom CLI build commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,3 +48,7 @@ export default defineConfig({
 
 `build.command` replaces the default tsdown build. It cannot be used together with a
 plugin `build` hook, because both define the build implementation.
+
+The command runs from the current working directory used to invoke `zelt build`.
+Local binaries are resolved from `node_modules/.bin` in that directory and each
+ancestor directory, so workspace-root binaries are available to package builds.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,3 +30,21 @@ export default defineConfig({
   // configuration options
 });
 ```
+
+### Custom build command
+
+By default, `zelt build` uses tsdown. To use another builder, set `build.command`:
+
+```typescript
+import { defineConfig } from '@zeltjs/cli';
+
+export default defineConfig({
+  app: () => import('./src/app').then((m) => m.app),
+  build: {
+    command: 'vite build',
+  },
+});
+```
+
+`build.command` replaces the default tsdown build. It cannot be used together with a
+plugin `build` hook, because both define the build implementation.

--- a/packages/cli/src/build-bin-path.lib.ts
+++ b/packages/cli/src/build-bin-path.lib.ts
@@ -1,0 +1,39 @@
+import { delimiter, dirname, join } from 'node:path';
+
+const findPathKey = (env: NodeJS.ProcessEnv): string =>
+  Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+
+const collectAncestorBinDirs = (cwd: string): string[] => {
+  const dirs: string[] = [];
+  let current = cwd;
+  let parent = dirname(current);
+
+  while (parent !== current) {
+    dirs.push(join(current, 'node_modules', '.bin'));
+    current = parent;
+    parent = dirname(current);
+  }
+
+  dirs.push(join(current, 'node_modules', '.bin'));
+  return dirs;
+};
+
+export const buildBinPath = (cwd: string, env: NodeJS.ProcessEnv): string => {
+  const pathKey = findPathKey(env);
+  const existingPath = env[pathKey];
+  const entries = collectAncestorBinDirs(cwd);
+
+  if (existingPath !== undefined && existingPath.length > 0) {
+    entries.push(existingPath);
+  }
+
+  return entries.join(delimiter);
+};
+
+export const buildCommandEnv = (cwd: string, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv => {
+  const pathKey = findPathKey(env);
+  return {
+    ...env,
+    [pathKey]: buildBinPath(cwd, env),
+  };
+};

--- a/packages/cli/src/build.command.test.ts
+++ b/packages/cli/src/build.command.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -18,6 +18,14 @@ describe('runBuild', () => {
     await rm(testDir, { recursive: true, force: true });
   });
 
+  const writeBin = async (rootDir: string, name: string, content: string): Promise<void> => {
+    const binDir = join(rootDir, 'node_modules', '.bin');
+    await mkdir(binDir, { recursive: true });
+    const binPath = join(binDir, name);
+    await writeFile(binPath, content);
+    await chmod(binPath, 0o755);
+  };
+
   it('runs build.command without requiring a tsdown entry', async () => {
     const command = `node -e "require('node:fs').writeFileSync('built.txt', 'ok')"`;
     await writeFile(
@@ -35,6 +43,62 @@ describe('runBuild', () => {
     await runBuild(testDir, {});
 
     await expect(readFile(join(testDir, 'built.txt'), 'utf8')).resolves.toBe('ok');
+  });
+
+  it('resolves build.command from ancestor node_modules/.bin', async () => {
+    const workspaceDir = join(testDir, 'workspace');
+    const projectDir = join(workspaceDir, 'app');
+    await mkdir(projectDir, { recursive: true });
+    await writeBin(
+      workspaceDir,
+      'custom-builder',
+      `#!/usr/bin/env sh\nprintf ok > "$PWD/custom-built.txt"\n`,
+    );
+    await writeFile(
+      join(projectDir, 'zelt.config.ts'),
+      `
+        export default {
+          app: () => ({}),
+          build: {
+            command: "custom-builder",
+          },
+        };
+      `,
+    );
+
+    await runBuild(projectDir, {});
+
+    await expect(readFile(join(projectDir, 'custom-built.txt'), 'utf8')).resolves.toBe('ok');
+  });
+
+  it('runs the default tsdown build through the same ancestor bin resolution', async () => {
+    const workspaceDir = join(testDir, 'workspace');
+    const projectDir = join(workspaceDir, 'app');
+    await mkdir(projectDir, { recursive: true });
+    await writeBin(
+      workspaceDir,
+      'tsdown',
+      `#!/usr/bin/env sh\nprintf "%s" "$*" > "$PWD/tsdown-args.txt"\nprintf ok > "$PWD/default-built.txt"\n`,
+    );
+    await writeFile(
+      join(projectDir, 'zelt.config.ts'),
+      `
+        export default {
+          app: () => ({}),
+          build: {
+            entry: "./src/main.ts",
+            outDir: "./dist",
+          },
+        };
+      `,
+    );
+
+    await runBuild(projectDir, {});
+
+    await expect(readFile(join(projectDir, 'default-built.txt'), 'utf8')).resolves.toBe('ok');
+    await expect(readFile(join(projectDir, 'tsdown-args.txt'), 'utf8')).resolves.toContain(
+      '--entry ./src/main.ts --out-dir ./dist',
+    );
   });
 
   it('throws when build.command is configured with a plugin build hook', async () => {

--- a/packages/cli/src/build.command.test.ts
+++ b/packages/cli/src/build.command.test.ts
@@ -1,0 +1,117 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runBuild } from './build.command';
+import { ZeltBuildCommandConflictError, ZeltBuildError, ZeltNoEntryError } from './cli.errors';
+
+describe('runBuild', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `zelt-cli-build-test-${Date.now()}`);
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('runs build.command without requiring a tsdown entry', async () => {
+    const command = `node -e "require('node:fs').writeFileSync('built.txt', 'ok')"`;
+    await writeFile(
+      join(testDir, 'zelt.config.ts'),
+      `
+        export default {
+          app: () => ({}),
+          build: {
+            command: ${JSON.stringify(command)},
+          },
+        };
+      `,
+    );
+
+    await runBuild(testDir, {});
+
+    await expect(readFile(join(testDir, 'built.txt'), 'utf8')).resolves.toBe('ok');
+  });
+
+  it('throws when build.command is configured with a plugin build hook', async () => {
+    await writeFile(
+      join(testDir, 'zelt.config.ts'),
+      `
+        export default {
+          app: () => ({}),
+          plugins: [
+            {
+              name: 'custom-builder',
+              build: async () => {},
+            },
+          ],
+          build: {
+            command: "node -e \\"process.exit(0)\\"",
+          },
+        };
+      `,
+    );
+
+    await expect(runBuild(testDir, {})).rejects.toThrow(ZeltBuildCommandConflictError);
+  });
+
+  it('runs a plugin build hook without requiring a tsdown entry', async () => {
+    await writeFile(
+      join(testDir, 'zelt.config.ts'),
+      `
+        import { writeFile } from 'node:fs/promises';
+
+        export default {
+          app: () => ({}),
+          plugins: [
+            {
+              name: 'custom-builder',
+              build: async ({ cwd }) => {
+                await writeFile(new URL('./plugin-built.txt', \`file://\${cwd}/\`), 'ok');
+              },
+            },
+          ],
+          build: {},
+        };
+      `,
+    );
+
+    await runBuild(testDir, {});
+
+    await expect(readFile(join(testDir, 'plugin-built.txt'), 'utf8')).resolves.toBe('ok');
+  });
+
+  it('throws a build error when build.command exits non-zero', async () => {
+    await writeFile(
+      join(testDir, 'zelt.config.ts'),
+      `
+        export default {
+          app: () => ({}),
+          build: {
+            command: "node -e \\"process.exit(7)\\"",
+          },
+        };
+      `,
+    );
+
+    await expect(runBuild(testDir, {})).rejects.toThrow(ZeltBuildError);
+  });
+
+  it('still requires an entry for the default tsdown build', async () => {
+    await writeFile(
+      join(testDir, 'zelt.config.ts'),
+      `
+        export default {
+          app: () => ({}),
+          build: {},
+        };
+      `,
+    );
+
+    await expect(runBuild(testDir, {})).rejects.toThrow(ZeltNoEntryError);
+  });
+});

--- a/packages/cli/src/build.command.test.ts
+++ b/packages/cli/src/build.command.test.ts
@@ -22,8 +22,9 @@ describe('runBuild', () => {
     const binDir = join(rootDir, 'node_modules', '.bin');
     await mkdir(binDir, { recursive: true });
     const binPath = join(binDir, name);
-    await writeFile(binPath, content);
+    await writeFile(binPath, `#!/usr/bin/env node\n${content}`);
     await chmod(binPath, 0o755);
+    await writeFile(`${binPath}.cmd`, `@echo off\r\nnode "%~dp0\\${name}" %*\r\n`);
   };
 
   it('runs build.command without requiring a tsdown entry', async () => {
@@ -52,7 +53,7 @@ describe('runBuild', () => {
     await writeBin(
       workspaceDir,
       'custom-builder',
-      `#!/usr/bin/env sh\nprintf ok > "$PWD/custom-built.txt"\n`,
+      `require('node:fs').writeFileSync('custom-built.txt', 'ok');\n`,
     );
     await writeFile(
       join(projectDir, 'zelt.config.ts'),
@@ -78,7 +79,7 @@ describe('runBuild', () => {
     await writeBin(
       workspaceDir,
       'tsdown',
-      `#!/usr/bin/env sh\nprintf "%s" "$*" > "$PWD/tsdown-args.txt"\nprintf ok > "$PWD/default-built.txt"\n`,
+      `require('node:fs').writeFileSync('tsdown-args.txt', process.argv.slice(2).join(' '));\nrequire('node:fs').writeFileSync('default-built.txt', 'ok');\n`,
     );
     await writeFile(
       join(projectDir, 'zelt.config.ts'),

--- a/packages/cli/src/build.command.ts
+++ b/packages/cli/src/build.command.ts
@@ -18,7 +18,7 @@ import { runCommandBuild } from './command-build.lib';
 import type { BuildConfig } from './config/config.types';
 import { loadZeltConfig } from './config/index';
 import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './plugin-runner.lib';
-import { runTsdownBuild } from './tsdown.lib';
+import { buildTsdownCommand } from './tsdown.lib';
 
 type BuildArgs = {
   readonly config?: string;
@@ -66,13 +66,14 @@ const assertBuildImplementation = (
 };
 
 /** @throws {ZeltBuildError} */
-const runDefaultBuild = async (cwd: string, buildConfig: BuildConfig): Promise<void> => {
+const runDefaultBuild = async (
+  cwd: string,
+  buildConfig: BuildConfig,
+  env: NodeJS.ProcessEnv,
+): Promise<void> => {
   consola.start('Building...');
-  if (buildConfig.command !== undefined) {
-    await runCommandBuild({ cwd, command: buildConfig.command });
-  } else {
-    await runTsdownBuild({ cwd, config: buildConfig });
-  }
+  const command = buildConfig.command ?? buildTsdownCommand(buildConfig);
+  await runCommandBuild({ cwd, command, env });
   consola.success('Build completed');
 };
 
@@ -96,7 +97,7 @@ export const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void>
     const buildResult = await runBuildHook(hookOptions);
 
     if (!buildResult.handled) {
-      await runDefaultBuild(cwd, buildConfig);
+      await runDefaultBuild(cwd, buildConfig, nodeCliRuntime.env());
     }
   } catch (error) {
     success = false;

--- a/packages/cli/src/build.command.ts
+++ b/packages/cli/src/build.command.ts
@@ -2,19 +2,19 @@ import { defineCommand } from 'citty';
 import consola from 'consola';
 import { match } from 'ts-pattern';
 
-import type {
-  ZeltBuildError,
-  ZeltConfigLoadError,
-  ZeltMultipleBuildHooksError,
-} from './cli.errors';
+import type { ZeltBuildError, ZeltConfigLoadError } from './cli.errors';
 import {
+  isZeltBuildCommandConflictError,
   isZeltBuildError,
   isZeltConfigLoadError,
   isZeltMultipleBuildHooksError,
   isZeltNoEntryError,
+  ZeltBuildCommandConflictError,
+  ZeltMultipleBuildHooksError,
   ZeltNoEntryError,
 } from './cli.errors';
 import { nodeCliRuntime } from './cli-runtime.lib';
+import { runCommandBuild } from './command-build.lib';
 import type { BuildConfig } from './config/config.types';
 import { loadZeltConfig } from './config/index';
 import { runBuildHook, runPostBuildHooks, runPreBuildHooks } from './plugin-runner.lib';
@@ -28,6 +28,7 @@ type BuildArgs = {
 
 type RunBuildError =
   | InstanceType<typeof ZeltConfigLoadError>
+  | InstanceType<typeof ZeltBuildCommandConflictError>
   | InstanceType<typeof ZeltBuildError>
   | InstanceType<typeof ZeltNoEntryError>
   | InstanceType<typeof ZeltMultipleBuildHooksError>;
@@ -38,15 +39,51 @@ const resolveBuildConfig = (args: BuildArgs, buildConfig: BuildConfig | undefine
   outDir: args.outDir ?? buildConfig?.outDir,
 });
 
-/** @throws {ZeltNoEntryError | ZeltBuildError | ZeltMultipleBuildHooksError | ZeltConfigLoadError | {} | null} */
-const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
+const getBuildHookPluginNames = (
+  plugins: readonly { readonly name: string; readonly build?: unknown }[] = [],
+) => plugins.filter((plugin) => plugin.build !== undefined).map((plugin) => plugin.name);
+
+/** @throws {ZeltMultipleBuildHooksError | ZeltBuildCommandConflictError | ZeltNoEntryError} */
+const assertBuildImplementation = (
+  buildConfig: BuildConfig,
+  buildHookPluginNames: readonly string[],
+): void => {
+  if (buildHookPluginNames.length > 1) {
+    throw new ZeltMultipleBuildHooksError({ pluginNames: buildHookPluginNames });
+  }
+
+  if (buildHookPluginNames[0] !== undefined && buildConfig.command !== undefined) {
+    throw new ZeltBuildCommandConflictError({ pluginName: buildHookPluginNames[0] });
+  }
+
+  if (
+    buildHookPluginNames.length === 0 &&
+    buildConfig.command === undefined &&
+    buildConfig.entry === undefined
+  ) {
+    throw new ZeltNoEntryError({});
+  }
+};
+
+/** @throws {ZeltBuildError} */
+const runDefaultBuild = async (cwd: string, buildConfig: BuildConfig): Promise<void> => {
+  consola.start('Building...');
+  if (buildConfig.command !== undefined) {
+    await runCommandBuild({ cwd, command: buildConfig.command });
+  } else {
+    await runTsdownBuild({ cwd, config: buildConfig });
+  }
+  consola.success('Build completed');
+};
+
+/** @throws {ZeltNoEntryError | ZeltBuildCommandConflictError | ZeltBuildError | ZeltMultipleBuildHooksError | ZeltConfigLoadError | {} | null} */
+export const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
   const configFile = typedArgs.config;
   const config = await loadZeltConfig(configFile !== undefined ? { cwd, configFile } : { cwd });
   const buildConfig = resolveBuildConfig(typedArgs, config.build);
+  const buildHookPluginNames = getBuildHookPluginNames(config.plugins);
 
-  if (buildConfig.entry === undefined) {
-    throw new ZeltNoEntryError({});
-  }
+  assertBuildImplementation(buildConfig, buildHookPluginNames);
 
   const hookOptions = { cwd, config, loadStaticApp: async () => config.app() };
 
@@ -59,9 +96,7 @@ const runBuild = async (cwd: string, typedArgs: BuildArgs): Promise<void> => {
     const buildResult = await runBuildHook(hookOptions);
 
     if (!buildResult.handled) {
-      consola.start('Building...');
-      await runTsdownBuild({ cwd, config: buildConfig });
-      consola.success('Build completed');
+      await runDefaultBuild(cwd, buildConfig);
     }
   } catch (error) {
     success = false;
@@ -81,7 +116,12 @@ const handleError = (error: RunBuildError): void => {
       consola.error('Failed to load config');
     })
     .when(isZeltNoEntryError, () => {
-      consola.error('No entry file specified. Use --entry or set build.entry in zelt.config.ts');
+      consola.error(
+        'No entry file specified. Use --entry, set build.entry, or set build.command in zelt.config.ts',
+      );
+    })
+    .when(isZeltBuildCommandConflictError, (e) => {
+      consola.error(e.message);
     })
     .when(isZeltBuildError, () => {
       consola.error('Build failed');
@@ -95,7 +135,7 @@ const handleError = (error: RunBuildError): void => {
 export const buildCommand = defineCommand({
   meta: {
     name: 'build',
-    description: 'Build the application using tsdown',
+    description: 'Build the application',
   },
   args: {
     config: {
@@ -124,6 +164,7 @@ export const buildCommand = defineCommand({
       if (
         isZeltConfigLoadError(error) ||
         isZeltBuildError(error) ||
+        isZeltBuildCommandConflictError(error) ||
         isZeltNoEntryError(error) ||
         isZeltMultipleBuildHooksError(error)
       ) {

--- a/packages/cli/src/cli-runtime.lib.ts
+++ b/packages/cli/src/cli-runtime.lib.ts
@@ -3,6 +3,7 @@ export type CliSignalHandler = () => void;
 
 export type CliRuntime = {
   readonly cwd: () => string;
+  readonly env: () => NodeJS.ProcessEnv;
   readonly setExitCode: (code: number) => void;
   readonly onSignal: (signal: CliSignal, handler: CliSignalHandler) => void;
   readonly offSignal: (signal: CliSignal, handler: CliSignalHandler) => void;
@@ -10,6 +11,7 @@ export type CliRuntime = {
 
 export const nodeCliRuntime: CliRuntime = {
   cwd: () => process.cwd(),
+  env: () => process.env,
   setExitCode: (code) => {
     process.exitCode = code;
   },

--- a/packages/cli/src/cli.errors.ts
+++ b/packages/cli/src/cli.errors.ts
@@ -26,6 +26,12 @@ export const ZeltBuildError = defineError(
   (ctx: { exitCode: number }) => `Build failed with exit code ${ctx.exitCode}`,
 );
 
+export const ZeltBuildCommandConflictError = defineError(
+  'ZeltBuildCommandConflictError',
+  (ctx: { pluginName: string }) =>
+    `Both plugin build hook (${ctx.pluginName}) and build.command are configured. Use only one build implementation.`,
+);
+
 export const ZeltNoEntryError = defineError('ZeltNoEntryError', () => 'No entry file specified');
 
 export const ZeltNoCliEntryError = defineError(
@@ -44,6 +50,11 @@ export const isZeltConfigLoadError = (
 
 export const isZeltBuildError = (err: unknown): err is InstanceType<typeof ZeltBuildError> =>
   err instanceof ZeltBuildError;
+
+export const isZeltBuildCommandConflictError = (
+  err: unknown,
+): err is InstanceType<typeof ZeltBuildCommandConflictError> =>
+  err instanceof ZeltBuildCommandConflictError;
 
 export const isZeltNoEntryError = (err: unknown): err is InstanceType<typeof ZeltNoEntryError> =>
   err instanceof ZeltNoEntryError;

--- a/packages/cli/src/command-build.lib.test.ts
+++ b/packages/cli/src/command-build.lib.test.ts
@@ -1,0 +1,33 @@
+import { EventEmitter } from 'node:events';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ZeltBuildError } from './cli.errors';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+const createChild = () => {
+  const child = new EventEmitter();
+  spawnMock.mockReturnValue(child);
+  return child;
+};
+
+describe('runCommandBuild', () => {
+  it('fails when the child process closes because of a signal', async () => {
+    const { runCommandBuild } = await import('./command-build.lib');
+    const child = createChild();
+
+    const result = runCommandBuild({
+      cwd: '/project',
+      command: 'vite build',
+      env: { PATH: '/bin' },
+    });
+    child.emit('close', null, 'SIGTERM');
+
+    await expect(result).rejects.toThrow(ZeltBuildError);
+  });
+});

--- a/packages/cli/src/command-build.lib.ts
+++ b/packages/cli/src/command-build.lib.ts
@@ -1,0 +1,38 @@
+import { spawn } from 'node:child_process';
+
+import consola from 'consola';
+
+import { ZeltBuildError } from './cli.errors';
+
+export type CommandBuildOptions = {
+  readonly cwd: string;
+  readonly command: string;
+};
+
+/** @throws {ZeltBuildError} */
+export const runCommandBuild = async (options: CommandBuildOptions): Promise<void> => {
+  const { cwd, command } = options;
+
+  consola.info(`Running build command in ${cwd}`);
+  consola.debug(command);
+
+  const exitCode = await new Promise<number>((resolvePromise, rejectPromise) => {
+    const child = spawn(command, {
+      cwd,
+      shell: true,
+      stdio: 'inherit',
+    });
+
+    child.on('close', (code) => {
+      resolvePromise(code ?? 0);
+    });
+
+    child.on('error', (err) => {
+      rejectPromise(err);
+    });
+  });
+
+  if (exitCode !== 0) {
+    throw new ZeltBuildError({ exitCode });
+  }
+};

--- a/packages/cli/src/command-build.lib.ts
+++ b/packages/cli/src/command-build.lib.ts
@@ -26,8 +26,13 @@ export const runCommandBuild = async (options: CommandBuildOptions): Promise<voi
       stdio: 'inherit',
     });
 
-    child.on('close', (code) => {
-      resolvePromise(code ?? 0);
+    child.on('close', (code, signal) => {
+      if (code === 0 && signal === null) {
+        resolvePromise(0);
+        return;
+      }
+
+      resolvePromise(code ?? 1);
     });
 
     child.on('error', (err) => {

--- a/packages/cli/src/command-build.lib.ts
+++ b/packages/cli/src/command-build.lib.ts
@@ -2,16 +2,18 @@ import { spawn } from 'node:child_process';
 
 import consola from 'consola';
 
+import { buildCommandEnv } from './build-bin-path.lib';
 import { ZeltBuildError } from './cli.errors';
 
 export type CommandBuildOptions = {
   readonly cwd: string;
   readonly command: string;
+  readonly env: NodeJS.ProcessEnv;
 };
 
 /** @throws {ZeltBuildError} */
 export const runCommandBuild = async (options: CommandBuildOptions): Promise<void> => {
-  const { cwd, command } = options;
+  const { cwd, command, env } = options;
 
   consola.info(`Running build command in ${cwd}`);
   consola.debug(command);
@@ -19,6 +21,7 @@ export const runCommandBuild = async (options: CommandBuildOptions): Promise<voi
   const exitCode = await new Promise<number>((resolvePromise, rejectPromise) => {
     const child = spawn(command, {
       cwd,
+      env: buildCommandEnv(cwd, env),
       shell: true,
       stdio: 'inherit',
     });

--- a/packages/cli/src/config/config.types.ts
+++ b/packages/cli/src/config/config.types.ts
@@ -1,6 +1,7 @@
 import * as v from 'valibot';
 
 const BuildConfigSchema = v.object({
+  command: v.optional(v.string()),
   entry: v.optional(v.string()),
   outDir: v.optional(v.string()),
   platform: v.optional(v.picklist(['node', 'browser', 'neutral'])),

--- a/packages/cli/src/tsdown.lib.test.ts
+++ b/packages/cli/src/tsdown.lib.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildTsdownCommand, quoteShellArg } from './tsdown.lib';
+
+describe('quoteShellArg', () => {
+  it('keeps simple values unquoted', () => {
+    expect(quoteShellArg('./src/main.ts')).toBe('./src/main.ts');
+  });
+
+  it('uses double quotes for shell values that need quoting', () => {
+    expect(quoteShellArg("./src/main file's.ts")).toBe('"./src/main file\'s.ts"');
+  });
+});
+
+describe('buildTsdownCommand', () => {
+  it('builds the default tsdown command with shell-safe arguments', () => {
+    expect(buildTsdownCommand({ entry: "./src/main file's.ts", outDir: './dist app' })).toContain(
+      `--entry "./src/main file's.ts" --out-dir "./dist app"`,
+    );
+  });
+});

--- a/packages/cli/src/tsdown.lib.ts
+++ b/packages/cli/src/tsdown.lib.ts
@@ -1,15 +1,4 @@
-import { spawn } from 'node:child_process';
-import { resolve } from 'node:path';
-
-import consola from 'consola';
-
-import { ZeltBuildError } from './cli.errors';
 import type { BuildConfig } from './config/config.types';
-
-export type BuildOptions = {
-  readonly cwd: string;
-  readonly config: BuildConfig;
-};
 
 const buildArgs = (config: BuildConfig): string[] => {
   const args: string[] = [];
@@ -40,32 +29,13 @@ const buildArgs = (config: BuildConfig): string[] => {
   return args;
 };
 
-/** @throws {ZeltBuildError} */
-export const runTsdownBuild = async (options: BuildOptions): Promise<void> => {
-  const { cwd, config } = options;
-  const args = buildArgs(config);
-
-  consola.info(`Running tsdown in ${cwd}`);
-  consola.debug(`tsdown ${args.join(' ')}`);
-
-  const tsdownBin = resolve(cwd, 'node_modules/.bin/tsdown');
-
-  const exitCode = await new Promise<number>((resolvePromise, rejectPromise) => {
-    const child = spawn(tsdownBin, args, {
-      cwd,
-      stdio: 'inherit',
-    });
-
-    child.on('close', (code) => {
-      resolvePromise(code ?? 0);
-    });
-
-    child.on('error', (err) => {
-      rejectPromise(err);
-    });
-  });
-
-  if (exitCode !== 0) {
-    throw new ZeltBuildError({ exitCode });
+const quoteShellArg = (arg: string): string => {
+  if (/^[A-Za-z0-9_./:=@%-]+$/.test(arg)) {
+    return arg;
   }
+
+  return `'${arg.replaceAll("'", "'\\''")}'`;
 };
+
+export const buildTsdownCommand = (config: BuildConfig): string =>
+  ['tsdown', ...buildArgs(config).map(quoteShellArg)].join(' ');

--- a/packages/cli/src/tsdown.lib.ts
+++ b/packages/cli/src/tsdown.lib.ts
@@ -29,12 +29,12 @@ const buildArgs = (config: BuildConfig): string[] => {
   return args;
 };
 
-const quoteShellArg = (arg: string): string => {
+export const quoteShellArg = (arg: string): string => {
   if (/^[A-Za-z0-9_./:=@%-]+$/.test(arg)) {
     return arg;
   }
 
-  return `'${arg.replaceAll("'", "'\\''")}'`;
+  return `"${arg.replaceAll('"', '\\"').replaceAll('$', '\\$').replaceAll('`', '\\`')}"`;
 };
 
 export const buildTsdownCommand = (config: BuildConfig): string =>


### PR DESCRIPTION
## Summary

- Add `build.command` to `@zeltjs/cli` so projects can replace the default tsdown build with a custom shell command such as `vite build`.
- Keep plugin `build` hooks as the explicit build override path, and reject configurations that define both a plugin build hook and `build.command`.
- Run both default tsdown and custom build commands through the same command runner, with `cwd` set to the `zelt build` invocation directory and `node_modules/.bin` resolved from that directory and its ancestors for pnpm workspace compatibility.
- Document the custom build command behavior in the CLI README.

## Validation

- `pnpm precommit`
- pre-push hook: `knip` and `prevent-force-push`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785322666&installation_id=133048706&pr_number=291&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F291&signature=81787d717155b8379e105f0d50ae1263d6b72f3377f4a2972dcbeca41cb94772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ビルド設定で、既定のビルド方法に加えて任意のカスタムコマンドを指定できるようになりました。
  * ビルド時に、現在の作業ディレクトリ配下および親ディレクトリの実行ファイルを見つけやすくなりました。

* **バグ修正**
  * ビルド設定の競合や未設定時のエラーメッセージを改善し、原因が分かりやすくなりました。
  * カスタムコマンドの失敗時に、より適切にエラーが返るようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->