### PR TITLE
feat(adapter-electron): multi-feature transport bindings for onElectron

### DIFF
--- a/packages/adapter-electron/README.md
+++ b/packages/adapter-electron/README.md
@@ -54,6 +54,33 @@ const data = await response.json();
 
 The channel string must match across all three layers.
 
+### Multiple HTTP features
+
+Configure additional named `http()` features alongside the renderer-facing one:
+
+```typescript
+const app = createApp([
+  http({ controllers: [ApiController] }),
+  http({ name: 'mcp', controllers: [McpController] }),
+]);
+
+const electronZelt = await onElectron(app);
+```
+
+By default the `http` feature is bound to the IPC bridge; pass `ipcFeature` to bind a different one instead:
+
+```typescript
+const electronZelt = await onElectron(app, { ipcFeature: 'mcp' });
+```
+
+Any other feature can be served over TCP instead of IPC — handy for exposing an MCP server or other external API from the same runtime and shared services, keeping only the router and trust boundary separate from the renderer-facing API:
+
+```typescript
+await electronZelt.mcp.listen({ port: 8765, hostname: '127.0.0.1' });
+```
+
+Breaking change: the old `electronZelt.fetch` shorthand is gone — use `electronZelt.http.fetch` instead.
+
 ## Learn More
 
 - [Getting Started with Electron](https://zeltjs.com/docs/getting-started/electron) — full walkthrough with electron-vite

--- a/packages/adapter-electron/package.json
+++ b/packages/adapter-electron/package.json
@@ -53,6 +53,7 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
+    "@zeltjs/adapter-node": "workspace:*",
     "@zeltjs/core": "workspace:*",
     "ts-pattern": "5.7.1"
   },

--- a/packages/adapter-electron/src/main/index.ts
+++ b/packages/adapter-electron/src/main/index.ts
@@ -3,7 +3,12 @@ export { ElectronEnvAdaptor } from './electron-env.adaptor';
 export { ElectronWindowRegistryService } from './electron-window-registry.service';
 export { ElectronWindowRuntimeService } from './electron-window-runtime.service';
 export { ipcEvent, setupIpcBridge, toIpcResponse, toRequest } from './ipc-bridge';
