### PR TITLE
fix(core): make lifecycle failures cleanup-safe

### DIFF
--- a/packages/core/src/app/app-bootstrap.lib.test.ts
+++ b/packages/core/src/app/app-bootstrap.lib.test.ts
@@ -1,6 +1,7 @@
 import { Container } from '@needle-di/core';
 import { describe, expect, it, vi } from 'vitest';
-import { LifecycleManager, ZeltLifecycleStateError } from '../kernel';
+import type { Lifecycle } from '../kernel';
+import { LifecycleManager, ZeltLifecycleStateError, ZeltReadyFailedError } from '../kernel';
 import { AppBootstrap } from './app-bootstrap.lib';
 
 describe('AppBootstrap', () => {
@@ -52,5 +53,63 @@ describe('AppBootstrap', () => {
     await runtime.shutdown();
 
     expect(shutdownSpy).toHaveBeenCalled();
+  });
+
+  it('should preserve startup failure and roll back started lifecycles', async () => {
+    const container = new Container();
+    const lifecycle = container.get(LifecycleManager);
+    const runtime = container.get(AppBootstrap);
+    const events: string[] = [];
+    const startupCause = new Error('startup failed');
+
+    lifecycle.register({
+      startup: async () => {
+        events.push('first:start');
+      },
+      shutdown: async () => {
+        events.push('first:stop');
+      },
+    });
+    lifecycle.register({
+      startup: async () => {
+        events.push('second:start');
+        throw startupCause;
+      },
+      shutdown: async () => {
+        events.push('second:stop');
+      },
+    });
+
+    const failure = await runtime.ready().catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(ZeltReadyFailedError);
+    expect(failure).toMatchObject({ cause: startupCause });
+    expect(events).toEqual(['first:start', 'second:start', 'first:stop']);
+    await expect(runtime.ready()).rejects.toBe(failure);
+
+    await runtime.shutdown();
+    expect(events).toEqual(['first:start', 'second:start', 'first:stop']);
+  });
+
+  it('should enter disposed state after lifecycle failures registered after ready', async () => {
+    const container = new Container();
+    const lifecycle = container.get(LifecycleManager);
+    const runtime = container.get(AppBootstrap);
+    const ready = await runtime.ready();
+    const startupCause = new Error('late startup failed');
+    const failingLifecycle: Lifecycle = {
+      startup: async () => {
+        throw startupCause;
+      },
+      shutdown: async () => {},
+    };
+    lifecycle.register(failingLifecycle);
+
+    const failure = await ready.get(AppBootstrap).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(ZeltReadyFailedError);
+    expect(failure).toMatchObject({ cause: startupCause });
+    await expect(ready.get(AppBootstrap)).rejects.toBeInstanceOf(ZeltLifecycleStateError);
+    await runtime.shutdown();
   });
 });

--- a/packages/core/src/app/app-bootstrap.lib.ts
+++ b/packages/core/src/app/app-bootstrap.lib.ts
@@ -26,7 +26,7 @@ export class AppBootstrap {
     private readonly configRegistry: ConfigRegistry = inject(ConfigRegistry),
   ) {}
 
