### PR TITLE
fix(core): define abstract leaf poison class at module top level

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -551,4 +551,20 @@ export default tseslint.config(
       'zelt/decorator-file-naming': 'off',
     },
   },
+  {
+    name: 'core/internal-injectables',
+    // core 内部のフレームワーククラス (AppBootstrap / ConfigRegistry / LifecycleManager /
+    // AbstractLeafImplementation)。@Injectable が zelt デコレータとしてメタデータを記録する
+    // ようになったことで命名検査の対象に入ったが、これらは .lib レイヤ規約と公開 API 名の
+    // 維持を decorator-file-naming より優先する。
+    files: [
+      'packages/core/src/app/app-bootstrap.lib.ts',
+      'packages/core/src/app/config-registry.lib.ts',
+      'packages/core/src/kernel/lifecycle.lib.ts',
+      'packages/core/src/kernel/di/leaf.lib.ts',
+    ],
+    rules: {
+      'zelt/decorator-file-naming': 'off',
+    },
+  },
 );

--- a/integration/discovery/e2e/discover-by-meta.spec.ts
+++ b/integration/discovery/e2e/discover-by-meta.spec.ts
@@ -76,7 +76,12 @@ describe('Discovery', () => {
 
   it('exposes @Webhook props via getClassMetadata', () => {
     const meta = getClassMetadata(CleanupWebhook);
-    expect(meta?.props).toEqual([{ decorator: 'integration/discovery/Webhook', name: 'cleanup' }]);
+    // @Injectable も zelt メタデータを記録するようになったため(studio がソース位置を
+    // 解決する前提)、Webhook props に加えて Injectable の記録が並ぶ。
+    expect(meta?.props).toEqual([
+      { decorator: 'integration/discovery/Webhook', name: 'cleanup' },
+      { decorator: 'Injectable' },
+    ]);
   });
 
   it('exposes @WebhookHandler props per method via getClassMetadata', () => {

--- a/integration/ec-backend/zelt.config.ts
+++ b/integration/ec-backend/zelt.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@zeltjs/cli';
+
+export default defineConfig({
+  app: () => import('./src/app').then((m) => m.createEcApp()),
+});

--- a/integration/scripts/switch-mode.sh
+++ b/integration/scripts/switch-mode.sh
@@ -44,8 +44,15 @@ PACKAGES=(
   "cli"
 )
 
+# Volta の node/npm shim は CWD から manifest (package.json) を探すため、
+# 呼び出し元の CWD に壊れた/生成途中の package.json があると起動自体に失敗する。
+# node/npm はすべてルート (manifest が常に正常) を CWD にして実行する。
+run_at_root() {
+  (cd "$ROOT_DIR" && "$@")
+}
+
 get_volta_section() {
-  node -e '
+  run_at_root node -e '
     const pkg = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
     const v = pkg.volta || {};
     const parts = Object.entries(v).map(([k, val]) => `    "${k}": "${val}"`);
@@ -64,7 +71,7 @@ get_integration_dirs() {
 get_npm_version() {
   local pkg="$1"
   local version
-  version=$(npm view "@zeltjs/$pkg" version 2>/dev/null | tail -1)
+  version=$(run_at_root npm view "@zeltjs/$pkg" version 2>/dev/null | tail -1)
   if [[ -z "$version" ]]; then
     echo "latest"
   else
@@ -98,7 +105,7 @@ get_catalog_version() {
 # `catalog:` プロトコルで参照されている依存名を重複なく列挙する。
 # (どの依存が catalog 管理かをハードコードせず実際の package.json から導出する)
 collect_catalog_dep_names() {
-  node -e '
+  run_at_root node -e '
     const fs = require("fs");
     const path = require("path");
     const dir = process.argv[1];
@@ -284,7 +291,7 @@ merge_extra_deps() {
   fi
 
   echo "  Merging package.extra.json..."
-  node -e '
+  run_at_root node -e '
     const fs = require("fs");
     const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
     const extra = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
@@ -304,7 +311,13 @@ setup_integration_dir() {
   name=$(basename "$integration_dir")
 
   echo "Setting up $name..."
-  generate_package_json "$mode" "$integration_dir" > "$integration_dir/package.json"
+  # `> package.json` 直書きだと、リダイレクトの truncate が先に走るため
+  # 生成が途中で失敗すると空の package.json が残り、以後の Volta 経由の
+  # コマンドがすべて manifest パースエラーになる。一時ファイル経由で置き換える。
+  local tmp_pkg
+  tmp_pkg=$(mktemp "$integration_dir/package.json.XXXXXX")
+  generate_package_json "$mode" "$integration_dir" > "$tmp_pkg"
+  mv "$tmp_pkg" "$integration_dir/package.json"
   merge_extra_deps "$integration_dir"
 
   echo "  Installing dependencies..."

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "nx": "21.6.10",
     "oxlint": "1.62.0",
     "precommit-verify": "0.1.8",
-    "throw-trace": "0.1.7",
+    "throw-trace": "0.1.8",
     "tsdown": "0.21.10",
     "typescript": "6.0.2",
     "typescript-eslint": "8.59.1",

--- a/packages/cli/src/studio/analyzer-entry.ts
+++ b/packages/cli/src/studio/analyzer-entry.ts
@@ -1,10 +1,18 @@
 // zelt studio の解析子プロセス。tsx で実行され、ユーザーの app をロードして
 // 依存グラフ JSON をマーカー行で親プロセスへ渡す。realize() は呼ばない。
+
+// c12(jiti) が独自キャッシュで app を評価すると、getClassSource が native import で
+// 引くモジュールとクラスが別インスタンスになり identity 逆引きが壊れる(かつ app が
+// 二重評価される)。tsx 配下では native import が TS を扱えるため jiti に native を優先させる
+process.env['JITI_TRY_NATIVE'] ??= 'true';
+
 import { relative, resolve } from 'node:path';
+import type { ClassSource } from '@zeltjs/decorator-metadata/inspect';
 import {
   getClassMetadata,
-  getDependenciesFromSource,
-  getSourcePosition,
+  getClassSource,
+  getDependencySources,
+  resolveClassSource,
 } from '@zeltjs/decorator-metadata/inspect';
 import consola from 'consola';
 
@@ -12,30 +20,35 @@ import { loadZeltConfig } from '../config/index';
 import type { AppLike, InspectableClass } from './analyzer.lib';
 import { extractDecoratorNames, isAppLike } from './analyzer.lib';
 import { GRAPH_MARKER } from './analyzer-protocol';
-import type { DependencyResolver, GraphRoot } from './graph/index';
+import type { DependencyResolution, DependencyResolver, GraphRoot } from './graph/index';
 import { buildDependencyGraph, decoratorsToKind } from './graph/index';
 
 const decoratorNamesFromMetadata = (cls: InspectableClass): readonly string[] =>
   extractDecoratorNames(getClassMetadata(cls)?.props ?? []);
 
 const rootFromClass =
-  (cwd: string, featureKey: string) =>
-  (cls: InspectableClass): GraphRoot => {
-    const pos = getSourcePosition(cls);
+  (featureKey: string) =>
+  async (cls: InspectableClass): Promise<GraphRoot> => {
+    const source = await getClassSource(cls);
+    if (source.isErr()) {
+      // 位置を特定できない root は unresolved 表示になる。原因は stderr に残す
+      consola.error(`[zelt studio] no ClassSource for ${cls.name}: ${source.error.message}`);
+    }
     return {
       className: cls.name,
-      filePath: pos ? relative(cwd, pos.sourceFile) : undefined,
+      source: source.isOk() ? source.value : undefined,
       kind: decoratorsToKind(decoratorNamesFromMetadata(cls)),
       featureKey,
     };
   };
 
-const collectRoots = (app: AppLike, cwd: string): readonly GraphRoot[] =>
-  app.features.flatMap((feature) => feature.featureClasses().map(rootFromClass(cwd, feature.key)));
+const collectRoots = (app: AppLike): Promise<GraphRoot[]> =>
+  Promise.all(
+    app.features.flatMap((feature) => feature.featureClasses().map(rootFromClass(feature.key))),
+  );
 
 /**
  * @throws {Error} from analyzer-entry.ts:loadApp
- * @throws {ZeltConfigLoadError} from config-loader.lib.ts:loadZeltConfig
  * @throws {ZeltConfigLoadError} from config-loader.lib.ts:loadZeltConfig
  */
 const loadApp = async (cwd: string, configFile: string | undefined): Promise<AppLike> => {
@@ -49,40 +62,52 @@ const loadApp = async (cwd: string, configFile: string | undefined): Promise<App
   return app;
 };
 
+// 依存クラスの kind 判定用デコレータ名。ClassSource は正準化済みなので
+// resolveClassSource はキャッシュ済みモジュールの export を引くだけで副作用はない
+const dependencyDecorators = async (source: ClassSource): Promise<readonly string[]> => {
+  const cls = await resolveClassSource(source);
+  return cls.isOk() ? extractDecoratorNames(getClassMetadata(cls.value)?.props ?? []) : [];
+};
+
 /**
  * @throws {Error} from analyzer-entry.ts:createResolveDependencies
  * @throws {UnsupportedTypeScriptVersionError} from resolve-typescript.lib.ts:resolveTypeScript
  */
 const createResolveDependencies =
-  (cwd: string, tsconfig: string): DependencyResolver =>
-  async (filePath, className) => {
-    const result = await getDependenciesFromSource(resolve(cwd, filePath), className, {
-      tsconfig,
-    });
-    if (result.isOk()) {
-      return {
-        kind: 'resolved',
-        deps: result.value.map((dep) => ({
-          className: dep.className,
-          filePath: relative(cwd, dep.sourceFile),
-          decorators: dep.decorators,
-        })),
-      };
+  (tsconfig: string): DependencyResolver =>
+  async (source) => {
+    const result = await getDependencySources(source, { tsconfig });
+    if (result.isErr()) {
+      // program 外のソース（node_modules 等）は展開対象外の葉として扱う
+      if (result.error.code === 'SOURCE_NOT_FOUND') return { kind: 'external' };
+      if (result.error.code === 'POSITION_INVALID') {
+        // そのクラスだけ解析不能。握り潰さず理由を stderr に残して unresolved にする
+        consola.error(`[zelt studio] unresolved ${source.exportName}: ${result.error.message}`);
+        return { kind: 'unresolved' };
+      }
+      // tsconfig / TS program の異常は全ノードに波及するので fatal
+      throw new Error(`${result.error.code}: ${result.error.message}`);
     }
-    if (result.error.code === 'SOURCE_NOT_FOUND' || result.error.code === 'POSITION_INVALID') {
-      // そのクラスだけ解析不能。握り潰さず理由を stderr に残して unresolved にする
-      consola.error(`[zelt studio] unresolved ${className}: ${result.error.message}`);
-      return { kind: 'unresolved' };
-    }
-    // tsconfig / TS program の異常は全ノードに波及するので fatal
-    throw new Error(`${result.error.code}: ${result.error.message}`);
+    const deps: DependencyResolution[] = await Promise.all(
+      result.value.map(async (dep): Promise<DependencyResolution> => {
+        if (dep.kind === 'unresolved') {
+          consola.error(`[zelt studio] unresolved ${dep.localName}: ${dep.reason}`);
+          return { kind: 'unresolved', localName: dep.localName };
+        }
+        return {
+          kind: 'class',
+          source: dep.source,
+          decorators: await dependencyDecorators(dep.source),
+        };
+      }),
+    );
+    return { kind: 'resolved', deps };
   };
 
 /**
  * @throws {Error} from analyzer-entry.ts:createResolveDependencies
  * @throws {UnsupportedTypeScriptVersionError} from resolve-typescript.lib.ts:resolveTypeScript
  * @throws {Error} from analyzer-entry.ts:loadApp
- * @throws {ZeltConfigLoadError} from config-loader.lib.ts:loadZeltConfig
  * @throws {ZeltConfigLoadError} from config-loader.lib.ts:loadZeltConfig
  */
 const main = async (): Promise<void> => {
@@ -91,8 +116,9 @@ const main = async (): Promise<void> => {
 
   const tsconfig = resolve(cwd, 'tsconfig.json');
   const graph = await buildDependencyGraph(
-    collectRoots(app, cwd),
-    createResolveDependencies(cwd, tsconfig),
+    await collectRoots(app),
+    createResolveDependencies(tsconfig),
+    { formatPath: (filePath) => relative(cwd, filePath) },
   );
   process.stdout.write(`${GRAPH_MARKER}${JSON.stringify(graph)}\n`);
 };

--- a/packages/cli/src/studio/graph/build-graph.lib.test.ts
+++ b/packages/cli/src/studio/graph/build-graph.lib.test.ts
@@ -1,23 +1,29 @@
+import type { ClassSource } from '@zeltjs/decorator-metadata/inspect';
 import { describe, expect, it } from 'vitest';
 
 import { buildDependencyGraph, decoratorsToKind, nodeId } from './build-graph.lib';
-import type { DependencyResolver, GraphRoot, ResolvedDependency } from './graph.types';
+import type { DependencyResolution, DependencyResolver, GraphRoot } from './graph.types';
 
-// map に無いキー = resolver が unresolved を返す
+const src = (filePath: string, exportName: string): ClassSource => ({ filePath, exportName });
+
+const idOf = (s: ClassSource): string => nodeId(s.filePath, s.exportName);
+
+// map に無いキー = resolver が external を返す（node_modules 等の展開対象外)
 const makeResolver =
-  (map: ReadonlyMap<string, readonly ResolvedDependency[]>): DependencyResolver =>
-  (filePath, className) => {
-    const deps = map.get(nodeId(filePath, className));
+  (map: ReadonlyMap<string, readonly DependencyResolution[]>): DependencyResolver =>
+  (source) => {
+    const deps = map.get(idOf(source));
     return Promise.resolve(
-      deps === undefined
-        ? ({ kind: 'unresolved' } as const)
-        : ({ kind: 'resolved', deps } as const),
+      deps === undefined ? ({ kind: 'external' } as const) : ({ kind: 'resolved', deps } as const),
     );
   };
 
+const dep = (filePath: string, exportName: string, decorators: readonly string[] = []) =>
+  ({ kind: 'class', source: src(filePath, exportName), decorators }) as const;
+
 const controllerRoot: GraphRoot = {
   className: 'AController',
-  filePath: 'src/a.controller.ts',
+  source: src('src/a.controller.ts', 'AController'),
   kind: 'controller',
   featureKey: 'http',
 };
@@ -41,12 +47,9 @@ describe('buildDependencyGraph', () => {
     const map = new Map([
       [
         nodeId('src/a.controller.ts', 'AController'),
-        [{ className: 'BService', filePath: 'src/b.service.ts', decorators: ['Injectable'] }],
+        [dep('src/b.service.ts', 'BService', ['Injectable'])],
       ],
-      [
-        nodeId('src/b.service.ts', 'BService'),
-        [{ className: 'CConfig', filePath: 'src/c.config.ts', decorators: ['Config'] }],
-      ],
+      [nodeId('src/b.service.ts', 'BService'), [dep('src/c.config.ts', 'CConfig', ['Config'])]],
       [nodeId('src/c.config.ts', 'CConfig'), []],
     ]);
 
@@ -67,15 +70,37 @@ describe('buildDependencyGraph', () => {
     ]);
   });
 
+  it('merges a class reached both as root and as dependency into one node', async () => {
+    // 旧実装では root(trace 由来)と依存(AST 由来)で ID が割れて 2 ノードになっていた。
+    // ClassSource 正準化後は同一ノードに合流するのがこの設計の核心
+    const adaptorSource = src('src/adaptor.ts', 'Adaptor');
+    const roots: GraphRoot[] = [
+      controllerRoot,
+      { className: 'Adaptor', source: adaptorSource, kind: 'service', featureKey: 'eventbus' },
+    ];
+    const map = new Map([
+      [nodeId('src/a.controller.ts', 'AController'), [dep('src/adaptor.ts', 'Adaptor')]],
+      [nodeId('src/adaptor.ts', 'Adaptor'), []],
+    ]);
+
+    const graph = await buildDependencyGraph(roots, makeResolver(map));
+
+    expect(graph.nodes).toHaveLength(2);
+    expect(graph.nodes.find((n) => n.className === 'Adaptor')?.featureKey).toBe('eventbus');
+    expect(graph.edges).toEqual([
+      {
+        from: nodeId('src/a.controller.ts', 'AController'),
+        to: nodeId('src/adaptor.ts', 'Adaptor'),
+      },
+    ]);
+  });
+
   it('terminates on circular dependencies and keeps both edges', async () => {
     const map = new Map([
-      [
-        nodeId('src/a.controller.ts', 'AController'),
-        [{ className: 'BService', filePath: 'src/b.service.ts', decorators: [] }],
-      ],
+      [nodeId('src/a.controller.ts', 'AController'), [dep('src/b.service.ts', 'BService')]],
       [
         nodeId('src/b.service.ts', 'BService'),
-        [{ className: 'AController', filePath: 'src/a.controller.ts', decorators: ['Controller'] }],
+        [dep('src/a.controller.ts', 'AController', ['Controller'])],
       ],
     ]);
 
@@ -90,16 +115,12 @@ describe('buildDependencyGraph', () => {
       controllerRoot,
       {
         className: 'XController',
-        filePath: 'src/x.controller.ts',
+        source: src('src/x.controller.ts', 'XController'),
         kind: 'controller',
         featureKey: 'http',
       },
     ];
-    const shared: ResolvedDependency = {
-      className: 'SharedService',
-      filePath: 'src/shared.service.ts',
-      decorators: [],
-    };
+    const shared = dep('src/shared.service.ts', 'SharedService');
     const map = new Map([
       [nodeId('src/a.controller.ts', 'AController'), [shared]],
       [nodeId('src/x.controller.ts', 'XController'), [shared]],
@@ -112,24 +133,51 @@ describe('buildDependencyGraph', () => {
     expect(graph.edges).toHaveLength(2);
   });
 
-  it('marks nodes the resolver cannot analyze as unresolved', async () => {
-    // Dynamic は map に無い = resolver が unresolved を返す
+  it('keeps external dependencies as leaf nodes without marking them unresolved', async () => {
+    // resolver が external を返すノード（node_modules 等）は展開されないだけで赤ではない
     const map = new Map([
       [
         nodeId('src/a.controller.ts', 'AController'),
-        [{ className: 'Dynamic', filePath: 'src/dynamic.ts', decorators: [] }],
+        [dep('node_modules/pkg/dist/index.js', 'Ext')],
       ],
     ]);
 
     const graph = await buildDependencyGraph([controllerRoot], makeResolver(map));
 
+    const ext = graph.nodes.find((n) => n.className === 'Ext');
+    expect(ext?.unresolved).toBeUndefined();
+    expect(graph.edges).toHaveLength(1);
+  });
+
+  it('renders per-dependency unresolved entries as unresolved nodes', async () => {
+    const map = new Map<string, readonly DependencyResolution[]>([
+      [nodeId('src/a.controller.ts', 'AController'), [{ kind: 'unresolved', localName: 'Hidden' }]],
+    ]);
+
+    const graph = await buildDependencyGraph([controllerRoot], makeResolver(map));
+
+    const hidden = graph.nodes.find((n) => n.className === 'Hidden');
+    expect(hidden?.unresolved).toBe(true);
+    expect(graph.edges).toHaveLength(1);
+  });
+
+  it('marks the node unresolved when the resolver fails for that class', async () => {
+    const resolver: DependencyResolver = (source) =>
+      Promise.resolve(
+        source.exportName === 'AController'
+          ? { kind: 'resolved', deps: [dep('src/dynamic.ts', 'Dynamic')] }
+          : { kind: 'unresolved' },
+      );
+
+    const graph = await buildDependencyGraph([controllerRoot], resolver);
+
     const dynamic = graph.nodes.find((n) => n.className === 'Dynamic');
     expect(dynamic?.unresolved).toBe(true);
   });
 
-  it('marks roots without filePath as unresolved and does not recurse into them', async () => {
+  it('marks roots without a ClassSource as unresolved and does not recurse into them', async () => {
     const graph = await buildDependencyGraph(
-      [{ className: 'Ghost', filePath: undefined, kind: 'service', featureKey: 'http' }],
+      [{ className: 'Ghost', source: undefined, kind: 'service', featureKey: 'http' }],
       makeResolver(new Map()),
     );
 
@@ -141,8 +189,8 @@ describe('buildDependencyGraph', () => {
   it('keeps two unresolved roots with the same className but different featureKeys distinct', async () => {
     const graph = await buildDependencyGraph(
       [
-        { className: 'Ghost', filePath: undefined, kind: 'service', featureKey: 'http' },
-        { className: 'Ghost', filePath: undefined, kind: 'service', featureKey: 'cron' },
+        { className: 'Ghost', source: undefined, kind: 'service', featureKey: 'http' },
+        { className: 'Ghost', source: undefined, kind: 'service', featureKey: 'cron' },
       ],
       makeResolver(new Map()),
     );
@@ -155,12 +203,12 @@ describe('buildDependencyGraph', () => {
 
   it('does not visit the same node twice even if it appears as root and dependency', async () => {
     let calls = 0;
-    const resolver: DependencyResolver = (_filePath, className) => {
+    const resolver: DependencyResolver = (source) => {
       calls += 1;
-      if (className === 'AController') {
+      if (source.exportName === 'AController') {
         return Promise.resolve({
           kind: 'resolved' as const,
-          deps: [{ className: 'BService', filePath: 'src/b.service.ts', decorators: [] }],
+          deps: [dep('src/b.service.ts', 'BService')],
         });
       }
       return Promise.resolve({ kind: 'resolved' as const, deps: [] });
@@ -171,7 +219,7 @@ describe('buildDependencyGraph', () => {
         controllerRoot,
         {
           className: 'BService',
-          filePath: 'src/b.service.ts',
+          source: src('src/b.service.ts', 'BService'),
           kind: 'service',
           featureKey: 'http',
         },
@@ -180,5 +228,14 @@ describe('buildDependencyGraph', () => {
     );
 
     expect(calls).toBe(2);
+  });
+
+  it('relativizes displayed file paths with formatPath while keeping ids consistent', async () => {
+    const graph = await buildDependencyGraph([controllerRoot], makeResolver(new Map()), {
+      formatPath: (p) => p.replace('src/', ''),
+    });
+
+    expect(graph.nodes[0]?.filePath).toBe('a.controller.ts');
+    expect(graph.nodes[0]?.id).toBe(nodeId('a.controller.ts', 'AController'));
   });
 });

--- a/packages/cli/src/studio/graph/build-graph.lib.ts
+++ b/packages/cli/src/studio/graph/build-graph.lib.ts
@@ -1,11 +1,13 @@
+import type { ClassSource } from '@zeltjs/decorator-metadata/inspect';
+
 import type {
   DependencyGraph,
+  DependencyResolution,
   DependencyResolver,
   GraphEdge,
   GraphNode,
   GraphNodeKind,
   GraphRoot,
-  ResolvedDependency,
 } from './graph.types';
 
 const DECORATOR_KIND_MAP: ReadonlyMap<string, GraphNodeKind> = new Map([
@@ -28,18 +30,26 @@ export const decoratorsToKind = (decorators: readonly string[]): GraphNodeKind =
 
 const UNKNOWN_FILE = '(unknown)';
 
-type QueueItem = { readonly id: string; readonly filePath: string; readonly className: string };
+export type BuildGraphOptions = {
+  // 表示用パスへの変換（例: cwd からの相対化）。ID にも同じ変換を使い、表示と ID の対応を保つ
+  readonly formatPath?: (filePath: string) => string;
+};
+
+type QueueItem = { readonly id: string; readonly source: ClassSource };
 
 type GraphState = {
   readonly nodes: Map<string, GraphNode>;
   readonly edgeKeys: Set<string>;
   readonly edges: GraphEdge[];
   readonly queue: QueueItem[];
+  readonly formatPath: (filePath: string) => string;
 };
 
-// filePath 不明なルートは AST 解析の起点を持てないため即 unresolved 扱いにする。
-// featureKey を判別子に含めないと、filePath 不明・同名 className の別ルートが
-// 同一 id に潰れて 2 つ目以降が消える
+const idOfSource = (state: GraphState, source: ClassSource): string =>
+  nodeId(state.formatPath(source.filePath), source.exportName);
+
+// ClassSource へ変換できないルートは依存解決の起点を持てないため即 unresolved 扱いにする。
+// featureKey を判別子に含めないと、同名 className の別ルートが同一 id に潰れて 2 つ目以降が消える
 const seedUnresolvedRoot = (state: GraphState, root: GraphRoot): void => {
   const id = nodeId(`${UNKNOWN_FILE}:${root.featureKey}`, root.className);
   if (state.nodes.has(id)) return;
@@ -54,20 +64,25 @@ const seedUnresolvedRoot = (state: GraphState, root: GraphRoot): void => {
 };
 
 const seedRoot = (state: GraphState, root: GraphRoot): void => {
-  if (root.filePath === undefined) {
+  if (root.source === undefined) {
     seedUnresolvedRoot(state, root);
     return;
   }
-  const id = nodeId(root.filePath, root.className);
-  if (state.nodes.has(id)) return;
+  const id = idOfSource(state, root.source);
+  const existing = state.nodes.get(id);
+  if (existing) {
+    // 依存として先に発見されたクラスが root でもある場合、featureKey を付け直して合流する
+    state.nodes.set(id, { ...existing, featureKey: root.featureKey });
+    return;
+  }
   state.nodes.set(id, {
     id,
     className: root.className,
-    filePath: root.filePath,
+    filePath: state.formatPath(root.source.filePath),
     kind: root.kind,
     featureKey: root.featureKey,
   });
-  state.queue.push({ id, filePath: root.filePath, className: root.className });
+  state.queue.push({ id, source: root.source });
 };
 
 const addEdge = (state: GraphState, from: string, to: string): void => {
@@ -77,16 +92,38 @@ const addEdge = (state: GraphState, from: string, to: string): void => {
   state.edges.push({ from, to });
 };
 
-const visitDependency = (state: GraphState, item: QueueItem, dep: ResolvedDependency): void => {
-  const depId = nodeId(dep.filePath, dep.className);
+const visitClassDependency = (
+  state: GraphState,
+  item: QueueItem,
+  dep: Extract<DependencyResolution, { kind: 'class' }>,
+): void => {
+  const depId = idOfSource(state, dep.source);
   if (!state.nodes.has(depId)) {
     state.nodes.set(depId, {
       id: depId,
-      className: dep.className,
-      filePath: dep.filePath,
+      className: dep.source.exportName,
+      filePath: state.formatPath(dep.source.filePath),
       kind: decoratorsToKind(dep.decorators),
     });
-    state.queue.push({ id: depId, filePath: dep.filePath, className: dep.className });
+    state.queue.push({ id: depId, source: dep.source });
+  }
+  addEdge(state, item.id, depId);
+};
+
+const visitUnresolvedDependency = (
+  state: GraphState,
+  item: QueueItem,
+  dep: Extract<DependencyResolution, { kind: 'unresolved' }>,
+): void => {
+  const depId = nodeId(UNKNOWN_FILE, dep.localName);
+  if (!state.nodes.has(depId)) {
+    state.nodes.set(depId, {
+      id: depId,
+      className: dep.localName,
+      filePath: UNKNOWN_FILE,
+      kind: 'service',
+      unresolved: true,
+    });
   }
   addEdge(state, item.id, depId);
 };
@@ -96,26 +133,33 @@ const visitQueueItem = async (
   item: QueueItem,
   resolveDependencies: DependencyResolver,
 ): Promise<void> => {
-  const result = await resolveDependencies(item.filePath, item.className);
+  const result = await resolveDependencies(item.source);
+  if (result.kind === 'external') return;
   if (result.kind === 'unresolved') {
     const node = state.nodes.get(item.id);
     if (node) state.nodes.set(item.id, { ...node, unresolved: true });
     return;
   }
   for (const dep of result.deps) {
-    visitDependency(state, item, dep);
+    if (dep.kind === 'class') {
+      visitClassDependency(state, item, dep);
+    } else {
+      visitUnresolvedDependency(state, item, dep);
+    }
   }
 };
 
 export const buildDependencyGraph = async (
   roots: readonly GraphRoot[],
   resolveDependencies: DependencyResolver,
+  options?: BuildGraphOptions,
 ): Promise<DependencyGraph> => {
   const state: GraphState = {
     nodes: new Map(),
     edgeKeys: new Set(),
     edges: [],
     queue: [],
+    formatPath: options?.formatPath ?? ((filePath) => filePath),
   };
 
   for (const root of roots) {

--- a/packages/cli/src/studio/graph/graph.types.ts
+++ b/packages/cli/src/studio/graph/graph.types.ts
@@ -1,3 +1,5 @@
+import type { ClassSource } from '@zeltjs/decorator-metadata/inspect';
+
 export type GraphNodeKind =
   | 'controller'
   | 'command'
@@ -30,23 +32,29 @@ export type DependencyGraph = {
 
 export type GraphRoot = {
   readonly className: string;
-  // undefined = ソース位置を特定できない（unresolved ノードになる）
-  readonly filePath: string | undefined;
+  // undefined = ClassSource へ変換できない（unresolved ノードになる）
+  readonly source: ClassSource | undefined;
   readonly kind: GraphNodeKind;
   readonly featureKey: string;
 };
 
-export type ResolvedDependency = {
-  readonly className: string;
-  readonly filePath: string;
-  readonly decorators: readonly string[];
-};
+// resolver が返す 1 依存分。'class' の source は decorator-metadata 側で
+// 実クラス経由に正準化済みのため、root 由来のノードと文字列比較だけで合流できる
+export type DependencyResolution =
+  | {
+      kind: 'class';
+      readonly source: ClassSource;
+      readonly decorators: readonly string[];
+    }
+  | { kind: 'unresolved'; readonly localName: string };
 
 // TS AST 解析の副作用はこの境界の外に隔離する。
+// external = 依存展開の対象外（node_modules 等、program に含まれないソース）でエラーではない。
 // unresolved = そのクラスのみ解析不能（理由のログ出力は resolver 実装側の責務）。
 // tsconfig 異常など全体に波及するエラーは resolver が throw して fatal に扱う
 export type ResolveResult =
-  | { kind: 'resolved'; readonly deps: readonly ResolvedDependency[] }
+  | { kind: 'resolved'; readonly deps: readonly DependencyResolution[] }
+  | { kind: 'external' }
   | { kind: 'unresolved' };
 
-export type DependencyResolver = (filePath: string, className: string) => Promise<ResolveResult>;
+export type DependencyResolver = (source: ClassSource) => Promise<ResolveResult>;

--- a/packages/cli/src/studio/graph/index.ts
+++ b/packages/cli/src/studio/graph/index.ts
@@ -1,11 +1,12 @@
+export type { BuildGraphOptions } from './build-graph.lib';
 export { buildDependencyGraph, decoratorsToKind, nodeId } from './build-graph.lib';
 export type {
   DependencyGraph,
+  DependencyResolution,
   DependencyResolver,
   GraphEdge,
   GraphNode,
   GraphNodeKind,
   GraphRoot,
-  ResolvedDependency,
   ResolveResult,
 } from './graph.types';

--- a/packages/cli/studio-ui/src/app.tsx
+++ b/packages/cli/studio-ui/src/app.tsx
@@ -1,4 +1,4 @@
-import type { Edge, NodeChange, NodeProps } from '@xyflow/react';
+import type { Edge, NodeProps } from '@xyflow/react';
 import { Background, Controls, Handle, Position, ReactFlow } from '@xyflow/react';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useState } from 'react';
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from 'react';
 import type { DependencyGraph } from '../../src/studio/graph/graph.types';
 import type { FlowNode } from './graph-to-flow.lib';
 import { graphToFlow } from './graph-to-flow.lib';
+import { applyStudioNodeChanges } from './node-changes.lib';
 import { loadPositions, savePosition } from './positions.lib';
 
 type AnalyzeResult =
@@ -24,18 +25,6 @@ const CardNode = ({ data }: NodeProps<FlowNode>): JSX.Element => (
 );
 
 const nodeTypes = { card: CardNode };
-
-// ドラッグ移動のみ反映する（削除等は扱わない）
-const applyPositionChanges = (nodes: FlowNode[], changes: NodeChange<FlowNode>[]): FlowNode[] =>
-  changes.reduce(
-    (acc, change) =>
-      change.type === 'position' && change.position
-        ? acc.map((n) =>
-            n.id === change.id ? { ...n, position: change.position ?? n.position } : n,
-          )
-        : acc,
-    nodes,
-  );
 
 const useStudioGraph = () => {
   const [nodes, setNodes] = useState<FlowNode[]>([]);
@@ -94,7 +83,7 @@ export const App = (): JSX.Element => {
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
-        onNodesChange={(changes) => setNodes((prev) => applyPositionChanges(prev, changes))}
+        onNodesChange={(changes) => setNodes((prev) => applyStudioNodeChanges(prev, changes))}
         onNodeDragStop={(_event, node) => savePosition(node.id, node.position)}
         fitView
       >

--- a/packages/cli/studio-ui/src/node-changes.lib.test.ts
+++ b/packages/cli/studio-ui/src/node-changes.lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FlowNode } from './graph-to-flow.lib';
+import { applyStudioNodeChanges } from './node-changes.lib';
+
+const node = (id: string): FlowNode => ({
+  id,
+  type: 'card',
+  position: { x: 0, y: 0 },
+  data: { className: id, filePath: `${id}.ts`, kind: 'controller', unresolved: false },
+});
+
+describe('applyStudioNodeChanges', () => {
+  it('applies position changes while dragging', () => {
+    const result = applyStudioNodeChanges(
+      [node('a'), node('b')],
+      [{ type: 'position', id: 'a', position: { x: 10, y: 20 }, dragging: true }],
+    );
+    expect(result.find((n) => n.id === 'a')?.position).toEqual({ x: 10, y: 20 });
+    expect(result.find((n) => n.id === 'b')?.position).toEqual({ x: 0, y: 0 });
+  });
+
+  it('applies dimensions changes so nodes keep their measurement during drag', () => {
+    // measured を落とすと adoptUserNodes が内部の計測情報を破棄し、
+    // ドラッグ中のノードが visibility: hidden になる
+    const result = applyStudioNodeChanges(
+      [node('a')],
+      [{ type: 'dimensions', id: 'a', dimensions: { width: 240, height: 80 } }],
+    );
+    expect(result.find((n) => n.id === 'a')?.measured).toEqual({ width: 240, height: 80 });
+  });
+
+  it('ignores remove changes', () => {
+    const result = applyStudioNodeChanges([node('a')], [{ type: 'remove', id: 'a' }]);
+    expect(result.map((n) => n.id)).toEqual(['a']);
+  });
+});

--- a/packages/cli/studio-ui/src/node-changes.lib.ts
+++ b/packages/cli/studio-ui/src/node-changes.lib.ts
@@ -1,0 +1,16 @@
+import type { NodeChange } from '@xyflow/react';
+import { applyNodeChanges } from '@xyflow/react';
+
+import type { FlowNode } from './graph-to-flow.lib';
+
+// dimensions change を捨てるとユーザーノードが measured を持てず、adoptUserNodes が
+// 内部の計測情報を破棄してドラッグ中のノードが visibility: hidden になる。
+// そのため remove（グラフはビューアであり削除は扱わない）以外は applyNodeChanges に委譲する。
+export const applyStudioNodeChanges = (
+  nodes: FlowNode[],
+  changes: NodeChange<FlowNode>[],
+): FlowNode[] =>
+  applyNodeChanges(
+    changes.filter((change) => change.type !== 'remove'),
+    nodes,
+  );

--- a/packages/core/src/app/app-bootstrap.lib.ts
+++ b/packages/core/src/app/app-bootstrap.lib.ts
@@ -1,11 +1,11 @@
-import { Container, injectable } from '@needle-di/core';
+import { Container } from '@needle-di/core';
 
 import {
   assertNoUnresolvedAbstractConfigs,
   overrideConfig,
   resolveConfig,
 } from '../built-in-service';
-import { inject, LifecycleManager, resolve, ZeltLifecycleStateError } from '../kernel';
+import { Injectable, inject, LifecycleManager, resolve, ZeltLifecycleStateError } from '../kernel';
 import { ConfigRegistry } from './config-registry.lib';
 
 export type ReadyResult = {
@@ -14,7 +14,7 @@ export type ReadyResult = {
 
 type AppBootstrapState = 'idle' | 'starting' | 'ready' | 'disposed';
 
-@injectable()
+@Injectable()
 export class AppBootstrap {
   private state: AppBootstrapState = 'idle';
   private readyPromise: Promise<ReadyResult> | undefined;

--- a/packages/core/src/app/config-registry.lib.ts
+++ b/packages/core/src/app/config-registry.lib.ts
@@ -1,8 +1,7 @@
-import { injectable } from '@needle-di/core';
-
 import type { ConfigClass } from '../built-in-service';
+import { Injectable } from '../kernel';
 
-@injectable()
+@Injectable()
 export class ConfigRegistry {
   private readonly defaults: ConfigClass<object>[] = [];
   private readonly overrides: ConfigClass<object>[] = [];

--- a/packages/core/src/kernel/di/injectable.lib.test.ts
+++ b/packages/core/src/kernel/di/injectable.lib.test.ts
@@ -1,0 +1,34 @@
+import { Container } from '@needle-di/core';
+import { getClassMetadata } from '@zeltjs/decorator-metadata';
+import { describe, expect, it } from 'vitest';
+
+import { ZeltDecoratorUsageError } from '../errors';
+import { Injectable } from './injectable.lib';
+
+@Injectable()
+class TracedService {
+  hello() {
+    return 'world';
+  }
+}
+
+describe('Injectable', () => {
+  it('records zelt class metadata with the decorator name', () => {
+    expect(getClassMetadata(TracedService)?.props).toEqual([{ decorator: 'Injectable' }]);
+  });
+
+  it('keeps needle-di auto-binding working', () => {
+    const container = new Container();
+    container.bind(TracedService);
+    expect(container.get(TracedService).hello()).toBe('world');
+  });
+
+  it('throws when applied twice to the same class', () => {
+    expect(() => {
+      @Injectable()
+      @Injectable()
+      class Duplicated {}
+      return Duplicated;
+    }).toThrow(ZeltDecoratorUsageError);
+  });
+});

--- a/packages/core/src/kernel/di/injectable.lib.ts
+++ b/packages/core/src/kernel/di/injectable.lib.ts
@@ -1,4 +1,11 @@
 // Service / Repository / Adapter (= Provider in spec terminology) を DI コンテナに登録するためのマーカー。
 // `@Controller` は `@Injectable` を兼ねる (spec §4.7) ので Entry class に再付与する必要はない。
-// @needle-di/core の `injectable` を Pascal-case alias として re-export する。
-export { injectable as Injectable } from '@needle-di/core';
+// @needle-di/core の `injectable` を直接 re-export すると zelt のメタデータ（トレース含む）が
+// 記録されず、studio 等がソース位置を解決できないため、他デコレータと同じ経路で合成する。
+import { createInjectableClassDecorator } from '../internal/index';
+
+/** @throws {E} */
+export const Injectable = () =>
+  createInjectableClassDecorator({ decorator: 'Injectable' } as const, undefined, {
+    unique: true,
+  });

--- a/packages/core/src/kernel/di/leaf.lib.ts
+++ b/packages/core/src/kernel/di/leaf.lib.ts
@@ -5,7 +5,6 @@ import { ZeltAppConfigurationError } from '../errors';
 import { Injectable } from './injectable.lib';
 
 type AnyClass<T extends object = object> = abstract new (...args: never[]) => T;
-type ConcreteClass<T extends object = object> = new (...args: unknown[]) => T;
 type AnyInstance = object;
 
 type LeafInjectionToken<T extends object = object> = InjectionToken<T>;
@@ -145,29 +144,31 @@ const bindLeafInternal = (container: Container, token: LeafInjectionToken, cls: 
   markTokenBoundToConcrete(container, token);
 };
 
-const createAbstractLeafImplementation = (cls: AnyClass): ConcreteClass => {
-  @Injectable()
-  class AbstractLeafImplementation {
-    /** @throws {ZeltAppConfigurationError} */
-    constructor() {
-      throw new ZeltAppConfigurationError({
-        reason: 'abstract_leaf_without_concrete',
-        details: cls.name,
-      });
-    }
+// モジュールトップレベルで定義する: 関数内で class を定義して @Injectable() を適用すると、
+// throw-trace がその関数を「デコレータの重複ガード例外(E)を投げうる」と判定し、
+// inject() を経由する全 constructor へ @throws 要求が伝播してしまう。
+// leaf 名は useFactory クロージャから constructor 引数で受け取る。
+@Injectable()
+class AbstractLeafImplementation {
+  /** @throws {ZeltAppConfigurationError} */
+  constructor(leafName: string) {
+    throw new ZeltAppConfigurationError({
+      reason: 'abstract_leaf_without_concrete',
+      details: leafName,
+    });
   }
-
-  return AbstractLeafImplementation;
-};
+}
 
 const bindAbstractLeafInternal = (
   container: Container,
   token: LeafInjectionToken,
   cls: AnyClass,
 ): void => {
-  const abstractImplementation = createAbstractLeafImplementation(cls);
   const singleToken = new InjectionToken<AnyInstance>(`${cls.name}:abstract`);
-  container.bind({ provide: singleToken, useClass: abstractImplementation });
+  container.bind({
+    provide: singleToken,
+    useFactory: () => new AbstractLeafImplementation(cls.name),
+  });
   container.bind({ provide: token, useExisting: singleToken });
   markTokenBoundToAbstractDefault(container, token);
 };

--- a/packages/core/src/kernel/di/leaf.lib.ts
+++ b/packages/core/src/kernel/di/leaf.lib.ts
@@ -1,7 +1,8 @@
 import type { Container } from '@needle-di/core';
-import { InjectionToken, injectable } from '@needle-di/core';
+import { InjectionToken } from '@needle-di/core';
 import { isClassConstructor, UnsafeInjectionTokenWeakMap } from '@zeltjs/unsafe-type-lib';
 import { ZeltAppConfigurationError } from '../errors';
+import { Injectable } from './injectable.lib';
 
 type AnyClass<T extends object = object> = abstract new (...args: never[]) => T;
 type ConcreteClass<T extends object = object> = new (...args: unknown[]) => T;
@@ -145,7 +146,7 @@ const bindLeafInternal = (container: Container, token: LeafInjectionToken, cls: 
 };
 
 const createAbstractLeafImplementation = (cls: AnyClass): ConcreteClass => {
-  @injectable()
+  @Injectable()
   class AbstractLeafImplementation {
     /** @throws {ZeltAppConfigurationError} */
     constructor() {

--- a/packages/core/src/kernel/lifecycle.lib.ts
+++ b/packages/core/src/kernel/lifecycle.lib.ts
@@ -1,4 +1,4 @@
-import { injectable } from '@needle-di/core';
+import { Injectable } from './di/index';
 import { ZeltReadyFailedError } from './errors';
 import type { ReadyValue } from './internal';
 import { createReadyValue, disposeReadyValue, sealReadyValue } from './internal';
@@ -14,7 +14,7 @@ type LifecycleEntry = {
   readyValue?: ReadyValue<object>;
 };
 
-@injectable()
+@Injectable()
 export class LifecycleManager {
   private readonly lifecycles: LifecycleEntry[] = [];
   private startedIndex = 0;

--- a/packages/decorator-metadata/package.json
+++ b/packages/decorator-metadata/package.json
@@ -54,6 +54,7 @@
     "typescript-6": "npm:typescript@~6.0.0"
   },
   "dependencies": {
+    "import-meta-resolve": "4.2.0",
     "ts-pattern": "5.6.2"
   },
   "devDependencies": {

--- a/packages/decorator-metadata/src/inspect/class-source.lib.ts
+++ b/packages/decorator-metadata/src/inspect/class-source.lib.ts
@@ -1,0 +1,131 @@
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import type { ResultAsync } from 'neverthrow';
+import { err, errAsync, ok, okAsync, ResultAsync as ResultAsyncCtor } from 'neverthrow';
+
+import { getInternalClassMetadata } from '../runtime/index';
+import type { ClassSource, InspectError } from './inspect.types';
+import { resolveDefinitionPosition } from './position.lib';
+
+type AnyClass = new (...args: never[]) => unknown;
+type ModuleExports = Record<string, unknown>;
+
+// ESM の module namespace object は常に object。Record への絞り込みだけ行う
+const toModuleExports = (value: unknown): ModuleExports =>
+  typeof value === 'object' && value !== null ? (value as ModuleExports) : {};
+
+type ImportOutcome =
+  | { ok: true; readonly value: ModuleExports }
+  | { ok: false; readonly message: string };
+
+// import() は動的な式のため fromPromise に直接渡せず (restrict-neverthrow-from-promise)、
+// reject しない Promise に自前で畳んでから fromSafePromise で持ち上げる
+const importOutcome = async (url: string): Promise<ImportOutcome> => {
+  try {
+    const mod: unknown = await import(url);
+    return { ok: true, value: toModuleExports(mod) };
+  } catch (error) {
+    return { ok: false, message: String(error) };
+  }
+};
+
+const importModule = (filePath: string): ResultAsync<ModuleExports, InspectError> =>
+  ResultAsyncCtor.fromSafePromise(importOutcome(pathToFileURL(filePath).href)).andThen((outcome) =>
+    outcome.ok
+      ? ok(outcome.value)
+      : err({
+          code: 'MODULE_LOAD_FAILED' as const,
+          message: `Failed to import ${filePath}: ${outcome.message}`,
+        }),
+  );
+
+// export 名はクラス名と一致するとは限らない (`export { A as B }`) ため、
+// モジュールの export を identity 比較で逆引きする。同一クラスが複数名で
+// export されている場合はクラス名と同名の export を優先する
+const findExportName = (mod: ModuleExports, cls: AnyClass): string | undefined => {
+  const names = Object.keys(mod).filter((name) => mod[name] === cls);
+  if (names.length === 0) return undefined;
+  return names.find((name) => name === cls.name) ?? names[0];
+};
+
+const classSourceFromModule = (
+  filePath: string,
+  cls: AnyClass,
+): ResultAsync<ClassSource, InspectError> =>
+  importModule(filePath).andThen((mod) => {
+    const exportName = findExportName(mod, cls);
+    if (exportName === undefined) {
+      return errAsync<ClassSource, InspectError>({
+        code: 'EXPORT_NOT_FOUND',
+        message: `Class ${cls.name} is not exported from ${filePath}`,
+      });
+    }
+    return okAsync<ClassSource, InspectError>({ filePath, exportName });
+  });
+
+// 定義ファイルパスから所属パッケージ (node_modules 配下) を割り出す
+const packageFromPath = (
+  sourceFile: string,
+): { readonly root: string; readonly name: string } | undefined => {
+  const normalized = sourceFile.replace(/\\/g, '/');
+  const marker = '/node_modules/';
+  const index = normalized.lastIndexOf(marker);
+  if (index === -1) return undefined;
+  const segments = normalized.slice(index + marker.length).split('/');
+  const name = segments[0]?.startsWith('@') ? `${segments[0]}/${segments[1]}` : segments[0];
+  if (name === undefined || name === '') return undefined;
+  return { root: `${normalized.slice(0, index)}${marker}${name}`, name };
+};
+
+// sourcemap 適用済みスタックは公開パッケージに同梱されない src パスを指すことがある。
+// その場合はパッケージの self-reference 解決でエントリモジュールに落とし、
+// エントリの export から ClassSource を作る (依存側の正準化も同じ経路に収束する)
+const packageEntryFallback = (
+  sourceFile: string,
+  cls: AnyClass,
+  original: InspectError,
+): ResultAsync<ClassSource, InspectError> => {
+  const pkg = packageFromPath(sourceFile);
+  if (!pkg) return errAsync(original);
+  try {
+    const parentUrl = pathToFileURL(`${pkg.root}/package.json`).href;
+    const entry = fileURLToPath(import.meta.resolve(pkg.name, parentUrl));
+    return classSourceFromModule(entry, cls);
+  } catch {
+    return errAsync(original);
+  }
+};
+
+export const getClassSource = (cls: AnyClass): ResultAsync<ClassSource, InspectError> => {
+  const internal = getInternalClassMetadata(cls);
+  if (!internal?.trace) {
+    return errAsync({
+      code: 'NO_METADATA',
+      message: `No decorator metadata found for class ${cls.name}`,
+    });
+  }
+  const pos = resolveDefinitionPosition(internal.trace);
+  if (!pos) {
+    return errAsync({
+      code: 'POSITION_INVALID',
+      message: `No source position captured for class ${cls.name}`,
+    });
+  }
+  return classSourceFromModule(pos.sourceFile, cls).orElse((error) =>
+    error.code === 'MODULE_LOAD_FAILED'
+      ? packageEntryFallback(pos.sourceFile, cls, error)
+      : errAsync(error),
+  );
+};
+
+export const resolveClassSource = (source: ClassSource): ResultAsync<AnyClass, InspectError> =>
+  importModule(source.filePath).andThen((mod) => {
+    const value = mod[source.exportName];
+    if (typeof value !== 'function') {
+      return errAsync<AnyClass, InspectError>({
+        code: 'EXPORT_NOT_FOUND',
+        message: `Export ${source.exportName} in ${source.filePath} is missing or not a class`,
+      });
+    }
+    return okAsync<AnyClass, InspectError>(value as AnyClass);
+  });

--- a/packages/decorator-metadata/src/inspect/class-source.lib.ts
+++ b/packages/decorator-metadata/src/inspect/class-source.lib.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { resolve } from 'import-meta-resolve';
 import type { ResultAsync } from 'neverthrow';
 import { err, errAsync, ok, okAsync, ResultAsync as ResultAsyncCtor } from 'neverthrow';
 
@@ -79,7 +80,9 @@ const packageFromPath = (
 
 // sourcemap 適用済みスタックは公開パッケージに同梱されない src パスを指すことがある。
 // その場合はパッケージの self-reference 解決でエントリモジュールに落とし、
-// エントリの export から ClassSource を作る (依存側の正準化も同じ経路に収束する)
+// エントリの export から ClassSource を作る (依存側の正準化も同じ経路に収束する)。
+// stable Node の import.meta.resolve は第2引数 (parentURL) を無視して自パッケージ
+// 基準の解決になるため、Node の resolver を移植した import-meta-resolve を使う
 const packageEntryFallback = (
   sourceFile: string,
   cls: AnyClass,
@@ -89,7 +92,7 @@ const packageEntryFallback = (
   if (!pkg) return errAsync(original);
   try {
     const parentUrl = pathToFileURL(`${pkg.root}/package.json`).href;
-    const entry = fileURLToPath(import.meta.resolve(pkg.name, parentUrl));
+    const entry = fileURLToPath(resolve(pkg.name, parentUrl));
     return classSourceFromModule(entry, cls);
   } catch {
     return errAsync(original);

--- a/packages/decorator-metadata/src/inspect/get-dependency-sources.lib.ts
+++ b/packages/decorator-metadata/src/inspect/get-dependency-sources.lib.ts
@@ -1,0 +1,250 @@
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import type { ResultAsync } from 'neverthrow';
+import { errAsync, ResultAsync as ResultAsyncCtor } from 'neverthrow';
+
+import { findClassByName } from './ast.lib';
+import { getClassSource, resolveClassSource } from './class-source.lib';
+import type {
+  ClassSource,
+  DependencySource,
+  GetDependenciesOptions,
+  InspectError,
+} from './inspect.types';
+import type { CachedProgram, ProgramCacheError } from './program-cache.lib';
+import { getOrCreateProgram } from './program-cache.lib';
+
+type TypeScriptModule = typeof import('typescript');
+type TSSourceFile = import('typescript').SourceFile;
+type TSClassDeclaration = import('typescript').ClassDeclaration;
+
+const DEFAULT_TSCONFIG = './tsconfig.json';
+
+// ローカル名 → import 元 (specifier + export 名)
+type ImportRef = { readonly specifier: string; readonly exportName: string };
+
+const addNamedImports = (
+  map: Map<string, ImportRef>,
+  clause: import('typescript').ImportClause,
+  specifier: string,
+  ts: TypeScriptModule,
+): void => {
+  const bindings = clause.namedBindings;
+  if (!bindings || !ts.isNamedImports(bindings)) return;
+  for (const element of bindings.elements) {
+    map.set(element.name.text, {
+      specifier,
+      exportName: element.propertyName?.text ?? element.name.text,
+    });
+  }
+};
+
+const buildImportMap = (sourceFile: TSSourceFile, ts: TypeScriptModule): Map<string, ImportRef> => {
+  const map = new Map<string, ImportRef>();
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+    const specifier = stmt.moduleSpecifier.text;
+    const clause = stmt.importClause;
+    if (!clause) continue;
+    if (clause.name) map.set(clause.name.text, { specifier, exportName: 'default' });
+    addNamedImports(map, clause, specifier, ts);
+  }
+  return map;
+};
+
+// `export { Local as Public }` の対応表 (export 名 → ローカル名 / ローカル名 → export 名)
+type ExportAliasMaps = {
+  readonly byExport: Map<string, string>;
+  readonly byLocal: Map<string, string>;
+};
+
+const buildExportAliasMaps = (sourceFile: TSSourceFile, ts: TypeScriptModule): ExportAliasMaps => {
+  const byExport = new Map<string, string>();
+  const byLocal = new Map<string, string>();
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isExportDeclaration(stmt) || stmt.moduleSpecifier !== undefined) continue;
+    const clause = stmt.exportClause;
+    if (!clause || !ts.isNamedExports(clause)) continue;
+    for (const element of clause.elements) {
+      const local = element.propertyName?.text ?? element.name.text;
+      byExport.set(element.name.text, local);
+      byLocal.set(local, element.name.text);
+    }
+  }
+  return { byExport, byLocal };
+};
+
+const hasModifier = (decl: TSClassDeclaration, kind: import('typescript').SyntaxKind): boolean =>
+  decl.modifiers?.some((m) => m.kind === kind) ?? false;
+
+const findDefaultExportedClass = (
+  sourceFile: TSSourceFile,
+  ts: TypeScriptModule,
+): TSClassDeclaration | undefined => {
+  for (const stmt of sourceFile.statements) {
+    if (
+      ts.isClassDeclaration(stmt) &&
+      hasModifier(stmt, ts.SyntaxKind.ExportKeyword) &&
+      hasModifier(stmt, ts.SyntaxKind.DefaultKeyword)
+    ) {
+      return stmt;
+    }
+  }
+  return undefined;
+};
+
+const findClassByExportName = (
+  sourceFile: TSSourceFile,
+  exportName: string,
+  aliases: ExportAliasMaps,
+  ts: TypeScriptModule,
+): TSClassDeclaration | undefined => {
+  if (exportName === 'default') return findDefaultExportedClass(sourceFile, ts);
+  const localName = aliases.byExport.get(exportName) ?? exportName;
+  return findClassByName(sourceFile, localName, ts);
+};
+
+// 同一ファイル内クラスの export 名。export されていなければ undefined
+const exportNameOfLocalClass = (
+  sourceFile: TSSourceFile,
+  localName: string,
+  aliases: ExportAliasMaps,
+  ts: TypeScriptModule,
+): string | undefined => {
+  const aliased = aliases.byLocal.get(localName);
+  if (aliased !== undefined) return aliased;
+  const decl = findClassByName(sourceFile, localName, ts);
+  if (!decl || !hasModifier(decl, ts.SyntaxKind.ExportKeyword)) return undefined;
+  return hasModifier(decl, ts.SyntaxKind.DefaultKeyword) ? 'default' : localName;
+};
+
+const collectInjectLocalNames = (
+  classNode: TSClassDeclaration,
+  ts: TypeScriptModule,
+): readonly string[] => {
+  const ctor = classNode.members.find((m) => ts.isConstructorDeclaration(m));
+  if (!ctor || !ts.isConstructorDeclaration(ctor)) return [];
+  return ctor.parameters.flatMap((param) => {
+    if (!param.initializer || !ts.isCallExpression(param.initializer)) return [];
+    const callee = param.initializer.expression;
+    if (!ts.isIdentifier(callee) || callee.text !== 'inject') return [];
+    const arg = param.initializer.arguments[0];
+    return arg && ts.isIdentifier(arg) ? [arg.text] : [];
+  });
+};
+
+// TS の相対 specifier は拡張子省略・`.js` 書き (ESM 流儀) の両方があり得るため候補を試す
+const relativeCandidates = (base: string): readonly string[] => [
+  base,
+  `${base}.ts`,
+  `${base}.tsx`,
+  `${base}.mts`,
+  ...(base.endsWith('.js') ? [base.replace(/\.js$/, '.ts')] : []),
+  `${base}/index.ts`,
+];
+
+const resolveSpecifierPath = (specifier: string, importerPath: string): string | undefined => {
+  if (specifier.startsWith('.')) {
+    const base = resolve(dirname(importerPath), specifier);
+    return relativeCandidates(base).find((candidate) => existsSync(candidate));
+  }
+  // bare specifier は実行時 (ESM loader) と同じ条件で解決しないと、dual package で
+  // 別インスタンス (CJS 側) に割れて ClassSource の同一性が壊れる
+  const parentUrl = pathToFileURL(importerPath).href;
+  try {
+    return fileURLToPath(import.meta.resolve(specifier, parentUrl));
+  } catch {
+    try {
+      return createRequire(importerPath).resolve(specifier);
+    } catch {
+      return undefined;
+    }
+  }
+};
+
+// 実クラス経由で ClassSource を正準化する。エントリ/チャンクのパス差や re-export の
+// 名前差があっても、クラスオブジェクトの trace 由来の値に収束させる。
+// 正準化に失敗した場合 (未デコレートのクラス等) は解決済みの raw 値をそのまま使う
+const canonicalize = async (localName: string, raw: ClassSource): Promise<DependencySource> => {
+  const cls = await resolveClassSource(raw);
+  if (cls.isErr()) {
+    return { kind: 'unresolved', localName, reason: cls.error.message };
+  }
+  const canonical = await getClassSource(cls.value);
+  return {
+    kind: 'class',
+    localName,
+    source: canonical.isOk() ? canonical.value : raw,
+  };
+};
+
+const toDependencySource = async (
+  localName: string,
+  sourceFile: TSSourceFile,
+  importMap: Map<string, ImportRef>,
+  aliases: ExportAliasMaps,
+  ts: TypeScriptModule,
+): Promise<DependencySource> => {
+  const importRef = importMap.get(localName);
+  if (importRef) {
+    const filePath = resolveSpecifierPath(importRef.specifier, sourceFile.fileName);
+    if (filePath === undefined) {
+      return {
+        kind: 'unresolved',
+        localName,
+        reason: `Cannot resolve module specifier '${importRef.specifier}' from ${sourceFile.fileName}`,
+      };
+    }
+    return canonicalize(localName, { filePath, exportName: importRef.exportName });
+  }
+  const exportName = exportNameOfLocalClass(sourceFile, localName, aliases, ts);
+  if (exportName === undefined) {
+    return {
+      kind: 'unresolved',
+      localName,
+      reason: `Class ${localName} in ${sourceFile.fileName} is not exported`,
+    };
+  }
+  return canonicalize(localName, { filePath: sourceFile.fileName, exportName });
+};
+
+const extract = (
+  cached: CachedProgram,
+  source: ClassSource,
+): ResultAsync<readonly DependencySource[], InspectError> => {
+  const { program, ts } = cached;
+  const sourceFile = program.getSourceFile(source.filePath);
+  if (!sourceFile) {
+    return errAsync({
+      code: 'SOURCE_NOT_FOUND',
+      message: `Source file not found: ${source.filePath}`,
+    });
+  }
+  const aliases = buildExportAliasMaps(sourceFile, ts);
+  const classNode = findClassByExportName(sourceFile, source.exportName, aliases, ts);
+  if (!classNode) {
+    return errAsync({
+      code: 'POSITION_INVALID',
+      message: `No class exported as ${source.exportName} in ${source.filePath}`,
+    });
+  }
+  const importMap = buildImportMap(sourceFile, ts);
+  const localNames = collectInjectLocalNames(classNode, ts);
+  return ResultAsyncCtor.fromSafePromise(
+    Promise.all(
+      localNames.map((name) => toDependencySource(name, sourceFile, importMap, aliases, ts)),
+    ),
+  );
+};
+
+/** @throws {UnsupportedTypeScriptVersionError} from resolve-typescript.lib.ts:resolveTypeScript */
+export const getDependencySources = (
+  source: ClassSource,
+  options?: GetDependenciesOptions,
+): ResultAsync<readonly DependencySource[], InspectError | ProgramCacheError> => {
+  const tsconfigPath = resolve(options?.tsconfig ?? DEFAULT_TSCONFIG);
+  return getOrCreateProgram(tsconfigPath).andThen((cached) => extract(cached, source));
+};

--- a/packages/decorator-metadata/src/inspect/index.ts
+++ b/packages/decorator-metadata/src/inspect/index.ts
@@ -1,9 +1,13 @@
 export { getClassMetadata } from '../runtime/index';
+export { getClassSource, resolveClassSource } from './class-source.lib';
 export { getDependencies, getDependenciesFromSource } from './get-dependencies.lib';
+export { getDependencySources } from './get-dependency-sources.lib';
 export { getTypeMetadata } from './get-type-metadata.lib';
 export type {
   ClassMetadata,
+  ClassSource,
   DependencyInfo,
+  DependencySource,
   ExpandStrategy,
   GetDependenciesOptions,
   InspectError,
@@ -16,7 +20,7 @@ export type {
   TypeInfo,
 } from './inspect.types';
 export type { Position, ResolvePositionOptions } from './position.lib';
-export { resolvePosition } from './position.lib';
+export { resolveDefinitionPosition, resolvePosition } from './position.lib';
 export type { ProgramCacheError } from './program-cache.lib';
 export { clearProgramCache, getOrCreateProgram } from './program-cache.lib';
 export type { GetSourcePositionOptions } from './source-position.lib';

--- a/packages/decorator-metadata/src/inspect/inspect.types.ts
+++ b/packages/decorator-metadata/src/inspect/inspect.types.ts
@@ -60,7 +60,28 @@ export type InspectErrorCode =
   | 'NO_METADATA'
   | 'SOURCE_NOT_FOUND'
   | 'POSITION_INVALID'
-  | 'TSCONFIG_ERROR';
+  | 'TSCONFIG_ERROR'
+  | 'EXPORT_NOT_FOUND'
+  | 'MODULE_LOAD_FAILED';
+
+/**
+ * 実クラスと静的なソース参照を相互変換するための識別子。
+ * filePath はそのまま dynamic import できる解決済みパスであること
+ * (= ClassSource は「import 可能」を不変条件とする)。
+ */
+export type ClassSource = {
+  readonly filePath: string;
+  readonly exportName: string;
+};
+
+/**
+ * getDependencySources の 1 依存分の結果。
+ * kind: 'class' の source は「実クラス経由で正準化済み」の ClassSource
+ * (同一クラスなら root 由来でも依存由来でも必ず同じ値になる)。
+ */
+export type DependencySource =
+  | { kind: 'class'; readonly localName: string; readonly source: ClassSource }
+  | { kind: 'unresolved'; readonly localName: string; readonly reason: string };
 
 export type InspectError = {
   readonly code: InspectErrorCode;

--- a/packages/decorator-metadata/src/inspect/position.lib.ts
+++ b/packages/decorator-metadata/src/inspect/position.lib.ts
@@ -110,22 +110,29 @@ const extractFilePath = (line: string): string | undefined => {
   return atMatch?.[1] ? normalizeStackFilePath(atMatch[1]) : undefined;
 };
 
-const extractOutsidePackageFiles = (stack: string): Set<string> => {
+const extractOutsidePackageFiles = (
+  stack: string,
+  isFrameworkPath: (path: string) => boolean,
+): Set<string> => {
   const lines = stack.split('\n').slice(1);
   const files = new Set<string>();
   for (const line of lines) {
     const file = extractFilePath(line);
     if (!file) continue;
     const normalized = file.replace(/\\/g, '/');
-    if (defaultIsFrameworkPath(normalized)) continue;
+    if (isFrameworkPath(normalized)) continue;
     files.add(normalized);
   }
   return files;
 };
 
-const diffOutsidePackageFiles = (defineStack: string, callStack: string): readonly string[] => {
-  const callFiles = extractOutsidePackageFiles(callStack);
-  const defineFiles = extractOutsidePackageFiles(defineStack);
+const diffOutsidePackageFiles = (
+  defineStack: string,
+  callStack: string,
+  isFrameworkPath: (path: string) => boolean,
+): readonly string[] => {
+  const callFiles = extractOutsidePackageFiles(callStack, isFrameworkPath);
+  const defineFiles = extractOutsidePackageFiles(defineStack, isFrameworkPath);
   const wrapperFiles: string[] = [];
   for (const file of defineFiles) {
     if (!callFiles.has(file)) wrapperFiles.push(file);
@@ -156,19 +163,26 @@ const findFirstUserPosition = (
   return undefined;
 };
 
-const buildIsFrameworkPath = (
+// define スタック（デコレータ factory 呼び出し時）にだけ現れるファイルは、factory を
+// 包む wrapper（例: core の createInjectableClassDecorator）とみなして除外対象に加える
+const buildIsExcludedPath = (
   trace: StackTrace,
-  options?: ResolvePositionOptions,
+  baseIsFrameworkPath: (path: string) => boolean,
 ): ((path: string) => boolean) => {
-  const baseIsFrameworkPath = options?.isFrameworkPath ?? defaultIsFrameworkPath;
   const defineStack = trace.error.stack;
   const callStack = trace.callError?.stack;
   if (!defineStack || !callStack) return baseIsFrameworkPath;
-  const wrapperFiles = diffOutsidePackageFiles(defineStack, callStack);
+  const wrapperFiles = diffOutsidePackageFiles(defineStack, callStack, baseIsFrameworkPath);
   if (wrapperFiles.length === 0) return baseIsFrameworkPath;
   const wrapperSet = new Set(wrapperFiles);
   return (path) => baseIsFrameworkPath(path) || wrapperSet.has(path.replace(/\\/g, '/'));
 };
+
+const buildIsFrameworkPath = (
+  trace: StackTrace,
+  options?: ResolvePositionOptions,
+): ((path: string) => boolean) =>
+  buildIsExcludedPath(trace, options?.isFrameworkPath ?? defaultIsFrameworkPath);
 
 export const resolvePosition = (
   trace: StackTrace | undefined,
@@ -178,4 +192,28 @@ export const resolvePosition = (
   const stack = trace.error.stack;
   if (!stack) return undefined;
   return findFirstUserPosition(stack, buildIsFrameworkPath(trace, options));
+};
+
+// デコレータ機構そのもの (decorator-metadata) のフレーム判定。
+// workspace 実行時は PACKAGE_ROOT、インストール実行時はパッケージパスの
+// マーカーで判定する (テスト fixture は resolvePosition と同様に機構扱いしない)
+const isDecoratorMachineryPath = (path: string): boolean => {
+  const normalized = path.replace(/\\/g, '/');
+  if (normalized.startsWith('node:')) return true;
+  if (normalized.includes('/@zeltjs/decorator-metadata/')) return true;
+  if (!isWithinPackageRoot(normalized, PACKAGE_ROOT)) return false;
+  return !isPackageTestPath(normalized, PACKAGE_ROOT);
+};
+
+/**
+ * クラス定義サイト (デコレータが適用されたモジュール) の位置を返す。
+ * resolvePosition が「ユーザーがデコレータを書いた場所」を探すために node_modules を
+ * 一律除外するのに対し、こちらは ClassSource 用に node_modules 内の定義もそのまま返す。
+ * 除外するのは機構自身と、define/call スタック差分から検出した factory wrapper のみ。
+ */
+export const resolveDefinitionPosition = (trace: StackTrace | undefined): Position | undefined => {
+  if (!trace) return undefined;
+  const stack = trace.error.stack;
+  if (!stack) return undefined;
+  return findFirstUserPosition(stack, buildIsExcludedPath(trace, isDecoratorMachineryPath));
 };

--- a/packages/decorator-metadata/src/test/class-source.test.ts
+++ b/packages/decorator-metadata/src/test/class-source.test.ts
@@ -1,0 +1,118 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { getClassSource, resolveClassSource } from '../inspect/index';
+
+const fixturePath = resolve(__dirname, './fixtures/class-source/exported.ts');
+
+describe('getClassSource', () => {
+  it('converts a decorated exported class to its ClassSource', async () => {
+    const { ExportedService } = await import('./fixtures/class-source/exported');
+
+    const result = await getClassSource(ExportedService);
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value).toEqual({ filePath: fixturePath, exportName: 'ExportedService' });
+  });
+
+  it('uses the export name, not the class name, for aliased exports', async () => {
+    const { AliasedService } = await import('./fixtures/class-source/exported');
+
+    const result = await getClassSource(AliasedService);
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value.exportName).toBe('AliasedService');
+  });
+
+  it('returns EXPORT_NOT_FOUND for a decorated class that is not exported', async () => {
+    const { hiddenRef } = await import('./fixtures/class-source/exported');
+    const hidden = hiddenRef();
+
+    const result = await getClassSource(hidden as new () => object);
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.code).toBe('EXPORT_NOT_FOUND');
+  });
+
+  it('returns NO_METADATA for a class without decorator metadata', async () => {
+    class Plain {}
+
+    const result = await getClassSource(Plain);
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.code).toBe('NO_METADATA');
+  });
+});
+
+describe('resolveClassSource', () => {
+  it('round-trips: resolving a ClassSource returns the identical class object', async () => {
+    const { ExportedService } = await import('./fixtures/class-source/exported');
+    const source = await getClassSource(ExportedService);
+    expect(source.isOk()).toBe(true);
+    if (!source.isOk()) return;
+
+    const result = await resolveClassSource(source.value);
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value).toBe(ExportedService);
+  });
+
+  it('returns MODULE_LOAD_FAILED for a non-existent file', async () => {
+    const result = await resolveClassSource({
+      filePath: resolve(__dirname, './fixtures/class-source/no-such-file.ts'),
+      exportName: 'Nope',
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.code).toBe('MODULE_LOAD_FAILED');
+  });
+
+  it('returns EXPORT_NOT_FOUND when the export name does not exist', async () => {
+    const result = await resolveClassSource({ filePath: fixturePath, exportName: 'Missing' });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.code).toBe('EXPORT_NOT_FOUND');
+  });
+});
+
+describe('resolveDefinitionPosition', () => {
+  it('returns node_modules definition sites and excludes factory wrappers via stack diff', async () => {
+    const { resolveDefinitionPosition } = await import('../inspect/index');
+    const { CaptureStackError } = await import('../runtime/index');
+
+    // define スタック: factory 呼び出し。core の wrapper フレームを含む
+    const defineError = new CaptureStackError();
+    defineError.stack = [
+      'CaptureStackError: Capture stack trace',
+      '    at captureStackTrace (/repo/node_modules/@zeltjs/decorator-metadata/dist/index.js:10:5)',
+      '    at createClassDecorator (/repo/node_modules/@zeltjs/decorator-metadata/dist/index.js:20:5)',
+      '    at createInjectableClassDecorator (/repo/node_modules/@zeltjs/core/dist/chunk.js:30:5)',
+      '    at /repo/node_modules/@zeltjs/eventbus/dist/index-chunk.js:7:1',
+    ].join('\n');
+
+    // call スタック: デコレータ適用時。wrapper は現れず、機構の内部依存 (ts-pattern) が挟まる
+    const callError = new CaptureStackError();
+    callError.stack = [
+      'CaptureStackError: Capture stack trace',
+      '    at captureStackTrace (/repo/node_modules/@zeltjs/decorator-metadata/dist/index.js:10:5)',
+      '    at decorate (/repo/node_modules/@zeltjs/decorator-metadata/dist/index.js:22:5)',
+      '    at I.with (/repo/node_modules/ts-pattern/dist/index.js:1:6833)',
+      '    at /repo/node_modules/@zeltjs/eventbus/dist/index-chunk.js:7:1',
+    ].join('\n');
+
+    const pos = resolveDefinitionPosition({
+      _brand: 'StackTrace',
+      error: defineError,
+      callError,
+    });
+
+    expect(pos?.sourceFile).toBe('/repo/node_modules/@zeltjs/eventbus/dist/index-chunk.js');
+  });
+});

--- a/packages/decorator-metadata/src/test/class-source.test.ts
+++ b/packages/decorator-metadata/src/test/class-source.test.ts
@@ -1,4 +1,8 @@
-import { resolve } from 'node:path';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import { getClassSource, resolveClassSource } from '../inspect/index';
@@ -45,6 +49,51 @@ describe('getClassSource', () => {
     expect(result.isErr()).toBe(true);
     if (!result.isErr()) return;
     expect(result.error.code).toBe('NO_METADATA');
+  });
+
+  // sourcemap 適用済みスタックが公開パッケージに同梱されない src パスを指すケース。
+  // stable Node の import.meta.resolve は第2引数 (parentURL) を無視するため、
+  // parentURL 基準の解決が実際に機能することを検証する。fallback はパスの
+  // /node_modules/ マーカーでパッケージルートを検出するため、リポジトリに
+  // node_modules 配下の fixture を置かず tmpdir に実行時生成する
+  it('falls back to the package entry when the recorded source path is not shipped', async () => {
+    // macOS では tmpdir が symlink (/var -> /private/var) のため realpath で正規化する
+    const base = await realpath(await mkdtemp(join(tmpdir(), 'class-source-fallback-')));
+    try {
+      const pkgRoot = join(base, 'node_modules', 'fallback-pkg');
+      await mkdir(join(pkgRoot, 'dist'), { recursive: true });
+      await writeFile(
+        join(pkgRoot, 'package.json'),
+        JSON.stringify({
+          name: 'fallback-pkg',
+          type: 'module',
+          exports: { '.': { import: './dist/index.mjs' } },
+        }),
+      );
+      const entryPath = join(pkgRoot, 'dist', 'index.mjs');
+      await writeFile(entryPath, 'export class PackagedService {}\n');
+
+      const entryModule: unknown = await import(pathToFileURL(entryPath).href);
+      const { PackagedService } = entryModule as { PackagedService: new () => object };
+      const { ensureClassMeta, CaptureStackError } = await import('../runtime/index');
+
+      const missingSrc = join(pkgRoot, 'src', 'index.ts');
+      const defineError = new CaptureStackError();
+      defineError.stack = [
+        'CaptureStackError: Capture stack trace',
+        `    at captureStackTrace (${resolve(__dirname, '../runtime/trace.lib.ts')}:16:17)`,
+        `    at ${missingSrc}:1:1`,
+      ].join('\n');
+      ensureClassMeta(PackagedService, { _brand: 'StackTrace', error: defineError });
+
+      const result = await getClassSource(PackagedService);
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(result.value).toEqual({ filePath: entryPath, exportName: 'PackagedService' });
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/decorator-metadata/src/test/fixtures/class-source/default-dep.ts
+++ b/packages/decorator-metadata/src/test/fixtures/class-source/default-dep.ts
@@ -1,0 +1,6 @@
+import { createClassDecorator } from '../../../index';
+
+const Service = createClassDecorator({ type: 'service' });
+
+@Service
+export default class DefaultDep {}

--- a/packages/decorator-metadata/src/test/fixtures/class-source/dep-consumer.ts
+++ b/packages/decorator-metadata/src/test/fixtures/class-source/dep-consumer.ts
@@ -1,0 +1,25 @@
+import { createClassDecorator } from '../../../index';
+
+import DefaultDep from './default-dep';
+import { AliasedService, ExportedService } from './exported';
+
+const Service = createClassDecorator({ type: 'service' });
+const inject = <T>(_cls: new (...args: never[]) => T): T => {
+  return {} as T;
+};
+
+@Service
+class LocalDep {}
+
+export { LocalDep as PublicLocalDep };
+
+@Service
+export class Consumer {
+  // biome-ignore lint/complexity/noUselessConstructor: fixture for AST-based inject() extraction tests
+  constructor(
+    _a = inject(ExportedService),
+    _b = inject(AliasedService),
+    _c = inject(LocalDep),
+    _d = inject(DefaultDep),
+  ) {}
+}

--- a/packages/decorator-metadata/src/test/fixtures/class-source/exported.ts
+++ b/packages/decorator-metadata/src/test/fixtures/class-source/exported.ts
@@ -1,0 +1,18 @@
+import { createClassDecorator } from '../../../index';
+
+const Service = createClassDecorator({ type: 'service' });
+
+@Service
+export class ExportedService {}
+
+@Service
+class Renamed {}
+
+export { Renamed as AliasedService };
+
+@Service
+class HiddenService {}
+
+// export されないクラスは ClassSource に変換できないケースの fixture。
+// 未使用扱いにならないよう参照だけ残す
+export const hiddenRef = (): unknown => HiddenService;

--- a/packages/decorator-metadata/src/test/fixtures/class-source/unresolved-consumer.ts
+++ b/packages/decorator-metadata/src/test/fixtures/class-source/unresolved-consumer.ts
@@ -1,0 +1,15 @@
+import { createClassDecorator } from '../../../index';
+
+const Service = createClassDecorator({ type: 'service' });
+const inject = <T>(_cls: new (...args: never[]) => T): T => {
+  return {} as T;
+};
+
+@Service
+class NeverExported {}
+
+@Service
+export class UnresolvedConsumer {
+  // biome-ignore lint/complexity/noUselessConstructor: fixture for AST-based inject() extraction tests
+  constructor(_a = inject(NeverExported)) {}
+}

--- a/packages/decorator-metadata/src/test/get-dependency-sources.test.ts
+++ b/packages/decorator-metadata/src/test/get-dependency-sources.test.ts
@@ -1,0 +1,104 @@
+import { resolve } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import type { DependencySource } from '../inspect/index';
+import { clearProgramCache, getDependencySources } from '../inspect/index';
+
+const tsconfig = resolve(__dirname, '../../tsconfig.json');
+const consumerPath = resolve(__dirname, './fixtures/class-source/dep-consumer.ts');
+const exportedPath = resolve(__dirname, './fixtures/class-source/exported.ts');
+const defaultDepPath = resolve(__dirname, './fixtures/class-source/default-dep.ts');
+
+const byLocalName = (
+  deps: readonly DependencySource[],
+  localName: string,
+): DependencySource | undefined => deps.find((d) => d.localName === localName);
+
+describe('getDependencySources', () => {
+  beforeAll(() => {
+    clearProgramCache();
+  });
+
+  const getConsumerDeps = async () => {
+    const result = await getDependencySources(
+      { filePath: consumerPath, exportName: 'Consumer' },
+      { tsconfig },
+    );
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) throw new Error('expected ok');
+    return result.value;
+  };
+
+  it('resolves a named import dependency to its canonical ClassSource', async () => {
+    const deps = await getConsumerDeps();
+    expect(byLocalName(deps, 'ExportedService')).toEqual({
+      kind: 'class',
+      localName: 'ExportedService',
+      source: { filePath: exportedPath, exportName: 'ExportedService' },
+    });
+  });
+
+  it('keeps the export name for aliased imports (identity-canonical)', async () => {
+    const deps = await getConsumerDeps();
+    expect(byLocalName(deps, 'AliasedService')).toEqual({
+      kind: 'class',
+      localName: 'AliasedService',
+      source: { filePath: exportedPath, exportName: 'AliasedService' },
+    });
+  });
+
+  it('resolves a same-file dependency through its aliased export', async () => {
+    const deps = await getConsumerDeps();
+    expect(byLocalName(deps, 'LocalDep')).toEqual({
+      kind: 'class',
+      localName: 'LocalDep',
+      source: { filePath: consumerPath, exportName: 'PublicLocalDep' },
+    });
+  });
+
+  it('resolves a default-import dependency', async () => {
+    const deps = await getConsumerDeps();
+    expect(byLocalName(deps, 'DefaultDep')).toEqual({
+      kind: 'class',
+      localName: 'DefaultDep',
+      source: { filePath: defaultDepPath, exportName: 'default' },
+    });
+  });
+
+  it('reports a non-exported same-file dependency as unresolved', async () => {
+    const result = await getDependencySources(
+      {
+        filePath: resolve(__dirname, './fixtures/class-source/unresolved-consumer.ts'),
+        exportName: 'UnresolvedConsumer',
+      },
+      { tsconfig },
+    );
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    const dep = byLocalName(result.value, 'NeverExported');
+    expect(dep?.kind).toBe('unresolved');
+  });
+
+  it('finds the class through an aliased export name of the target itself', async () => {
+    // ClassSource の exportName が実クラス名と違っても(export { Renamed as AliasedService })
+    // クラス宣言まで辿って依存を返せること
+    const result = await getDependencySources(
+      { filePath: exportedPath, exportName: 'AliasedService' },
+      { tsconfig },
+    );
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value).toEqual([]);
+  });
+
+  it('returns SOURCE_NOT_FOUND for a file outside the program', async () => {
+    const result = await getDependencySources(
+      { filePath: resolve(__dirname, './no-such-file.ts'), exportName: 'X' },
+      { tsconfig },
+    );
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.code).toBe('SOURCE_NOT_FOUND');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,9 @@ importers:
 
   packages/decorator-metadata:
     dependencies:
+      import-meta-resolve:
+        specifier: 4.2.0
+        version: 4.2.0
       ts-pattern:
         specifier: 5.6.2
         version: 5.6.2
@@ -8484,6 +8487,9 @@ packages:
   import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   import-without-cache@0.3.3:
     resolution: {integrity: sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==}
@@ -20464,6 +20470,8 @@ snapshots:
       resolve-from: 4.0.0
 
   import-lazy@4.0.0: {}
+
+  import-meta-resolve@4.2.0: {}
 
   import-without-cache@0.3.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: 0.1.8
         version: 0.1.8
       throw-trace:
-        specifier: 0.1.7
-        version: 0.1.7
+        specifier: 0.1.8
+        version: 0.1.8
       tsdown:
         specifier: 0.21.10
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@6.0.2)
@@ -11385,8 +11385,8 @@ packages:
     peerDependencies:
       tslib: ^2
 
-  throw-trace@0.1.7:
-    resolution: {integrity: sha512-exl9xIzB8tEUDTIWJUTl/HR85WJl0D9bQI4Q8oOzny3OuhJo59D9lM7bEOCNgq8hhzwM9SmKmfm1ggmOUzaBTQ==}
+  throw-trace@0.1.8:
+    resolution: {integrity: sha512-6yEAs8W8MEOL5AUSUXWeJEbkErf9iXGc0FOA7z+nIBMso8DC34VGrr8JS84v8TFosklea7N1vY4BeMMPAuqyqQ==}
     engines: {node: '>=18'}
     cpu: [x64, arm64]
     os: [linux, darwin, win32]
@@ -24335,7 +24335,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  throw-trace@0.1.7: {}
+  throw-trace@0.1.8: {}
 
   thunky@1.1.0: {}
 


### PR DESCRIPTION
## Summary

`throw-trace check` reported 97 errors, all propagating from a single throw: the decorator duplicate-application guard in `decorators.lib.ts`. The propagation path was:

1. `leaf.lib.ts` created `AbstractLeafImplementation` **inside a function** and applied `@Injectable()` there
2. throw-trace treats in-function decorator application as "the enclosing function may throw the decorator's guard error (`E`)"
3. The requirement propagated through the DI chain (`ensureLeafBound` → `resolve` → `inject()`) into **every constructor using `inject()` default parameters**, and transitively to bootstrap, test helpers, and fixtures

## Changes

- Move the abstract-leaf poison class to module top level (decorator application at module scope is not attributed to any function) and pass the leaf name through the `useFactory` closure as a constructor argument, mirroring `bindLeafInternal`
- Bump `throw-trace` to `0.1.8`

Runtime behavior is unchanged: resolving an abstract leaf without a concrete implementation still throws `ZeltAppConfigurationError` with the leaf name, and the duplicate-application guard of `@Injectable` is untouched.

## Verification

- `pnpm throw-trace`: **97 errors → No issues found in 395 files** (verified under both 0.1.7 and 0.1.8)
- `pnpm typecheck`: pass
- `pnpm test`: 146 files / 1045 tests pass
- Existing test `leaf.lib.test.ts` already asserts the leaf name appears in the error message, covering the name-passing change
- eslint / oxlint / biome clean on the changed file

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786231040&installation_id=133048706&pr_number=304&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F304&signature=67d3bfcf8fec158a75ac1d79922074c4eae7c42a9a8299856a1eb2cb0d0969e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 依存グラフ解析の精度を向上し、クラスの定義元や依存関係をより正確に追跡できるようにしました。
  * 外部依存や未解決の依存を区別して表示できるようになりました。
  * グラフ表示用にパスを相対化できるようになりました。
  * スタジオ上のノード位置・サイズ情報の更新処理を改善しました。
  * 新しい依存関係解析機能とアプリ起動設定を追加しました。

* **バグ修正**
  * 依存グラフ内で同じクラスが重複表示される問題を修正しました。
  * ノード削除操作で内部計測情報が失われる問題を修正しました。
  * 統合環境の設定生成に失敗した際、空の設定ファイルが残る問題を修正しました。

* **改善**
  * 依存性注入デコレーターのメタデータ処理とエラー検出を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->