-export { type ElectronAppOptions, type OnElectronApp, onElectron } from './on-electron';
+export {
+  type ElectronAppOptions,
+  type OnElectronApp,
+  onElectron,
+  ZeltElectronIpcFeatureNotFoundError,
+} from './on-electron';
 export type {
   WindowDefinition,
   WindowHandle,

--- a/packages/adapter-electron/src/main/on-electron.exceptions.ts
+++ b/packages/adapter-electron/src/main/on-electron.exceptions.ts
@@ -1,0 +1,13 @@
+type ZeltElectronIpcFeatureNotFoundContext = { readonly ipcFeature: string };
+
+/** No HttpFeature matches the `ipcFeature` key requested for IPC binding. */
+export class ZeltElectronIpcFeatureNotFoundError extends Error {
+  override readonly name = 'ZeltElectronIpcFeatureNotFoundError';
+  readonly context: ZeltElectronIpcFeatureNotFoundContext;
+
+  constructor(context: ZeltElectronIpcFeatureNotFoundContext) {
+    super(`No HttpFeature registered with key "${context.ipcFeature}" to bind to the IPC bridge`);
+    this.context = context;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/packages/adapter-electron/src/main/on-electron.test.ts
+++ b/packages/adapter-electron/src/main/on-electron.test.ts
@@ -93,6 +93,7 @@ describe('onElectron', () => {
 
         expect(electronApp.mcp).toHaveProperty('listen');
         expect('listen' in electronApp).toBe(false);
+        expect('fetch' in electronApp).toBe(false);
       } finally {
         await electronApp.shutdown();
       }
@@ -142,6 +143,7 @@ describe('onElectron', () => {
   describe('missing ipcFeature', () => {
     it('rejects with ZeltElectronIpcFeatureNotFoundError when no feature matches the key', async () => {
       await expect(
+        // @ts-expect-error runtime safety-net test: 'does-not-exist' is not a configured feature key.
         onElectron(createMultiFeatureApp(), { ipcFeature: 'does-not-exist' }),
       ).rejects.toThrow(ZeltElectronIpcFeatureNotFoundError);
     });
@@ -153,12 +155,33 @@ describe('onElectron', () => {
 
       const app = createApp([http({ controllers: [HttpOnlyController] }), mcpFeature]);
 
-      await expect(onElectron(app, { ipcFeature: 'does-not-exist' })).rejects.toThrow(
-        ZeltElectronIpcFeatureNotFoundError,
-      );
+      await expect(
+        // @ts-expect-error runtime safety-net test: 'does-not-exist' is not a configured feature key.
+        onElectron(app, { ipcFeature: 'does-not-exist' }),
+      ).rejects.toThrow(ZeltElectronIpcFeatureNotFoundError);
 
       expect(shutdownSpy).toHaveBeenCalled();
     });
+
+    it('rejects with AggregateError when cleanup shutdown also fails', async () => {
+      const mcpFeature = http({ name: 'mcp' as const, controllers: [McpOnlyController] });
+      mcpFeature.registerShutdown(() => {
+        throw new Error('shutdown callback failed');
+      });
+
+      const app = createApp([http({ controllers: [HttpOnlyController] }), mcpFeature]);
+
+      await expect(
+        // @ts-expect-error runtime safety-net test: 'does-not-exist' is not a configured feature key.
+        onElectron(app, { ipcFeature: 'does-not-exist' }),
+      ).rejects.toThrow(AggregateError);
+    });
+
+    const _assertIpcFeatureMustMatchConfiguredKeys = (): void => {
+      // @ts-expect-error 'nope' is not a key of any HttpFeature configured on this app.
+      void onElectron(createMultiFeatureApp(), { ipcFeature: 'nope' });
+    };
+    void _assertIpcFeatureMustMatchConfiguredKeys;
   });
 
   describe('shutdown', () => {

--- a/packages/adapter-electron/src/main/on-electron.test.ts
+++ b/packages/adapter-electron/src/main/on-electron.test.ts
@@ -1,0 +1,175 @@
+import { Controller, createApp, Get, http } from '@zeltjs/core';
+import type { IpcMainInvokeEvent } from 'electron';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { IpcFetchRequest, IpcFetchResponse } from '../shared/ipc.types';
+import { onElectron } from './on-electron';
+import { ZeltElectronIpcFeatureNotFoundError } from './on-electron.exceptions';
+
+type IpcHandler = (event: IpcMainInvokeEvent, payload: IpcFetchRequest) => unknown;
+
+const createFakeIpcMain = () => {
+  const handlers = new Map<string, IpcHandler>();
+  const removedChannels: string[] = [];
+  return {
+    handlers,
+    removedChannels,
+    ipcMain: {
+      handle: (channel: string, listener: IpcHandler) => {
+        handlers.set(channel, listener);
+      },
+      removeHandler: (channel: string) => {
+        handlers.delete(channel);
+        removedChannels.push(channel);
+      },
+    },
+    invoke: (channel: string, payload: IpcFetchRequest): Promise<IpcFetchResponse> => {
+      const handler = handlers.get(channel);
+      if (handler === undefined) throw new Error(`no ipcMain handler registered for ${channel}`);
+      return handler({} as IpcMainInvokeEvent, payload) as Promise<IpcFetchResponse>;
+    },
+  };
+};
+
+let fakeIpcMain = createFakeIpcMain();
+
+vi.mock('electron', () => ({
+  get app() {
+    return { whenReady: () => Promise.resolve(), quit: () => {} };
+  },
+  get ipcMain() {
+    return fakeIpcMain.ipcMain;
+  },
+  BrowserWindow: class {},
+  dialog: {},
+  Menu: class {},
+  protocol: {},
+  screen: {},
+  shell: {},
+}));
+
+const getRequest = (path: string): IpcFetchRequest => ({
+  method: 'GET',
+  path,
+  headers: [],
+  body: { kind: 'none' },
+});
+
+@Controller('/')
+class HttpOnlyController {
+  @Get('/http-only')
+  getHttpOnly() {
+    return { scope: 'http' };
+  }
+}
+
+@Controller('/')
+class McpOnlyController {
+  @Get('/mcp-only')
+  getMcpOnly() {
+    return { scope: 'mcp' };
+  }
+}
+
+const createMultiFeatureApp = () =>
+  createApp([
+    http({ controllers: [HttpOnlyController] }),
+    http({ name: 'mcp' as const, controllers: [McpOnlyController] }),
+  ]);
+
+describe('onElectron', () => {
+  beforeEach(() => {
+    fakeIpcMain = createFakeIpcMain();
+  });
+
+  describe('default ipcFeature binding', () => {
+    it('binds the http feature to the IPC channel and exposes other features as listen namespaces', async () => {
+      const electronApp = await onElectron(createMultiFeatureApp());
+
+      try {
+        const response = await fakeIpcMain.invoke('http://zelt-ipc', getRequest('/http-only'));
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ kind: 'text', value: JSON.stringify({ scope: 'http' }) });
+
+        expect(electronApp.mcp).toHaveProperty('listen');
+        expect('listen' in electronApp).toBe(false);
+      } finally {
+        await electronApp.shutdown();
+      }
+    });
+  });
+
+  describe('mcp.listen', () => {
+    it('serves the mcp feature over a real TCP listener while the http feature stays IPC-only', async () => {
+      const electronApp = await onElectron(createMultiFeatureApp());
+
+      try {
+        const handle = await electronApp.mcp.listen({ port: 0, hostname: '127.0.0.1' });
+
+        try {
+          const mcpOk = await fetch(`http://127.0.0.1:${handle.address.port}/mcp-only`);
+          expect(mcpOk.status).toBe(200);
+          await expect(mcpOk.json()).resolves.toEqual({ scope: 'mcp' });
+
+          const httpMiss = await fetch(`http://127.0.0.1:${handle.address.port}/http-only`);
+          expect(httpMiss.status).toBe(404);
+        } finally {
+          await handle.shutdown();
+        }
+      } finally {
+        await electronApp.shutdown();
+      }
+    });
+  });
+
+  describe('ipcFeature option', () => {
+    it('binds the requested feature key to the IPC channel instead of the default http feature', async () => {
+      const electronApp = await onElectron(createMultiFeatureApp(), { ipcFeature: 'mcp' });
+
+      try {
+        const response = await fakeIpcMain.invoke('http://zelt-ipc', getRequest('/mcp-only'));
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ kind: 'text', value: JSON.stringify({ scope: 'mcp' }) });
+
+        const httpMiss = await fakeIpcMain.invoke('http://zelt-ipc', getRequest('/http-only'));
+        expect(httpMiss.status).toBe(404);
+      } finally {
+        await electronApp.shutdown();
+      }
+    });
+  });
+
+  describe('missing ipcFeature', () => {
+    it('rejects with ZeltElectronIpcFeatureNotFoundError when no feature matches the key', async () => {
+      await expect(
+        onElectron(createMultiFeatureApp(), { ipcFeature: 'does-not-exist' }),
+      ).rejects.toThrow(ZeltElectronIpcFeatureNotFoundError);
+    });
+
+    it('shuts down the already-started runtime instead of leaking it', async () => {
+      const shutdownSpy = vi.fn();
+      const mcpFeature = http({ name: 'mcp' as const, controllers: [McpOnlyController] });
+      mcpFeature.registerShutdown(shutdownSpy);
+
+      const app = createApp([http({ controllers: [HttpOnlyController] }), mcpFeature]);
+
+      await expect(onElectron(app, { ipcFeature: 'does-not-exist' })).rejects.toThrow(
+        ZeltElectronIpcFeatureNotFoundError,
+      );
+
+      expect(shutdownSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('shutdown', () => {
+    it('removes the IPC handler and closes listening servers registered via feature shutdown', async () => {
+      const electronApp = await onElectron(createMultiFeatureApp());
+      const handle = await electronApp.mcp.listen({ port: 0, hostname: '127.0.0.1' });
+
+      await electronApp.shutdown();
+
+      expect(fakeIpcMain.removedChannels).toContain('http://zelt-ipc');
+      await expect(fetch(`http://127.0.0.1:${handle.address.port}/mcp-only`)).rejects.toThrow();
+    });
+  });
+});

--- a/packages/adapter-electron/src/main/on-electron.ts
+++ b/packages/adapter-electron/src/main/on-electron.ts
@@ -1,13 +1,21 @@
+import type { ListenOptions, ServerHandle } from '@zeltjs/adapter-node';
+import { createListenForHttp } from '@zeltjs/adapter-node';
 import type {
   ConfigClass,
   ConfiguredFeature,
-  CreateRuntimeOptions,
-  HttpCapabilities,
+  FeatureApp,
+  FeatureReadyCapabilities,
   RuntimeApp,
 } from '@zeltjs/core';
+import { HTTP_FEATURE_KEY, HttpFeature } from '@zeltjs/core';
+
 import { ElectronAdaptor } from './electron.adaptor';
 import { ElectronEnvAdaptor } from './electron-env.adaptor';
 import { setupIpcBridge } from './ipc-bridge';
+import { ZeltElectronIpcFeatureNotFoundError } from './on-electron.exceptions';
+
+export type { ServerHandle } from '@zeltjs/adapter-node';
+export { ZeltElectronIpcFeatureNotFoundError } from './on-electron.exceptions';
 
 type IpcChannel = `http://${string}` | `https://${string}`;
 
@@ -15,46 +23,125 @@ export type ElectronAppOptions = {
   readonly configs?: readonly ConfigClass<object>[];
   readonly warmup?: boolean;
   readonly ipcChannel?: IpcChannel;
+  readonly ipcFeature?: string;
 };
 
-type HttpRuntimeApp = RuntimeApp<readonly ConfiguredFeature[]> & {
-  readonly http: HttpCapabilities;
-};
-
-type HttpApp = {
-  readonly createRuntime: (options?: CreateRuntimeOptions) => Promise<HttpRuntimeApp>;
-};
-
-export type OnElectronApp = {
-  readonly get: HttpRuntimeApp['get'];
-  readonly fetch: (request: Request) => Promise<Response>;
+type EnvironmentElectronAppPart = {
   readonly shutdown: () => Promise<void>;
 };
 
+type HttpElectronAppPart = {
+  readonly listen: (portOrOptions?: number | ListenOptions) => Promise<ServerHandle>;
+};
+
+type ElectronFeatureCapabilities<TFeature extends ConfiguredFeature> =
+  FeatureReadyCapabilities<TFeature> &
+    (TFeature extends HttpFeature<string> ? HttpElectronAppPart : unknown);
+
+type ElectronNamespacedCapabilities<F extends readonly ConfiguredFeature[]> = {
+  readonly [TFeature in F[number] as TFeature['key']]: ElectronFeatureCapabilities<TFeature>;
+};
+
+export type OnElectronApp = RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentElectronAppPart;
+
+type ElectronAppForFeatures<F extends readonly ConfiguredFeature[]> = RuntimeApp<F> &
+  EnvironmentElectronAppPart &
+  ElectronNamespacedCapabilities<F>;
+
 const DEFAULT_IPC_CHANNEL = 'http://zelt-ipc';
 
-/** @throws {ZeltContextNotAvailableError} */
-export const onElectron = async (
-  app: HttpApp,
+// warmup already started feature-owned resources (e.g. DB connections); any setup failure
+// after createRuntime() must tear them down via cleanup so they aren't left leaked.
+/** @throws {AggregateError} */
+const withCleanupOnError = async <T>(
+  cleanup: () => Promise<void>,
+  body: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await body();
+  } catch (error) {
+    try {
+      await cleanup();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        'onElectron setup failed and runtime shutdown also failed',
+      );
+    }
+    throw error;
+  }
+};
+
+const createElectronApp = (
+  readyApp: RuntimeApp<readonly ConfiguredFeature[]>,
+  shutdown: () => Promise<void>,
+): OnElectronApp => {
+  const base: RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentElectronAppPart = {
+    ...readyApp,
+    shutdown,
+  };
+
+  const electronApp: OnElectronApp = { ...base };
+
+  for (const entry of readyApp.getFeatureEntries(HttpFeature)) {
+    Object.defineProperty(electronApp, entry.key, {
+      value: {
+        ...entry.capabilities,
+        listen: createListenForHttp(entry.capabilities.fetch, (callback) =>
+          entry.feature.registerShutdown(callback),
+        ),
+      },
+      configurable: true,
+      enumerable: true,
+    });
+  }
+
+  return electronApp;
+};
+
+export function onElectron<const F extends readonly ConfiguredFeature[]>(
+  app: FeatureApp<F>,
+  options?: ElectronAppOptions,
+): Promise<ElectronAppForFeatures<F>>;
+
+/** @throws {ZeltContextNotAvailableError | ZeltElectronIpcFeatureNotFoundError | AggregateError} */
+export async function onElectron<const F extends readonly ConfiguredFeature[]>(
+  app: FeatureApp<F>,
   options: ElectronAppOptions = {},
-): Promise<OnElectronApp> => {
+): Promise<OnElectronApp> {
   const readyApp = await app.createRuntime({
     ...(options.configs === undefined ? {} : { configs: options.configs }),
     fallbackConfigs: [ElectronEnvAdaptor],
     warmup: options.warmup ?? true,
   });
 
-  const electronApp = await readyApp.get(ElectronAdaptor);
-  const channel = options.ipcChannel ?? DEFAULT_IPC_CHANNEL;
+  return withCleanupOnError(
+    () => readyApp.shutdown(),
+    async () => {
+      const ipcFeature = options.ipcFeature ?? HTTP_FEATURE_KEY;
+      const ipcEntry = readyApp
+        .getFeatureEntries(HttpFeature)
+        .find((entry) => entry.key === ipcFeature);
 
-  const removeIpcHandler = setupIpcBridge(electronApp.ready.ipcMain, readyApp.http.fetch, channel);
+      if (ipcEntry === undefined) {
+        throw new ZeltElectronIpcFeatureNotFoundError({ ipcFeature });
+      }
 
-  return {
-    get: readyApp.get,
-    fetch: readyApp.http.fetch,
-    shutdown: async () => {
-      removeIpcHandler();
-      await readyApp.shutdown();
+      const electronAdaptor = await readyApp.get(ElectronAdaptor);
+      const channel = options.ipcChannel ?? DEFAULT_IPC_CHANNEL;
+
+      const removeIpcHandler = setupIpcBridge(
+        electronAdaptor.ready.ipcMain,
+        ipcEntry.capabilities.fetch,
+        channel,
+      );
+
+      const shutdown = async (): Promise<void> => {
+        removeIpcHandler();
+        await readyApp.shutdown();
+      };
+
+      return createElectronApp(readyApp, shutdown);
     },
-  };
-};
+  );
+}

--- a/packages/adapter-electron/src/main/on-electron.ts
+++ b/packages/adapter-electron/src/main/on-electron.ts
@@ -19,12 +19,17 @@ export { ZeltElectronIpcFeatureNotFoundError } from './on-electron.exceptions';
 
 type IpcChannel = `http://${string}` | `https://${string}`;
 
-export type ElectronAppOptions = {
+export type ElectronAppOptions<TIpcFeature extends string = string> = {
   readonly configs?: readonly ConfigClass<object>[];
   readonly warmup?: boolean;
   readonly ipcChannel?: IpcChannel;
-  readonly ipcFeature?: string;
+  readonly ipcFeature?: TIpcFeature;
 };
+
+type HttpFeatureKeys<F extends readonly ConfiguredFeature[]> = Extract<
+  F[number],
+  HttpFeature<string>
+>['key'];
 
 type EnvironmentElectronAppPart = {
   readonly shutdown: () => Promise<void>;
@@ -101,7 +106,7 @@ const createElectronApp = (
 
 export function onElectron<const F extends readonly ConfiguredFeature[]>(
   app: FeatureApp<F>,
-  options?: ElectronAppOptions,
+  options?: ElectronAppOptions<HttpFeatureKeys<F>>,
 ): Promise<ElectronAppForFeatures<F>>;
 
 /** @throws {ZeltContextNotAvailableError | ZeltElectronIpcFeatureNotFoundError | AggregateError} */
@@ -115,8 +120,15 @@ export async function onElectron<const F extends readonly ConfiguredFeature[]>(
     warmup: options.warmup ?? true,
   });
 
+  // declared outside the body so cleanup can remove the IPC handler even if a step
+  // after setupIpcBridge (e.g. createElectronApp) throws before onElectron returns.
+  let removeIpcHandler: (() => void) | undefined;
+
   return withCleanupOnError(
-    () => readyApp.shutdown(),
+    async () => {
+      removeIpcHandler?.();
+      await readyApp.shutdown();
+    },
     async () => {
       const ipcFeature = options.ipcFeature ?? HTTP_FEATURE_KEY;
       const ipcEntry = readyApp
@@ -130,14 +142,14 @@ export async function onElectron<const F extends readonly ConfiguredFeature[]>(
       const electronAdaptor = await readyApp.get(ElectronAdaptor);
       const channel = options.ipcChannel ?? DEFAULT_IPC_CHANNEL;
 
-      const removeIpcHandler = setupIpcBridge(
+      removeIpcHandler = setupIpcBridge(
         electronAdaptor.ready.ipcMain,
         ipcEntry.capabilities.fetch,
         channel,
       );
 
       const shutdown = async (): Promise<void> => {
-        removeIpcHandler();
+        removeIpcHandler?.();
         await readyApp.shutdown();
       };
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -36,6 +36,14 @@ console.log(`Listening on port ${server.address.port}`);
 Each named `http()` feature gets its own namespace with an independent `listen()`, sharing the same runtime and services:
 
 ```typescript
+@Controller('/admin')
+class AdminController {
+  @Get('/')
+  status() {
+    return { admin: true };
+  }
+}
+
 const app = createApp([
   http({ controllers: [HelloController] }),
   http({ name: 'admin', controllers: [AdminController] }),

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -32,3 +32,16 @@ const nodeApp = await onNode(app);
 const server = await nodeApp.http.listen({ port: 3000 });
 console.log(`Listening on port ${server.address.port}`);
 ```
+
+Each named `http()` feature gets its own namespace with an independent `listen()`, sharing the same runtime and services:
+
+```typescript
+const app = createApp([
+  http({ controllers: [HelloController] }),
+  http({ name: 'admin', controllers: [AdminController] }),
+]);
+
+const nodeApp = await onNode(app);
+await nodeApp.http.listen(3000);
+await nodeApp.admin.listen(8080);
+```

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -1,4 +1,6 @@
 export { createAdaptorServer } from '@hono/node-server';
+export type { ListenOptions } from './listen.lib';
+export { createListenForHttp } from './listen.lib';
 export { NodeCliConfig } from './node-cli.config';
 export type { ServerHandle } from './on-node';
 export { onNode } from './on-node';

--- a/packages/adapter-node/src/listen.lib.ts
+++ b/packages/adapter-node/src/listen.lib.ts
@@ -1,0 +1,42 @@
+import type { ServerType } from '@hono/node-server';
+import { serve } from '@hono/node-server';
+
+export type ListenOptions = {
+  readonly port?: number;
+  readonly hostname?: string;
+};
+
+export type ServerHandle = {
+  readonly address: { port: number; address: string };
+  readonly shutdown: () => Promise<void>;
+};
+
+const closeServer = (server: ServerType): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+
+export const createListenForHttp = (
+  appFetch: (request: Request) => Promise<Response>,
+  registerShutdown: (callback: () => Promise<void>) => () => Promise<void>,
+): ((portOrOptions?: number | ListenOptions) => Promise<ServerHandle>) => {
+  return async (portOrOptions?: number | ListenOptions): Promise<ServerHandle> => {
+    const listenOptions: ListenOptions =
+      typeof portOrOptions === 'number' ? { port: portOrOptions } : (portOrOptions ?? {});
+
+    const port = listenOptions.port ?? 3000;
+    const hostname = listenOptions.hostname ?? '0.0.0.0';
+
+    let server!: ServerType;
+    const serverReady = new Promise<{ port: number; address: string }>((resolve) => {
+      server = serve({ fetch: appFetch, port, hostname }, (info) =>
+        resolve({ port: info.port, address: info.address }),
+      );
+    });
+    const shutdown = registerShutdown(() => closeServer(server));
+
+    const address = await serverReady;
+
+    return { address, shutdown };
+  };
+};

--- a/packages/adapter-node/src/listen.lib.ts
+++ b/packages/adapter-node/src/listen.lib.ts
@@ -16,6 +16,7 @@ const closeServer = (server: ServerType): Promise<void> =>
     server.close((err) => (err ? reject(err) : resolve()));
   });
 
+/** @throws {Error} propagates the server's bind error (e.g. EADDRINUSE) instead of hanging */
 export const createListenForHttp = (
   appFetch: (request: Request) => Promise<Response>,
   registerShutdown: (callback: () => Promise<void>) => () => Promise<void>,
@@ -28,14 +29,17 @@ export const createListenForHttp = (
     const hostname = listenOptions.hostname ?? '0.0.0.0';
 
     let server!: ServerType;
-    const serverReady = new Promise<{ port: number; address: string }>((resolve) => {
-      server = serve({ fetch: appFetch, port, hostname }, (info) =>
-        resolve({ port: info.port, address: info.address }),
-      );
+    const serverReady = new Promise<{ port: number; address: string }>((resolve, reject) => {
+      const onError = (err: Error): void => reject(err);
+      server = serve({ fetch: appFetch, port, hostname }, (info) => {
+        server.off('error', onError);
+        resolve({ port: info.port, address: info.address });
+      });
+      server.once('error', onError);
     });
-    const shutdown = registerShutdown(() => closeServer(server));
 
     const address = await serverReady;
+    const shutdown = registerShutdown(() => closeServer(server));
 
     return { address, shutdown };
   };

--- a/packages/adapter-node/src/on-node.test.ts
+++ b/packages/adapter-node/src/on-node.test.ts
@@ -271,6 +271,24 @@ describe('onNode with HTTP', () => {
     expect(res.status).toBe(200);
   });
 
+  it('rejects instead of hanging when the port is already in use', async () => {
+    @Controller('/')
+    class ConflictController {
+      @Get('/')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([http({ controllers: [ConflictController] })]);
+    nodeApp = await onNode(app);
+
+    if (!isHttpNodeApp(nodeApp)) throw new Error('expected listen');
+    handle = await nodeApp.http.listen(0);
+
+    await expect(nodeApp.http.listen(handle.address.port)).rejects.toThrow();
+  });
+
   it('listens on each named HTTP namespace independently', async () => {
     @Controller('/')
     class PublicController {

--- a/packages/adapter-node/src/on-node.ts
+++ b/packages/adapter-node/src/on-node.ts
@@ -1,5 +1,3 @@
-import type { ServerType } from '@hono/node-server';
-import { serve } from '@hono/node-server';
 import type {
   ConfigClass,
   ConfiguredFeature,
@@ -9,18 +7,12 @@ import type {
 } from '@zeltjs/core';
 import { HttpFeature } from '@zeltjs/core';
 
+import type { ListenOptions, ServerHandle } from './listen.lib';
+import { createListenForHttp } from './listen.lib';
 import { NodeCliConfig } from './node-cli.config';
 import { ProcessEnvAdaptor } from './process-env.adaptor';
 
-type ListenOptions = {
-  readonly port?: number;
-  readonly hostname?: string;
-};
-
-export type ServerHandle = {
-  readonly address: { port: number; address: string };
-  readonly shutdown: () => Promise<void>;
-};
+export type { ServerHandle } from './listen.lib';
 
 export type NodeAppOptions = {
   readonly configs?: readonly ConfigClass<object>[];
@@ -51,36 +43,6 @@ export type NodeApp = RuntimeApp<readonly ConfiguredFeature[]> & EnvironmentNode
 type NodeAppForFeatures<F extends readonly ConfiguredFeature[]> = RuntimeApp<F> &
   EnvironmentNodeAppPart &
   NodeNamespacedCapabilities<F>;
-
-const closeServer = (server: ServerType): Promise<void> =>
-  new Promise<void>((resolve, reject) => {
-    server.close((err) => (err ? reject(err) : resolve()));
-  });
-
-const createListenForHttp = (
-  appFetch: (request: Request) => Promise<Response>,
-  registerShutdown: (callback: () => Promise<void>) => () => Promise<void>,
-): ((portOrOptions?: number | ListenOptions) => Promise<ServerHandle>) => {
-  return async (portOrOptions?: number | ListenOptions): Promise<ServerHandle> => {
-    const listenOptions: ListenOptions =
-      typeof portOrOptions === 'number' ? { port: portOrOptions } : (portOrOptions ?? {});
-
-    const port = listenOptions.port ?? 3000;
-    const hostname = listenOptions.hostname ?? '0.0.0.0';
-
-    let server!: ServerType;
-    const serverReady = new Promise<{ port: number; address: string }>((resolve) => {
-      server = serve({ fetch: appFetch, port, hostname }, (info) =>
-        resolve({ port: info.port, address: info.address }),
-      );
-    });
-    const shutdown = registerShutdown(() => closeServer(server));
-
-    const address = await serverReady;
-
-    return { address, shutdown };
-  };
-};
 
 const getArgs = (): readonly string[] => globalThis.process.argv.slice(2);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
 
   packages/adapter-electron:
     dependencies:
+      '@zeltjs/adapter-node':
+        specifier: workspace:*
+        version: link:../adapter-node
       '@zeltjs/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

`onElectron` previously assumed a single `http` feature bound to the Electron IPC bridge. Apps that also need to expose an HTTP server over TCP from the main process (e.g. an MCP server for external clients) had no way to do so without creating a second runtime — splitting DI container and service instances.

This PR aligns `onElectron` with `onNode`'s multi-feature namespace structure so a single runtime can expose multiple `http()` features over different transports:

```ts
const app = createApp([
  http({ controllers: [ApiController] }),          // renderer-facing (IPC)
  http({ name: 'mcp', controllers: [McpController] }), // external (TCP)
]);

const electronApp = await onElectron(app);          // http → IPC bridge
await electronApp.mcp.listen({ port: 8765, hostname: '127.0.0.1' });
```

One runtime, shared services; only the routers and trust boundaries are separated.

## Changes

- **adapter-node**: extract `createListenForHttp` into `listen.lib.ts` and export it (plus `ListenOptions`) so other Node-runtime adapters can reuse it. No behavior change.
- **adapter-electron**:
  - `onElectron` is now generic over the configured features and exposes per-feature-key namespaced capabilities with `listen()`, mirroring `onNode`.
  - New `ipcFeature` option selects which feature key is bound to the IPC bridge (default `'http'`, backward compatible).
  - Fail fast with `ZeltElectronIpcFeatureNotFoundError` when the requested key has no matching feature; the warmed-up runtime is shut down before rethrowing (no leaked resources), with `AggregateError` preserving both errors if shutdown also fails.
  - Depends on `@zeltjs/adapter-node` for the shared listen helper.
- **docs**: README sections for multi-transport usage in both adapters.

## Breaking change

The top-level `fetch` shorthand returned by `onElectron` is removed. Use `app.<key>.fetch` (e.g. `electronApp.http.fetch`) instead.

## Testing

- adapter-electron: 32 tests (new `on-electron.test.ts` covers IPC binding default/override, TCP listen isolation per feature, missing-feature failure incl. runtime teardown, shutdown removing the IPC handler and closing listeners; namespace typing is exercised without casts so type inference is compile-checked)
- adapter-node: 29 tests (regression)
- typecheck, eslint, oxlint clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785812616&installation_id=133048706&pr_number=301&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F301&signature=60085512d86fbccde8d6c26065e8005b3b96e9110eda32b6ffc610255484f32b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Electron と Node で、複数の HTTP 機能を同時に扱えるようになりました。
  * 各機能を個別に起動できる `listen()` 形式が使えるようになりました。
  * Electron で接続先の機能を切り替えられるようになりました。

* **Bug Fixes**
  * 起動失敗時や終了時の後始末がより確実になりました。
  * 存在しない機能を指定した場合、わかりやすく失敗するようになりました。

* **Documentation**
  * 複数機能の構成例と、HTTP の使い方の説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->