### PR TITLE
feat(core): class-level @SkipMiddleware with scope precedence

### DIFF
--- a/packages/core/src/features/http/app.test.ts
+++ b/packages/core/src/features/http/app.test.ts
@@ -11,6 +11,7 @@ import { http } from './http.feature';
 import { fromHonoMiddleware } from './middleware';
 import { Middleware } from './middleware/middleware.decorator';
 import type { Next } from './middleware/middleware.types';
+import { SecureHeadersMiddleware } from './middleware/secure-headers/secure-headers.middleware';
 import { SkipMiddleware } from './middleware/skip-middleware.decorator';
 import { UseMiddleware } from './middleware/use-middleware.decorator';
 import { getContext, request, setContext } from './request/injection';
@@ -516,6 +517,194 @@ describe('middleware', () => {
     executed.length = 0;
     await readyApp.http.request('/test/public');
     expect(executed).toEqual(['public']);
+  });
+
+  it('skips global middleware for every controller route with class-level @SkipMiddleware', async () => {
+    const executed: string[] = [];
+    @Middleware
+    class AuthMiddleware {
+      async use(next: Next): Promise<Response | undefined> {
+        executed.push('auth');
+        await next();
+        return undefined;
+      }
+    }
+
+    @SkipMiddleware(AuthMiddleware)
+    @Controller('/test')
+    class TestController {
+      @Get('/one')
+      one() {
+        executed.push('one');
+        return { ok: true };
+      }
+
+      @Get('/two')
+      two() {
+        executed.push('two');
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([
+      http({
+        controllers: [TestController],
+        middlewares: [AuthMiddleware],
+      }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    executed.length = 0;
+    await readyApp.http.request('/test/one');
+    expect(executed).toEqual(['one']);
+
+    executed.length = 0;
+    await readyApp.http.request('/test/two');
+    expect(executed).toEqual(['two']);
+  });
+
+  it('unions class-level and method-level @SkipMiddleware declarations', async () => {
+    const executed: string[] = [];
+    @Middleware
+    class AuthMiddleware {
+      async use(next: Next): Promise<Response | undefined> {
+        executed.push('auth');
+        await next();
+        return undefined;
+      }
+    }
+    @Middleware
+    class LoggingMiddleware {
+      async use(next: Next): Promise<Response | undefined> {
+        executed.push('logging');
+        await next();
+        return undefined;
+      }
+    }
+
+    @SkipMiddleware(AuthMiddleware)
+    @Controller('/test')
+    class TestController {
+      @Get('/class-only')
+      classOnly() {
+        executed.push('classOnly');
+        return { ok: true };
+      }
+
+      @SkipMiddleware(LoggingMiddleware)
+      @Get('/public')
+      public() {
+        executed.push('public');
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([
+      http({
+        controllers: [TestController],
+        middlewares: [AuthMiddleware, LoggingMiddleware],
+      }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    executed.length = 0;
+    await readyApp.http.request('/test/class-only');
+    expect(executed).toEqual(['logging', 'classOnly']);
+
+    executed.length = 0;
+    await readyApp.http.request('/test/public');
+    expect(executed).toEqual(['public']);
+  });
+
+  it('runs method-level @UseMiddleware when the same middleware is skipped at class level', async () => {
+    const executed: string[] = [];
+    @Middleware
+    class TrackingMiddleware {
+      async use(next: Next): Promise<Response | undefined> {
+        executed.push('tracking');
+        await next();
+        return undefined;
+      }
+    }
+
+    @SkipMiddleware(TrackingMiddleware)
+    @Controller('/test')
+    class TestController {
+      @UseMiddleware(TrackingMiddleware)
+      @Get('/explicit')
+      explicit() {
+        executed.push('handler');
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([
+      http({
+        controllers: [TestController],
+        middlewares: [TrackingMiddleware],
+      }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    await readyApp.http.request('/test/explicit');
+    expect(executed).toEqual(['tracking', 'handler']);
+  });
+
+  it('skips method-level @UseMiddleware when the same method also declares @SkipMiddleware', async () => {
+    const executed: string[] = [];
+    @Middleware
+    class TrackingMiddleware {
+      async use(next: Next): Promise<Response | undefined> {
+        executed.push('tracking');
+        await next();
+        return undefined;
+      }
+    }
+
+    @Controller('/test')
+    class TestController {
+      @SkipMiddleware(TrackingMiddleware)
+      @UseMiddleware(TrackingMiddleware)
+      @Get('/explicit')
+      explicit() {
+        executed.push('handler');
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([http({ controllers: [TestController] })]);
+    const readyApp = await app.createRuntime();
+
+    await readyApp.http.request('/test/explicit');
+    expect(executed).toEqual(['handler']);
+  });
+
+  it('skips built-in security middleware with class-level @SkipMiddleware', async () => {
+    @SkipMiddleware(SecureHeadersMiddleware)
+    @Controller('/webhooks')
+    class WebhookController {
+      @Get('/incoming')
+      incoming() {
+        return { ok: true };
+      }
+    }
+
+    @Controller('/api')
+    class ApiController {
+      @Get('/data')
+      data() {
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([http({ controllers: [WebhookController, ApiController] })]);
+    const readyApp = await app.createRuntime();
+
+    const skippedRes = await readyApp.http.request('/webhooks/incoming');
+    expect(skippedRes.headers.get('X-Content-Type-Options')).toBeNull();
+
+    const defaultRes = await readyApp.http.request('/api/data');
+    expect(defaultRes.headers.get('X-Content-Type-Options')).toBe('nosniff');
   });
 
   it('resolves @Middleware class through DI', async () => {

--- a/packages/core/src/features/http/middleware/index.ts
+++ b/packages/core/src/features/http/middleware/index.ts
@@ -1,4 +1,5 @@
 export { fromHonoMiddleware } from './from-hono-middleware.lib';
+export type { SkippedMiddlewareSets } from './middleware-guard.lib';
 export {
   attachSkippedMiddlewares,
   guardMiddleware,

--- a/packages/core/src/features/http/middleware/middleware-guard.lib.ts
+++ b/packages/core/src/features/http/middleware/middleware-guard.lib.ts
@@ -8,6 +8,13 @@ import type { HonoMiddleware, MiddlewareIdentifier, MiddlewareInput } from './mi
 
 const SKIPPED_MIDDLEWARES = Symbol('zelt:skipped-middlewares');
 
+export type SkippedMiddlewareSets = {
+  readonly classLevel: ReadonlySet<MiddlewareIdentifier>;
+  readonly methodLevel: ReadonlySet<MiddlewareIdentifier>;
+};
+
+type MiddlewareSkipScope = 'default' | 'method';
+
 const hasUseMethod = (proto: unknown): boolean => {
   if (proto === null || proto === undefined) return false;
   if (typeof proto !== 'object') return false;
@@ -41,21 +48,40 @@ export const resolveMiddleware = (
   return async (_c, next) => await instance.use(next, middleware.options);
 };
 
-export const attachSkippedMiddlewares = (
-  handler: object,
-  skipped: ReadonlySet<MiddlewareIdentifier>,
-): void => {
+export const attachSkippedMiddlewares = (handler: object, skipped: SkippedMiddlewareSets): void => {
   Reflect.set(handler, SKIPPED_MIDDLEWARES, skipped);
 };
 
-const findSkippedMiddlewares = (c: Context): ReadonlySet<unknown> | undefined => {
+// Read-side counterpart of SkippedMiddlewareSets: values cross the handler
+// symbol boundary as unknown, and instanceof can only recover Set<unknown>.
+type FoundSkippedSets = {
+  readonly classLevel: ReadonlySet<unknown>;
+  readonly methodLevel: ReadonlySet<unknown>;
+};
+
+const findSkippedMiddlewares = (c: Context): FoundSkippedSets | undefined => {
   for (const route of matchedRoutes(c)) {
     // route() mounting may wrap handlers for error-handler scoping;
     // findTargetHandler unwraps to the function the skip set was attached to.
     const skipped: unknown = Reflect.get(findTargetHandler(route.handler), SKIPPED_MIDDLEWARES);
-    if (skipped instanceof Set) return skipped;
+    if (typeof skipped !== 'object' || skipped === null) continue;
+    const classLevel: unknown = Reflect.get(skipped, 'classLevel');
+    const methodLevel: unknown = Reflect.get(skipped, 'methodLevel');
+    if (classLevel instanceof Set && methodLevel instanceof Set) {
+      return { classLevel, methodLevel };
+    }
   }
   return undefined;
+};
+
+const shouldSkipMiddleware = (
+  skipped: FoundSkippedSets | undefined,
+  identifier: MiddlewareIdentifier,
+  scope: MiddlewareSkipScope,
+): boolean => {
+  if (!skipped) return false;
+  if (scope === 'method') return skipped.methodLevel.has(identifier);
+  return skipped.classLevel.has(identifier) || skipped.methodLevel.has(identifier);
 };
 
 // Skip is decided here, at execution time, against the matched endpoint's
@@ -64,10 +90,11 @@ const findSkippedMiddlewares = (c: Context): ReadonlySet<unknown> | undefined =>
 export const guardMiddleware = (
   identifier: MiddlewareIdentifier,
   middleware: HonoMiddleware,
+  options?: { readonly skipScope?: MiddlewareSkipScope },
 ): HonoMiddleware => {
   return async (c, next) => {
     const skipped = findSkippedMiddlewares(c);
-    if (skipped?.has(identifier)) return next();
+    if (shouldSkipMiddleware(skipped, identifier, options?.skipScope ?? 'default')) return next();
     const result = await middleware(c, next);
     if (result instanceof Response) {
       c.res = result;

--- a/packages/core/src/features/http/middleware/skip-middleware.decorator.test.ts
+++ b/packages/core/src/features/http/middleware/skip-middleware.decorator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getSkipMiddlewareMetadata } from '../routing';
+import { getControllerSkipMiddlewareMetadata, getSkipMiddlewareMetadata } from '../routing';
 import { Controller } from '../routing/controller.decorator';
 import { Get } from '../routing/http-method.decorator';
 import type { MiddlewareInstance } from './middleware.types';
@@ -20,6 +20,20 @@ class LoggingMiddleware implements MiddlewareInstance {
 }
 
 describe('@SkipMiddleware', () => {
+  it('registers skipped middlewares on controller metadata', () => {
+    @SkipMiddleware(AuthMiddleware)
+    @Controller('/test')
+    class TestController {
+      @Get('/')
+      handler() {
+        return {};
+      }
+    }
+
+    const meta = getControllerSkipMiddlewareMetadata(TestController);
+    expect(meta).toEqual([AuthMiddleware]);
+  });
+
   it('registers skipped middlewares on method metadata', () => {
     @Controller('/test')
     class TestController {

--- a/packages/core/src/features/http/middleware/skip-middleware.decorator.ts
+++ b/packages/core/src/features/http/middleware/skip-middleware.decorator.ts
@@ -1,11 +1,23 @@
-import { createMethodDecorator } from '@zeltjs/decorator-metadata';
+import type { ClassDecoratorFn, MethodDecoratorFn } from '@zeltjs/decorator-metadata';
+import {
+  createClassDecorator,
+  createMethodDecorator,
+  dispatchClassOrMethodDecorator,
+} from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel';
 import type { MiddlewareIdentifier } from './middleware.types';
 
 /** @throws {E} */
-export const SkipMiddleware = (...skipped: MiddlewareIdentifier[]) =>
-  createMethodDecorator({ decorator: 'SkipMiddleware' as const, skipped } as const, {
+export const SkipMiddleware = (
+  ...skipped: MiddlewareIdentifier[]
+): ClassDecoratorFn & MethodDecoratorFn => {
+  const props = { decorator: 'SkipMiddleware' as const, skipped } as const;
+  const classDecorate = createClassDecorator(props);
+  const methodDecorate = createMethodDecorator(props, {
     rejectStatic: () =>
       new ZeltDecoratorUsageError({ decoratorName: 'SkipMiddleware', reason: 'static_method' }),
   });
+
+  return dispatchClassOrMethodDecorator(classDecorate, methodDecorate);
+};

--- a/packages/core/src/features/http/middleware/use-middleware.decorator.ts
+++ b/packages/core/src/features/http/middleware/use-middleware.decorator.ts
@@ -1,12 +1,12 @@
 import type { ClassDecoratorFn, MethodDecoratorFn } from '@zeltjs/decorator-metadata';
-import { createClassDecorator, createMethodDecorator } from '@zeltjs/decorator-metadata';
-import { toUnknownCallable } from '@zeltjs/unsafe-type-lib';
-import { match, P } from 'ts-pattern';
+import {
+  createClassDecorator,
+  createMethodDecorator,
+  dispatchClassOrMethodDecorator,
+} from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel';
 import type { MiddlewareClass } from './middleware.types';
-
-const tc39ClassPattern = { kind: 'class' as const, metadata: P.nonNullable };
 
 const toMiddlewareInput = <TOptions>(
   middleware: MiddlewareClass<TOptions>,
@@ -38,29 +38,5 @@ export function UseMiddleware<TOptions>(
       new ZeltDecoratorUsageError({ decoratorName: 'UseMiddleware', reason: 'static_method' }),
   });
 
-  function dispatch<T extends abstract new (...args: never[]) => unknown>(
-    value: T,
-    context: ClassDecoratorContext,
-  ): void;
-  function dispatch(
-    value: (...args: never[]) => unknown,
-    context: ClassMethodDecoratorContext,
-  ): void;
-  function dispatch<T extends new (...args: never[]) => unknown>(target: T): T | undefined;
-  function dispatch(
-    target: object,
-    propertyKey: string | symbol,
-    descriptor?: PropertyDescriptor,
-  ): void;
-  function dispatch(...args: unknown[]): unknown {
-    const isClassDecorator = match(args[1])
-      .with(P.nullish, () => true)
-      .with(tc39ClassPattern, () => true)
-      .otherwise(() => false);
-    const fn = isClassDecorator
-      ? toUnknownCallable(classDecorate)
-      : toUnknownCallable(methodDecorate);
-    return fn(...args);
-  }
-  return dispatch;
+  return dispatchClassOrMethodDecorator(classDecorate, methodDecorate);
 }

--- a/packages/core/src/features/http/routing/index.ts
+++ b/packages/core/src/features/http/routing/index.ts
@@ -11,6 +11,7 @@ export {
   getAuthorizedMetadata,
   getControllerMetadata,
   getControllerMiddlewareMetadata,
+  getControllerSkipMiddlewareMetadata,
   getMethodMiddlewareMetadata,
   getRouteMetadata,
   getSkipMiddlewareMetadata,

--- a/packages/core/src/features/http/routing/route-builder.lib.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.ts
@@ -6,6 +6,7 @@ import {
   ZeltDecoratorUsageError,
   ZeltRouteConfigurationError,
 } from '../../../kernel';
+import type { SkippedMiddlewareSets } from '../middleware';
 import {
   attachSkippedMiddlewares,
   guardMiddleware,
@@ -13,11 +14,7 @@ import {
   resolveMiddleware,
 } from '../middleware';
 import { currentRoles, currentUser } from '../middleware/auth';
-import type {
-  HonoMiddleware,
-  MiddlewareIdentifier,
-  MiddlewareInput,
-} from '../middleware/middleware.types';
+import type { HonoMiddleware, MiddlewareInput } from '../middleware/middleware.types';
 import { setHonoContext } from '../request';
 import { hasBodySource, setBodySource, setPathParams } from '../request/injection';
 import { joinPath } from './path-utils.lib';
@@ -26,6 +23,7 @@ import {
   getAuthorizedMetadata,
   getControllerMetadata,
   getControllerMiddlewareMetadata,
+  getControllerSkipMiddlewareMetadata,
   getMethodMiddlewareMetadata,
   getRouteMetadata,
   getSkipMiddlewareMetadata,
@@ -127,13 +125,18 @@ const collectRouteMiddlewares = (
   );
   const authorizedMeta = getAuthorizedMetadata(controllerClass, methodName);
 
-  const inputs: MiddlewareInput[] = [
-    ...(controllerMeta?.flat() ?? []),
-    ...methodMetas.flatMap((m) => m.middlewares),
-  ];
+  const controllerInputs: MiddlewareInput[] = [...(controllerMeta?.flat() ?? [])];
+  const methodInputs: MiddlewareInput[] = methodMetas.flatMap((m) => m.middlewares);
 
-  const guarded = inputs.map((input) =>
+  const guarded = controllerInputs.map((input) =>
     guardMiddleware(middlewareIdentity(input), resolveMiddleware(input, resolver)),
+  );
+  guarded.push(
+    ...methodInputs.map((input) =>
+      guardMiddleware(middlewareIdentity(input), resolveMiddleware(input, resolver), {
+        skipScope: 'method',
+      }),
+    ),
   );
 
   if (authorizedMeta) {
@@ -146,12 +149,14 @@ const collectRouteMiddlewares = (
 const collectSkippedMiddlewares = (
   controllerClass: ControllerClass,
   methodName: string | symbol,
-): ReadonlySet<MiddlewareIdentifier> =>
-  new Set(
+): SkippedMiddlewareSets => ({
+  classLevel: new Set(getControllerSkipMiddlewareMetadata(controllerClass)),
+  methodLevel: new Set(
     getSkipMiddlewareMetadata(controllerClass)
       .filter((m) => m.methodName === methodName)
       .flatMap((m) => m.skipped),
-  );
+  ),
+});
 
 // Populates the request context store before route-chained middlewares and
 // the controller run. The router-level request injection normally ran

--- a/packages/core/src/features/http/routing/routing-metadata.lib.test.ts
+++ b/packages/core/src/features/http/routing/routing-metadata.lib.test.ts
@@ -10,6 +10,7 @@ import {
   getAuthorizedMetadata,
   getControllerMetadata,
   getControllerMiddlewareMetadata,
+  getControllerSkipMiddlewareMetadata,
   getMethodMiddlewareMetadata,
   getRouteMetadata,
   getSkipMiddlewareMetadata,
@@ -91,6 +92,22 @@ describe('metadata collectors (via decorators)', () => {
     }
 
     expect(getSkipMiddlewareMetadata(Z)).toEqual([{ methodName: 'free', skipped: [MwA] }]);
+  });
+
+  it('collects controller-level SkipMiddleware metadata', () => {
+    class MwA {
+      async use(): Promise<undefined> {
+        return undefined;
+      }
+    }
+    @SkipMiddleware(MwA)
+    @Controller('/z')
+    class Z {
+      @Get('/free')
+      free(): void {}
+    }
+
+    expect(getControllerSkipMiddlewareMetadata(Z)).toEqual([MwA]);
   });
 
   it('collects Authorized metadata per method', () => {

--- a/packages/core/src/features/http/routing/routing-metadata.lib.ts
+++ b/packages/core/src/features/http/routing/routing-metadata.lib.ts
@@ -28,6 +28,8 @@ type MethodMiddlewareMetadata = {
   readonly middlewares: readonly MiddlewareInput[];
 };
 
+type ControllerSkipMiddlewareMetadata = readonly MiddlewareIdentifier[];
+
 type SkipMiddlewareMetadata = {
   readonly methodName: string | symbol;
   readonly skipped: readonly MiddlewareIdentifier[];
@@ -163,6 +165,21 @@ export const getMethodMiddlewareMetadata = (cls: object): readonly MethodMiddlew
     }
   }
   return result;
+};
+
+export const getControllerSkipMiddlewareMetadata = (
+  cls: object,
+): ControllerSkipMiddlewareMetadata => {
+  const meta = getClassMetadata(cls);
+  if (!meta) return [];
+  const skipped: MiddlewareIdentifier[] = [];
+  for (const p of meta.props) {
+    const entry = match(p)
+      .with(skipMiddlewarePattern, (sm) => toMiddlewareIdentifiers(sm.skipped))
+      .otherwise(() => undefined);
+    if (entry) skipped.push(...entry);
+  }
+  return skipped;
 };
 
 export const getSkipMiddlewareMetadata = (cls: object): readonly SkipMiddlewareMetadata[] => {

--- a/packages/decorator-metadata/src/index.ts
+++ b/packages/decorator-metadata/src/index.ts
@@ -18,5 +18,6 @@ export {
   createConfigurableClassDecorator,
   createMethodDecorator,
   createPropertyDecorator,
+  dispatchClassOrMethodDecorator,
   getClassMetadata,
 } from './runtime/index';

--- a/packages/decorator-metadata/src/runtime/decorators.lib.ts
+++ b/packages/decorator-metadata/src/runtime/decorators.lib.ts
@@ -128,6 +128,37 @@ export const createConfigurableClassDecorator = <TOptions extends Record<string,
   return decorate;
 };
 
+export const dispatchClassOrMethodDecorator = (
+  classDecorate: ClassDecoratorFn,
+  methodDecorate: MethodDecoratorFn,
+): ClassDecoratorFn & MethodDecoratorFn => {
+  function dispatch<T extends abstract new (...args: never[]) => unknown>(
+    value: T,
+    context: ClassDecoratorContext,
+  ): void;
+  function dispatch(
+    value: (...args: never[]) => unknown,
+    context: ClassMethodDecoratorContext,
+  ): void;
+  function dispatch<T extends new (...args: never[]) => unknown>(target: T): T | undefined;
+  function dispatch(
+    target: object,
+    propertyKey: string | symbol,
+    descriptor?: PropertyDescriptor,
+  ): void;
+  function dispatch(...args: unknown[]): unknown {
+    const isClassDecorator = match(args[1])
+      .with(P.nullish, () => true)
+      .with(tc39ClassContextPattern, () => true)
+      .otherwise(() => false);
+    const fn = isClassDecorator
+      ? toUnknownCallable(classDecorate)
+      : toUnknownCallable(methodDecorate);
+    return fn(...args);
+  }
+  return dispatch;
+};
+
 type MethodInfo = {
   readonly classKey: object;
   readonly name: string | symbol;

--- a/packages/decorator-metadata/src/runtime/index.ts
+++ b/packages/decorator-metadata/src/runtime/index.ts
@@ -15,6 +15,7 @@ export {
   createConfigurableClassDecorator,
   createMethodDecorator,
   createPropertyDecorator,
+  dispatchClassOrMethodDecorator,
 } from './decorators.lib';
 export type { ClassMeta, MethodMeta, PropertyMeta } from './store.lib';
 export {

--- a/packages/decorator-metadata/src/test/runtime.test.ts
+++ b/packages/decorator-metadata/src/test/runtime.test.ts
@@ -13,6 +13,7 @@ import {
   createClassDecorator,
   createMethodDecorator,
   createPropertyDecorator,
+  dispatchClassOrMethodDecorator,
   getClassMetadata,
   recordClass,
   recordMethod,
@@ -393,6 +394,27 @@ describe('create* options', () => {
       { decorator: 'Controller', basePath: '/users' },
       { decorator: 'UseAuth' },
     ]);
+  });
+
+  it('dispatchClassOrMethodDecorator treats TC39 class contexts without metadata as class decorators', () => {
+    const apply = dispatchClassOrMethodDecorator(
+      createClassDecorator({ decorator: 'Class' }),
+      createMethodDecorator({ decorator: 'Method' }),
+    );
+    class Foo {}
+    const ctx = {
+      kind: 'class',
+      name: 'Foo',
+      addInitializer: () => {},
+    } as unknown as ClassDecoratorContext;
+
+    const result = (apply as unknown as (value: unknown, ctx: ClassDecoratorContext) => unknown)(
+      Foo,
+      ctx,
+    );
+
+    expect(result).toBeUndefined();
+    expect(getClassMetadata(Foo)?.props).toEqual([{ decorator: 'Class' }]);
   });
 
   describe('legacy decorator support', () => {

--- a/website/docs/http-security.md
+++ b/website/docs/http-security.md
@@ -3,7 +3,9 @@
 
 # HTTP Security
 
-Zelt provides built-in HTTP security through two configuration classes: `SecureHeadersConfig` and `CorsConfig`. Both use the `@Config` decorator pattern for type-safe, DI-based configuration.
+Zelt provides built-in HTTP security through two auto-registered middleware classes: `SecureHeadersMiddleware` and `CorsMiddleware`. Both are registered globally on every HTTP app and run on all routes before your configured global middleware.
+
+Configuration is controlled through `SecureHeadersConfig` and `CorsConfig`. Both use the `@Config` decorator pattern for type-safe, DI-based configuration.
 
 - **SecureHeadersConfig** is enabled by default with secure defaults
 - **CorsConfig** is disabled by default (empty origin) and must be explicitly configured
@@ -16,17 +18,17 @@ Security headers are automatically applied to all responses. The default configu
 
 | Header | Default |
 |--------|---------|
-| `Cross-Origin-Resource-Policy` | enabled |
-| `Cross-Origin-Opener-Policy` | enabled |
-| `Origin-Agent-Cluster` | enabled |
-| `Referrer-Policy` | enabled |
-| `Strict-Transport-Security` | enabled |
-| `X-Content-Type-Options` | enabled |
-| `X-DNS-Prefetch-Control` | enabled |
-| `X-Download-Options` | enabled |
-| `X-Frame-Options` | enabled |
-| `X-Permitted-Cross-Domain-Policies` | enabled |
-| `X-XSS-Protection` | enabled |
+| `Cross-Origin-Resource-Policy` | `same-origin` |
+| `Cross-Origin-Opener-Policy` | `same-origin` |
+| `Origin-Agent-Cluster` | `?1` |
+| `Referrer-Policy` | `no-referrer` |
+| `Strict-Transport-Security` | `max-age=15552000; includeSubDomains` |
+| `X-Content-Type-Options` | `nosniff` |
+| `X-DNS-Prefetch-Control` | `off` |
+| `X-Download-Options` | `noopen` |
+| `X-Frame-Options` | `SAMEORIGIN` |
+| `X-Permitted-Cross-Domain-Policies` | `none` |
+| `X-XSS-Protection` | `0` |
 | `X-Powered-By` | removed |
 | `Cross-Origin-Embedder-Policy` | disabled |
 
@@ -118,7 +120,7 @@ class MyCorsConfig extends CorsConfig {
 
 ## Registration
 
-Register custom configs when creating the app:
+The middleware classes are registered automatically. Register custom configs when creating the app:
 
 ```typescript
 import { createApp, Config, CorsConfig, SecureHeadersConfig, Controller, Get, http } from '@zeltjs/core';
@@ -142,3 +144,36 @@ const app = createApp([http({
 ```
 
 The framework automatically detects and uses your custom configuration classes when registered in the `configs` array.
+
+## Skipping Security Middleware
+
+Use `@SkipMiddleware` to skip either built-in middleware for one endpoint or every endpoint in a controller. Method-level and controller-level skips are combined.
+
+```typescript
+import {
+  Controller,
+  CorsMiddleware,
+  Get,
+  SecureHeadersMiddleware,
+  SkipMiddleware,
+} from '@zeltjs/core';
+
+@SkipMiddleware(CorsMiddleware)
+@Controller('/webhook')
+class WebhookController {
+  @Get('/health')
+  health() {
+    return { ok: true };
+  }
+
+  @SkipMiddleware(SecureHeadersMiddleware)
+  @Get('/raw')
+  raw() {
+    return { ok: true };
+  }
+}
+```
+
+In this example, non-preflight requests to `WebhookController` endpoints skip CORS response headers. The `/webhook/raw` endpoint also skips secure headers.
+
+`@SkipMiddleware(CorsMiddleware)` does not disable CORS preflight handling. `OPTIONS` preflight requests are handled by `CorsMiddleware` before an endpoint handler is selected, so the preflight response can still include CORS allow headers. The actual endpoint response is the part that skips `CorsMiddleware`.

--- a/website/docs/middleware.md
+++ b/website/docs/middleware.md
@@ -123,6 +123,35 @@ export class ApiController {
 }
 ```
 
+Apply `@SkipMiddleware` to a controller class to exclude middleware from every route in that controller:
+
+```typescript
+import { Controller, Get, Middleware, SkipMiddleware, type Next } from '@zeltjs/core';
+
+@Middleware
+class AuthMiddleware { async use(next: Next) { await next(); return undefined; } }
+// ---cut---
+@SkipMiddleware(AuthMiddleware)
+@Controller('/public')
+export class PublicController {
+  @Get('/health')
+  health() {
+    return { status: 'ok' };
+  }
+
+  @Get('/version')
+  version() {
+    return { version: '1.0.0' };
+  }
+}
+```
+
+Class-level and method-level skip declarations are combined. If a controller skips `AuthMiddleware` and a method skips `LoggingMiddleware`, that method skips both.
+
+More specific middleware attachment wins over a class-level skip. If a controller has `@SkipMiddleware(AuthMiddleware)` but one method also has `@UseMiddleware(AuthMiddleware)`, `AuthMiddleware` runs for that method. If the same method has both `@UseMiddleware(AuthMiddleware)` and `@SkipMiddleware(AuthMiddleware)`, the method-level skip wins.
+
+`CorsMiddleware` and `SecureHeadersMiddleware` are auto-registered on every HTTP app. See [HTTP Security](./http-security.md) for their defaults, configuration options, skip examples, and CORS preflight behavior.
+
 ## Context Sharing
 
 Middleware can share data with handlers via `setContext()` and `getContext()`.


### PR DESCRIPTION
## Summary

Closes the remaining middleware-scoping gap found during EC-backend dogfooding: `@SkipMiddleware` was method-only, and the auto-registered security middlewares were undocumented.

### Class-level `@SkipMiddleware`

`@SkipMiddleware` can now decorate controller classes. A class-level skip applies to global middlewares, the built-in security middlewares (`CorsMiddleware` / `SecureHeadersMiddleware`), and controller-level `@UseMiddleware` attachments, for every route of the controller.

### Skip precedence: specific scope wins

- A middleware explicitly attached with method-level `@UseMiddleware` **runs** even when the same middleware is skipped at class level — "controller is mostly public, but this one route needs auth" now works instead of silently serving unauthenticated.
- Method-level `@SkipMiddleware` still wins over `@UseMiddleware` on the same method (unchanged).
- Implemented via split skip sets (`classLevel` / `methodLevel`) and a `skipScope` on `guardMiddleware`; registration still never filters middlewares.

### Shared decorator dispatch

The class-vs-method dispatch previously inlined in `UseMiddleware` is extracted as `dispatchClassOrMethodDecorator` in `@zeltjs/decorator-metadata` and reused by both decorators. Class detection now uses the canonical TC39 context pattern, which also fixes a latent misrouting when `context.metadata` is absent.

### Docs

- Default security middleware auto-registration documented (defaults tables verified against source).
- CORS preflight caveat: `@SkipMiddleware(CorsMiddleware)` does not affect OPTIONS preflight responses.
- `middleware.md` / `http-security.md` single-sourced (defaults and config examples live only in http-security.md), precedence rules documented.

## Test plan

- New integration tests: class-level skip across routes, class+method union, method-level `@UseMiddleware` vs class-level skip, same-method skip-vs-use, built-in security middleware skip (asserts `X-Content-Type-Options`).
- New unit tests for controller-level skip metadata and TC39 metadata-absent class dispatch.
- Full precommit gate passed: core 486 tests, decorator-metadata 43 tests, typecheck, lint, website verify:docs (585 blocks).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785765659&installation_id=133048706&pr_number=299&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F299&signature=232a3f9ef4ad343121b7bab1e764917b383c281839fd9e35ee0aa6b5c273f6cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `@SkipMiddleware` がコントローラ全体にも適用できるようになり、配下のルートまとめて中間ウェアを除外できるようになりました。
  * クラスレベルとメソッドレベルのスキップを併用でき、適用範囲に応じた挙動がより明確になりました。
  * セキュリティ関連の中間ウェア設定とスキップ方法の案内を更新しました。

* **Bug Fixes**
  * スキップ対象でも、メソッド側の `UseMiddleware` が期待どおり動作するケースを整理しました。
  * 組み込みのセキュリティヘッダーも、スキップ指定で無効化できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->