### PR TITLE
fix(core): isolate internal error bridge boundary

### DIFF
--- a/dependency-cruiser.config.cjs
+++ b/dependency-cruiser.config.cjs
@@ -1,6 +1,7 @@
 const coreSrc = '^packages/core/src/';
 const coreLayer = (name) => `${coreSrc}${name}/`;
 const coreLayerDeep = (name) => `${coreLayer(name)}(?!index\\.ts$).+`;
+const coreKernelDeepExceptErrorIndex = `${coreLayer('kernel')}(?!index\\.ts$|errors/index\\.ts$).+`;
 
 module.exports = {
   forbidden: [
@@ -57,12 +58,12 @@ module.exports = {
       },
     },
     {
-      name: 'core-internal-bridge-imports-core-index-only',
+      name: 'core-internal-bridge-imports-core-public-indexes-only',
       severity: 'error',
       from: { path: coreLayer('internal-bridge') },
       to: {
         path: [
-          coreLayerDeep('kernel'),
+          coreKernelDeepExceptErrorIndex,
           coreLayerDeep('built-in-service'),
           coreLayerDeep('app'),
           coreLayer('features'),

--- a/packages/core/src/internal-bridge/errors.ts
+++ b/packages/core/src/internal-bridge/errors.ts
@@ -1,1 +1,1 @@
-export { defineError } from '../kernel';
+export { defineError } from '../kernel/errors';


### PR DESCRIPTION
## Summary

- route `@zeltjs/core/internal-bridge/errors` through the portable `kernel/errors` public boundary
- allow that explicit public index in the core dependency rules while continuing to reject kernel leaf imports
- remove `node:async_hooks` from the ESM and CJS reachability graph of the error bridge

## Why

The error bridge previously re-exported through the full kernel barrel. Bundling that barrel connected the portable error entry to a shared chunk containing `node:async_hooks`, even though `defineError` itself is platform-independent.

## Verification

- `pnpm run precommit`
- 146 test files passed, 1 skipped
- 1051 tests passed, 2 skipped
- typecheck, cycle detection, 24-project build, lint, docs verification, dist imports, and throw-trace passed
- ESM import and CJS require of `@zeltjs/core/internal-bridge/errors` passed
- runtime-contract violations for `@zeltjs/core/internal-bridge/errors`: 2 to 0
- pre-push `knip` and force-push protection passed

## Follow-up

The full runtime-contract command still reports 26 violations assigned to the planned GraphQL runtime/codegen and platform-primitives follow-up PRs. This PR intentionally fixes only the core internal error bridge boundary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786320066&installation_id=133048706&pr_number=307&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F307&signature=dad23e00250121f39f8b3e3b7b99ff11bb7986d5b9d489e6420c5991e4ca361c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * エラー定義の参照先を整理し、内部ブリッジ経由でエラー関連機能をより安定して利用できるようにしました。
  * 公開インデックス以外への不要な内部参照を制限し、モジュール間の依存関係を適切に管理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->