### PR TITLE
fix(hono-client): preserve portable literal types

### DIFF
--- a/packages/hono-client/src/generator/app-type-resolver.service.ts
+++ b/packages/hono-client/src/generator/app-type-resolver.service.ts
@@ -615,6 +615,19 @@ export class AppTypeResolverService {
     return resolvedPath;
   }
 
+  private stripTextRanges(
+    node: TSTypeNode,
+    ts: TypeScriptModule,
+    transformContext: TSTransformationContext,
+  ): TSTypeNode {
+    const visit = (child: TSNode): TSVisitResult => {
+      const visited = ts.visitEachChild(child, visit, transformContext);
+      return ts.setTextRange(visited, { pos: -1, end: -1 });
+    };
+
+    return ts.visitNode(node, visit, ts.isTypeNode);
+  }
+
   private inlineLocalImportReferences(
     program: TSProgram,
     source: string,
@@ -639,7 +652,7 @@ export class AppTypeResolverService {
           new Map(),
           new Set(),
         );
-        if (result.ok) return result.value;
+        if (result.ok) return this.stripTextRanges(result.value, ts, context);
         failureMessage = result.message;
         return root;
       },

--- a/packages/hono-client/src/generator/emit-portable.lib.test.ts
+++ b/packages/hono-client/src/generator/emit-portable.lib.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import type { ControllerClass, HttpMetadata } from './generator.types';
 import { PortableAppTypeEmitterService } from './portable-app-type-emitter.service';
 import { PortableDtoController } from './test/fixtures/portable-dto.controller';
+import { PortableLicenseController } from './test/fixtures/portable-license.controller';
 
 @Controller('/users')
 export class UserController {
@@ -81,6 +82,23 @@ const portableDtoMetadata: HttpMetadata = {
           path: '/:id',
           fullPath: '/portable-dto/:id',
           methodName: 'show',
+        },
+      ],
+    },
+  ],
+};
+
+const portableLicenseMetadata: HttpMetadata = {
+  controllers: [
+    {
+      basePath: '/license',
+      name: 'PortableLicenseController',
+      routes: [
+        {
+          method: 'GET',
+          path: '/validate',
+          fullPath: '/license/validate',
+          methodName: 'validate',
         },
       ],
     },
@@ -270,6 +288,29 @@ describe('emitPortableAppType', () => {
       expect(result.value).toContain('value:');
       expect(result.value).toContain('bio: string');
       expect(result.value).not.toContain('PortableProfile');
+      await expectGeneratedAppTypeToTypeCheck(result.value);
+    },
+    portableTestTimeout,
+  );
+
+  it(
+    'preserves string literal types when inlining imported local aliases',
+    async () => {
+      const result = await emitter.emit({
+        metadata: portableLicenseMetadata,
+        controllers: [PortableLicenseController] as readonly ControllerClass[],
+        distDir,
+        tsconfig,
+        projectRoot,
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value).toMatch(/status:\s*['"]valid['"]/);
+      expect(result.value).toMatch(/status:\s*['"]revoked['"]/);
+      expect(result.value).not.toContain('cense-se');
+      expect(result.value).not.toContain('orResponse');
       await expectGeneratedAppTypeToTypeCheck(result.value);
     },
     portableTestTimeout,

--- a/packages/hono-client/src/generator/test/fixtures/portable-license.controller.ts
+++ b/packages/hono-client/src/generator/test/fixtures/portable-license.controller.ts
@@ -1,0 +1,10 @@
+import { Controller } from '@zeltjs/core';
+
+import type { ValidateSuccess } from './portable-license.types';
+
+@Controller('/license')
+export class PortableLicenseController {
+  validate(): ValidateSuccess {
+    return { status: 'revoked' };
+  }
+}

--- a/packages/hono-client/src/generator/test/fixtures/portable-license.types.ts
+++ b/packages/hono-client/src/generator/test/fixtures/portable-license.types.ts
@@ -1,0 +1,3 @@
+export type ValidateSuccess =
+  | { status: 'valid'; readonly payload: string; readonly signature: string }
+  | { status: 'revoked' };


### PR DESCRIPTION
## Summary
- strip TypeScript text ranges from inlined local type nodes before printing portable output
- add a portable regression fixture for imported local aliases with string literal unions
- ensure generated portable output keeps valid/revoked literal statuses and type-checks

## Verification
- pnpm --filter @zeltjs/hono-client test -- emit-portable.lib.test.ts
- pnpm --filter @zeltjs/hono-client typecheck
- pnpm knip

Stacked on #294.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785496473&installation_id=133048706&pr_number=296&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F296&signature=051203dba87568623ce4d9e5478f3dd0cadb4b742015fb1c4d3ef818a8ec8bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 型情報の生成がより安定し、インライン化された参照でも出力の整合性が保たれるようになりました。
  * ライセンス検証の例に対応した生成結果のサポートを追加し、文字列リテラルの保持を改善しました。

* **テスト**
  * 生成コードが型チェックを通ること、および不要な文字列が混入しないことを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->