### PR TITLE
docs: adapter README API fixes and programmatic AppType generation

### DIFF
--- a/packages/adapter-bun/README.md
+++ b/packages/adapter-bun/README.md
@@ -15,7 +15,7 @@ bun add @zeltjs/adapter-bun @zeltjs/core
 ## Usage
 
 ```typescript
-import { createApp, Controller, Get } from '@zeltjs/core';
+import { createApp, http, Controller, Get } from '@zeltjs/core';
 import { onBun } from '@zeltjs/adapter-bun';
 
 @Controller('/hello')
@@ -26,10 +26,8 @@ class HelloController {
   }
 }
 
-const app = createApp({
-  http: { controllers: [HelloController] },
-});
+const app = createApp([http({ controllers: [HelloController] })]);
 
-const bun = await onBun(app);
-bun.listen(3000);
+const bunApp = await onBun(app);
+bunApp.http.serve({ port: 3000 });
 ```

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -15,7 +15,7 @@ pnpm add @zeltjs/adapter-cloudflare-workers
 ## Usage
 
 ```typescript
-import { createApp, Controller, Get } from '@zeltjs/core';
+import { createApp, http, Controller, Get } from '@zeltjs/core';
 import { onCloudflareWorkers } from '@zeltjs/adapter-cloudflare-workers';
 
 @Controller('/hello')
@@ -26,7 +26,7 @@ class HelloController {
   }
 }
 
-const app = createApp({ controllers: [HelloController] });
+const app = createApp([http({ controllers: [HelloController] })]);
 
 const workers = await onCloudflareWorkers(app);
 
@@ -49,7 +49,7 @@ onCloudflareWorkers(app, {
 `onCloudflareWorkers()` automatically registers `CloudflareWorkersEnvAdaptor`, which reads from the `cloudflare:workers` env. Use `inject(Env)` to access environment variables:
 
 ```typescript
-import { createApp, Controller, Get, Env, inject } from '@zeltjs/core';
+import { createApp, http, Controller, Get, Env, inject } from '@zeltjs/core';
 import { onCloudflareWorkers } from '@zeltjs/adapter-cloudflare-workers';
 
 @Controller('/config')
@@ -62,9 +62,7 @@ class ConfigController {
   }
 }
 
-const app = createApp({
-  http: { controllers: [ConfigController] },
-});
+const app = createApp([http({ controllers: [ConfigController] })]);
 
 const workers = await onCloudflareWorkers(app);
 