-  /** @throws {ZeltLifecycleStateError | ZeltReadyFailedError | ZeltAppConfigurationError} */
+  /** @throws {AggregateError | ZeltLifecycleStateError | ZeltReadyFailedError | ZeltAppConfigurationError} */
   async ready(): Promise<ReadyResult> {
     if (this.state === 'disposed') {
       throw new ZeltLifecycleStateError({ operation: 'ready', currentState: 'disposed' });
@@ -40,7 +40,7 @@ export class AppBootstrap {
     return this.readyPromise;
   }
 
-  /** @throws {ZeltLifecycleStateError | ZeltReadyFailedError | ZeltAppConfigurationError} */
+  /** @throws {AggregateError | ZeltLifecycleStateError | ZeltReadyFailedError | ZeltAppConfigurationError} */
   private async doReady(): Promise<ReadyResult> {
     await this.lifecycleManager.startup();
 
@@ -72,7 +72,7 @@ export class AppBootstrap {
     }
   }
 
-  /** @throws {ZeltLifecycleStateError | ZeltReadyFailedError | ZeltAppConfigurationError} */
+  /** @throws {AggregateError | ZeltLifecycleStateError | ZeltReadyFailedError | ZeltAppConfigurationError} */
   private buildReadyResult(): ReadyResult {
     return {
       get: async <T extends object>(cls: new (...args: never[]) => T): Promise<T> => {
@@ -86,7 +86,7 @@ export class AppBootstrap {
     };
   }
 
-  /** @throws {ZeltLifecycleStateError} */
+  /** @throws {AggregateError | ZeltLifecycleStateError} */
   async shutdown(): Promise<void> {
     if (this.state === 'disposed') {
       return;

--- a/packages/core/src/app/create-app.lib.ts
+++ b/packages/core/src/app/create-app.lib.ts
@@ -136,7 +136,7 @@ const hasFeature = (
   return features.some((feature) => feature instanceof featureClass);
 };
 
-/** @throws {ZeltLifecycleStateError | ZeltReadyFailedError | ZeltAppConfigurationError} */
+/** @throws {AggregateError | ZeltLifecycleStateError | ZeltReadyFailedError | ZeltAppConfigurationError} */
 const createRuntimeApp = async <const F extends readonly ConfiguredFeature[]>(
   features: F,
   baseConfigs: readonly ConfigClass<object>[] | undefined,
@@ -158,7 +158,7 @@ const createRuntimeApp = async <const F extends readonly ConfiguredFeature[]>(
   }
 
   let shuttingDown = false;
-  /** @throws {ZeltLifecycleStateError} */
+  /** @throws {AggregateError | ZeltLifecycleStateError} */
   const shutdown = async (): Promise<void> => {
     if (shuttingDown) return;
     shuttingDown = true;
@@ -186,7 +186,7 @@ const createRuntimeApp = async <const F extends readonly ConfiguredFeature[]>(
   return attachContainer(readyApp, container);
 };
 
-/** @throws {ZeltAppConfigurationError | ZeltDecoratorUsageError | ZeltReadyFailedError | ZeltLifecycleStateError} */
+/** @throws {AggregateError | ZeltAppConfigurationError | ZeltDecoratorUsageError | ZeltReadyFailedError | ZeltLifecycleStateError} */
 export const createApp = <const F extends readonly ConfiguredFeature[]>(
   features: F,
   options?: CreateAppOptions,

--- a/packages/core/src/features/http/http-bootstrap.lib.ts
+++ b/packages/core/src/features/http/http-bootstrap.lib.ts
@@ -22,7 +22,7 @@ const ROOT_REQUEST = createContextKey<Request>('zelt:request-root');
 // The request context store must exist before any middleware runs (setUser
 // etc. write into it). Only the outermost router actually creates the store;
 // nested routers see an existing store and stay transparent.
-/** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError | ZeltReadyFailedError} */
+/** @throws {AggregateError | ZeltContextNotAvailableError | ZeltLifecycleStateError | ZeltReadyFailedError} */
 export const createBootstrapMiddleware = (
   lifecycle: LifecycleManager,
   routerToken: symbol,

--- a/packages/core/src/features/http/routing/route-builder.lib.ts
+++ b/packages/core/src/features/http/routing/route-builder.lib.ts
@@ -212,7 +212,7 @@ const registerRoute = (hono: HonoRouter, ctx: RouteBuilderContext, route: Route)
     ctx.resolver,
   );
 
-  /** @throws {ZeltContextNotAvailableError | ZeltReadyFailedError | ZeltLifecycleStateError | ZeltRouteConfigurationError} */
+  /** @throws {AggregateError | ZeltContextNotAvailableError | ZeltReadyFailedError | ZeltLifecycleStateError | ZeltRouteConfigurationError} */
   const handler = async (c: MiddlewareContext): Promise<Response> => {
     const instance = getOrCreateInstance(ctx, route.controllerClass);
     await ctx.lifecycle.startupPending();

--- a/packages/core/src/kernel/lifecycle.lib.test.ts
+++ b/packages/core/src/kernel/lifecycle.lib.test.ts
@@ -60,6 +60,48 @@ describe('LifecycleManager', () => {
     expect(events).toEqual(['second:stop', 'first:stop']);
   });
 
+  it('continues shutdown in reverse order and aggregates failures', async () => {
+    const manager = new LifecycleManager();
+    const events: string[] = [];
+    const shutdownError = new Error('second shutdown failed');
+
+    manager.register({
+      startup: async () => {},
+      shutdown: async () => {
+        events.push('first:stop');
+      },
+    });
+    manager.register({
+      startup: async () => {},
+      shutdown: async () => {
+        events.push('second:stop');
+        throw shutdownError;
+      },
+    });
+
+    await manager.startup();
+
+    await expect(manager.shutdown()).rejects.toMatchObject({ errors: [shutdownError] });
+    expect(events).toEqual(['second:stop', 'first:stop']);
+  });
+
+  it('does not run shutdown hooks again after shutdown completes', async () => {
+    const manager = new LifecycleManager();
+    let shutdownCalls = 0;
+    manager.register({
+      startup: async () => {},
+      shutdown: async () => {
+        shutdownCalls++;
+      },
+    });
+
+    await manager.startup();
+    await manager.shutdown();
+    await manager.shutdown();
+
+    expect(shutdownCalls).toBe(1);
+  });
+
   it('executes startup sequentially (waits for each to complete)', async () => {
     const manager = new LifecycleManager();
     let concurrent = 0;
@@ -158,7 +200,7 @@ describe('LifecycleManager', () => {
       name: 'ZeltReadyFailedError',
       cause,
     });
-    await expect(manager.startup()).rejects.toBeInstanceOf(ZeltReadyFailedError);
+    await expect(manager.startup()).rejects.toBeInstanceOf(ZeltLifecycleStateError);
   });
 
   it('startupPending is idempotent when no new lifecycles registered', async () => {
@@ -261,7 +303,7 @@ describe('LifecycleManager', () => {
       expect(events).toEqual(['started', 'stopped']);
     });
 
-    it('only shuts down started lifecycles', async () => {
+    it('rolls back only successfully started lifecycles when startup fails', async () => {
       const manager = new LifecycleManager();
       const events: string[] = [];
 
@@ -298,9 +340,45 @@ describe('LifecycleManager', () => {
       manager.register(third);
 
       await expect(manager.startup()).rejects.toBeInstanceOf(ZeltReadyFailedError);
+      expect(events).toEqual(['first:start', 'second:start', 'first:stop']);
+      await expect(manager.startup()).rejects.toBeInstanceOf(ZeltLifecycleStateError);
+
       await manager.shutdown();
 
       expect(events).toEqual(['first:start', 'second:start', 'first:stop']);
+    });
+
+    it('surfaces startup and rollback failures and disposes ReadyValues', async () => {
+      const manager = new LifecycleManager();
+      const startupCause = new Error('second startup failed');
+      const rollbackError = new Error('first rollback failed');
+
+      const ready = manager.register({
+        startup: async () => ({ client: 'ready' }),
+        shutdown: async () => {
+          throw rollbackError;
+        },
+      });
+      manager.register({
+        startup: async () => {
+          throw startupCause;
+        },
+        shutdown: async () => {},
+      });
+
+      const failure = await manager.startup().catch((error: unknown) => error);
+
+      expect(failure).toBeInstanceOf(AggregateError);
+      expect(failure).toMatchObject({
+        errors: [
+          {
+            name: 'ZeltReadyFailedError',
+            cause: startupCause,
+          },
+          rollbackError,
+        ],
+      });
+      expect(() => ready.client).toThrow(ZeltLifecycleStateError);
     });
   });
 });

--- a/packages/core/src/kernel/lifecycle.lib.ts
+++ b/packages/core/src/kernel/lifecycle.lib.ts
@@ -1,5 +1,5 @@
 import { Injectable } from './di/index';
-import { ZeltReadyFailedError } from './errors';
+import { ZeltLifecycleStateError, ZeltReadyFailedError } from './errors';
 import type { ReadyValue } from './internal';
 import { createReadyValue, disposeReadyValue, sealReadyValue } from './internal';
 
@@ -18,6 +18,8 @@ type LifecycleEntry = {
 export class LifecycleManager {
   private readonly lifecycles: LifecycleEntry[] = [];
   private startedIndex = 0;
+  private disposed = false;
+  private shutdownPromise: Promise<void> | undefined;
 
   register(lifecycle: Lifecycle<void>): void;
   register<T extends object>(lifecycle: Lifecycle<T>): ReadyValue<T>;
@@ -27,51 +29,114 @@ export class LifecycleManager {
     return readyValue;
   }
 
-  /** @throws {ZeltReadyFailedError | ZeltLifecycleStateError} */
+  /** @throws {AggregateError | ZeltReadyFailedError | ZeltLifecycleStateError} */
   async startup(): Promise<void> {
     await this.startupPending();
   }
 
-  /** @throws {ZeltReadyFailedError | ZeltLifecycleStateError} */
+  /** @throws {AggregateError | ZeltReadyFailedError | ZeltLifecycleStateError} */
   async startupPending(): Promise<void> {
+    this.assertCanStart();
+    await this.startPendingLifecycles();
+  }
+
+  /** @throws {ZeltLifecycleStateError} */
+  private assertCanStart(): void {
+    if (this.disposed) {
+      throw new ZeltLifecycleStateError({ operation: 'startup', currentState: 'disposed' });
+    }
+  }
+
+  /** @throws {AggregateError | ZeltReadyFailedError} */
+  private async startPendingLifecycles(): Promise<void> {
     while (this.startedIndex < this.lifecycles.length) {
       const entry = this.lifecycles[this.startedIndex];
       if (entry) {
-        const result = await this.startLifecycle(entry.lc);
-        if (result && typeof result === 'object' && entry.readyValue) {
-          sealReadyValue(entry.readyValue, result);
+        try {
+          const result = await entry.lc.startup();
+          // Count the lifecycle as started before sealing its ReadyValue. If
+          // sealing fails, the resource returned by startup still needs rollback.
+          this.startedIndex++;
+          if (result && typeof result === 'object' && entry.readyValue) {
+            sealReadyValue(entry.readyValue, result);
+          }
+        } catch (cause) {
+          await this.failStartup(cause, this.getLifecycleName(entry.lc));
         }
+        continue;
       }
       this.startedIndex++;
     }
   }
 
-  /** @throws {ZeltReadyFailedError | ZeltLifecycleStateError} */
-  private async startLifecycle(lifecycle: Lifecycle<unknown>): Promise<unknown> {
-    try {
-      return await lifecycle.startup();
-    } catch (cause) {
-      if (cause instanceof ZeltReadyFailedError) {
-        throw cause;
-      }
-      throw new ZeltReadyFailedError({ lifecycleName: this.getLifecycleName(lifecycle) }, cause);
+  /** @throws {AggregateError | ZeltLifecycleStateError | ZeltReadyFailedError} */
+  private async failStartup(cause: unknown, lifecycleName: string): Promise<never> {
+    this.disposed = true;
+    const rollbackErrors = await this.stopStartedLifecycles();
+    rollbackErrors.push(...this.disposeReadyValues());
+    if (rollbackErrors.length > 0) {
+      throw new AggregateError(
+        [new ZeltReadyFailedError({ lifecycleName }, cause), ...rollbackErrors],
+        'Lifecycle startup failed and rollback encountered errors',
+      );
     }
+    throw new ZeltReadyFailedError({ lifecycleName }, cause);
   }
 
   private getLifecycleName(lifecycle: Lifecycle<unknown>): string {
     return lifecycle.constructor.name || '<anonymous>';
   }
 
-  /** @throws {ZeltLifecycleStateError} */
-  async shutdown(): Promise<void> {
-    for (let i = this.startedIndex - 1; i >= 0; i--) {
-      const entry = this.lifecycles[i];
-      if (entry) {
+  private async stopStartedLifecycles(): Promise<unknown[]> {
+    const errors: unknown[] = [];
+    while (this.startedIndex > 0) {
+      this.startedIndex--;
+      const entry = this.lifecycles[this.startedIndex];
+      if (!entry) continue;
+      try {
         await entry.lc.shutdown();
+      } catch (error) {
+        errors.push(error);
+      } finally {
         if (entry.readyValue) {
-          disposeReadyValue(entry.readyValue);
+          try {
+            disposeReadyValue(entry.readyValue);
+          } catch (error) {
+            errors.push(error);
+          }
         }
       }
+    }
+    return errors;
+  }
+
+  private disposeReadyValues(): unknown[] {
+    const errors: unknown[] = [];
+    for (const entry of this.lifecycles) {
+      if (!entry.readyValue) continue;
+      try {
+        disposeReadyValue(entry.readyValue);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    return errors;
+  }
+
+  /** @throws {AggregateError} */
+  shutdown(): Promise<void> {
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.disposed = true;
+    this.shutdownPromise = this.doShutdown();
+    return this.shutdownPromise;
+  }
+
+  /** @throws {AggregateError} */
+  private async doShutdown(): Promise<void> {
+    const errors = await this.stopStartedLifecycles();
+    errors.push(...this.disposeReadyValues());
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'One or more lifecycle shutdown hooks failed');
     }
   }
 }

--- a/packages/testing/src/test-target.lib.ts
+++ b/packages/testing/src/test-target.lib.ts
@@ -31,6 +31,7 @@ const mergeGlobalDefaults = (configs: readonly AnyConfigClass[]): AnyConfigClass
 
 /**
  * @throws {ZeltAppConfigurationError}
+ * @throws {AggregateError}
  * @throws {ZeltLifecycleStateError}
  * @throws {ZeltInternalError}
  * @throws {ZeltReadyFailedError}


### PR DESCRIPTION
## Summary

- roll back successfully started lifecycles in reverse order when startup fails
- continue all shutdown hooks and aggregate cleanup failures
- dispose ReadyValue instances and make shutdown idempotent
- propagate the new AggregateError contract through runtime call sites

## Test plan

- `pnpm run precommit`
- targeted lifecycle/AppBootstrap tests: 22 passed
- full suite: 1051 passed, 2 skipped
- throw-trace: no issues in 395 files

## Notes

- This is PR A of the architecture cleanup series.
- No UI changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786295562&installation_id=133048706&pr_number=305&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F305&signature=a5f3220b0086e12d43995cf5f9ea3a10cb4aaaf56d7daf26faa45ab340d257e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 起動処理の失敗時に、開始済みの処理を自動的にロールバックするよう改善しました。
  - 起動や停止で複数のエラーが発生した場合、エラー情報をまとめて通知するようになりました。
  - 停止処理を複数回呼び出しても、重複して実行されないよう改善しました。
  - 失敗した実行状態を無効化し、不整合な状態で処理が継続される問題を防止しました。

- **ドキュメント**
  - 各処理で発生し得るエラーの説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->