### PR TITLE
fix(readme): align Quick Start with actual createApp API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,13 @@ class UserController {
 ### 3. Create and Run the Application
 
 ```typescript
-import { createApp } from '@zeltjs/core';
+import { createApp, http } from '@zeltjs/core';
 import { onNode } from '@zeltjs/adapter-node';
 
-const app = createApp({
-  http: {
-    controllers: [UserController],
-  },
-});
+const app = createApp([http({ controllers: [UserController] })]);
 
 const nodeApp = await onNode(app);
-const server = await nodeApp.listen({ port: 3000 });
+const server = await nodeApp.http.listen({ port: 3000 });
 console.log(`Server running at http://localhost:${server.address.port}`);
 ```
 
@@ -128,12 +124,12 @@ Same application code, different adapters:
 // Node.js
 import { onNode } from '@zeltjs/adapter-node';
 const nodeApp = await onNode(app);
-await nodeApp.listen({ port: 3000 });
+await nodeApp.http.listen({ port: 3000 });
 
 // Bun
 import { onBun } from '@zeltjs/adapter-bun';
 const bunApp = await onBun(app);
-bunApp.serve({ port: 3000 });
+bunApp.http.serve({ port: 3000 });
 
 // Cloudflare Workers
 import { onCloudflareWorkers } from '@zeltjs/adapter-cloudflare-workers';


### PR DESCRIPTION
## Summary
- README の Quick Start / Deploy Anywhere が実装・公式ドキュメントと乖離しており、そのままコピーすると動作しない状態だったため修正
- `createApp({ http: {...} })` → `createApp([http({...})])`(Feature 配列を受け取る現行 API に合わせる)
- `nodeApp.listen(...)` → `nodeApp.http.listen(...)`
- `bunApp.serve(...)` → `bunApp.http.serve(...)`

## Test plan
- [x] `pnpm run precommit`(build / typecheck / lint / docs 検証 / test)がパス

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785503717&installation_id=133048706&pr_number=297&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F297&signature=d0808783e209105a2abd05fcb6d91782893cb6b20b461e46cf539e5428192c4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->