--- a/packages/adapter-electron/README.md
+++ b/packages/adapter-electron/README.md
@@ -2,9 +2,9 @@
 
 [![Documentation](https://img.shields.io/badge/docs-zeltjs.com-blue)](https://zeltjs.com)
 
-Electron adapter for Zelt applications.
+Electron adapter for Zelt applications. Your Zelt app runs in the main process; the renderer calls it over IPC with the standard Fetch API shape.
 
-**[Read the Documentation](https://zeltjs.com)**
+**[Read the Documentation](https://zeltjs.com/docs/getting-started/electron)**
 
 ## Installation
 
@@ -14,8 +14,10 @@ npm install @zeltjs/adapter-electron @zeltjs/core
 
 ## Usage
 
+### Main process
+
 ```typescript
-import { createApp, Controller, Get } from '@zeltjs/core';
+import { createApp, http, Controller, Get } from '@zeltjs/core';
 import { onElectron } from '@zeltjs/adapter-electron';
 
 @Controller('/api')
@@ -26,9 +28,34 @@ class ApiController {
   }
 }
 
-const app = createApp({
-  http: { controllers: [ApiController] },
-});
+const app = createApp([http({ controllers: [ApiController] })]);
 
-const electron = await onElectron(app);
+const electronZelt = await onElectron(app, { ipcChannel: 'http://zelt-app' });
 ```
+
+### Preload script
+
+```typescript
+import { exposeIpc } from '@zeltjs/adapter-electron/preload';
+
+exposeIpc({ channel: 'http://zelt-app' });
+```
+
+### Renderer
+
+```typescript
+import { ipcFetch } from '@zeltjs/adapter-electron/renderer';
+
+const response = await ipcFetch('http://zelt-app/api/status', undefined, {
+  channel: 'http://zelt-app',
+});
+const data = await response.json();
+```
+
+The channel string must match across all three layers.
+
+## Learn More
+
+- [Getting Started with Electron](https://zeltjs.com/docs/getting-started/electron) — full walkthrough with electron-vite
+- [IPC Bridge](https://zeltjs.com/docs/electron/ipc-bridge) — channel configuration, `ipcEvent()` access to the underlying `IpcMainInvokeEvent`, type-safe clients with `@zeltjs/hono-client`, shutdown wiring
+- [Window Management](https://zeltjs.com/docs/electron/window-management) — managing BrowserWindows through Zelt DI

--- a/packages/adapter-lambda/README.md
+++ b/packages/adapter-lambda/README.md
@@ -15,7 +15,7 @@ npm install @zeltjs/adapter-lambda @zeltjs/core
 ## Usage
 
 ```typescript
-import { createApp, Controller, Get } from '@zeltjs/core';
+import { createApp, http, Controller, Get } from '@zeltjs/core';
 import { onLambda } from '@zeltjs/adapter-lambda';
 
 @Controller('/hello')
@@ -26,11 +26,9 @@ class HelloController {
   }
 }
 
-const app = createApp({
-  http: { controllers: [HelloController] },
-});
+const app = createApp([http({ controllers: [HelloController] })]);
 
-const lambda = await onLambda(app);
+const lambdaApp = await onLambda(app);
 
-export const handler = lambda.handler;
+export const handler = lambdaApp.handler;
 ```

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -15,10 +15,20 @@ npm install @zeltjs/adapter-node @zeltjs/core
 ## Usage
 
 ```typescript
-import { serve } from '@zeltjs/adapter-node';
-import { createApp } from '@zeltjs/core';
+import { createApp, http, Controller, Get } from '@zeltjs/core';
+import { onNode } from '@zeltjs/adapter-node';
 
-const app = createApp({ controllers: [...] });
+@Controller('/hello')
+class HelloController {
+  @Get('/')
+  greet() {
+    return { message: 'Hello from Node.js!' };
+  }
+}
 
-serve(app, { port: 3000 });
+const app = createApp([http({ controllers: [HelloController] })]);
+
+const nodeApp = await onNode(app);
+const server = await nodeApp.http.listen({ port: 3000 });
+console.log(`Listening on port ${server.address.port}`);
 ```

--- a/website/docs/electron/ipc-bridge.md
+++ b/website/docs/electron/ipc-bridge.md
@@ -139,6 +139,8 @@ export const client = hc<AppType>('http://zelt-app', {
 });
 ```
 
+`AppType` is generated from your app definition — either by the CLI plugin (`zelt build`) or, when your build is driven by electron-vite instead of the Zelt CLI, programmatically via [`GeneratorService.generateFromApp()`](../hono-client#programmatic-generation). For renderer code that cannot import from the main process build output, generate with `portable: true`.
+
 ## Accessing the IPC Event
 
 In controllers, use `ipcEvent()` to access the underlying `IpcMainInvokeEvent`:

--- a/website/docs/hono-client.md
+++ b/website/docs/hono-client.md
@@ -63,6 +63,35 @@ pnpm zelt build
 
 This generates `<outDir>/<output>` (default: `generated/app-type.ts`) containing the `AppType`.
 
+## Programmatic Generation
+
+When your build is not driven by the Zelt CLI — an electron-vite pipeline, a custom build script, a monorepo task runner — use `GeneratorService.generateFromApp()` directly. It takes the `http` feature of your app and returns the generated type source as a string:
+
+```typescript
+import { createApp, http } from '@zeltjs/core';
+import { GeneratorService } from '@zeltjs/hono-client';
+declare function writeFileSync(path: string, data: string, encoding: 'utf-8'): void;
+const app = createApp([http({ controllers: [] })]);
+// ---cut---
+const generator = new GeneratorService();
+const content = await generator.generateFromApp(app.http, { distDir: './dist' });
+
+writeFileSync('./dist/app-type.generated.ts', content, 'utf-8');
+```
+
+Run this as a build step after your app modules are compiled — for example a script executed by `node` against the built output, or an electron-vite `buildStart` hook.
+
+### Generate Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `distDir` | `string` | Directory of the built app output; generated imports are resolved against it |
+| `portable` | `boolean` | Emit a self-contained type file with resolved literal types instead of imports into `distDir` |
+| `tsconfig` | `string` | Path to the project tsconfig (required when `portable: true`) |
+| `projectRoot` | `string` | Project root for path resolution (required when `portable: true`) |
+
+Use `portable: true` when the generated file is consumed outside the server package — for example an Electron renderer or a separate frontend workspace that cannot import from the server's `dist`.
+
 ### Generated app-type.ts
 
 ```typescript


### PR DESCRIPTION
## Summary

Resolves the remaining Electron-adapter docs feedback: usage docs coverage and stale README examples. Docs-only change — no runtime code touched.

### Adapter READMEs updated to the current API

All five adapter READMEs still showed the legacy `createApp({ http: ... })` / `createApp({ controllers })` shape:

- **adapter-electron**: rewritten with `createApp([http(...)])` and the full main / preload / renderer trio (`onElectron` + `exposeIpc` + `ipcFetch`), linking to the Electron guides including `ipcEvent()`
- **adapter-node / bun / cloudflare-workers / lambda**: same stale examples fixed; entry APIs verified against source (`onNode().http.listen({ port })`, `onBun().http.serve({ port })`, `workers.fetch`, `lambdaApp.handler`)

### Programmatic AppType generation documented

`website/docs/hono-client.md` gains a **Programmatic Generation** section: `GeneratorService.generateFromApp(app.http, { distDir })` for builds not driven by the Zelt CLI (electron-vite pipelines, custom scripts), with the Standard/Portable options table (`portable: true` + `tsconfig` + `projectRoot` for consumers that cannot import from the server's `dist`).

`website/docs/electron/ipc-bridge.md`'s hono-client section now links to that generation flow instead of leaving `AppType` as an unexplained stub.

## Test plan

- `pnpm --filter website verify:docs` — 584 doc blocks type-checked (the new `generateFromApp` example compiles against the real `@zeltjs/hono-client` types), 10 excerpt checks OK
- Full precommit gate passed (typecheck, lint, build, tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785767080&installation_id=133048706&pr_number=300&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F300&signature=207cb6fe8fa8fc13a0493d4ce585f3604c3f0d2f6d33bfbdec93a79e5bfe2c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->