### PR TITLE
refactor(graphql): separate runtime and codegen entries

### DIFF
--- a/integration/graphql-dogfooding/e2e/graphql.spec.ts
+++ b/integration/graphql-dogfooding/e2e/graphql.spec.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rm } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
-import { generateGraphqlSdl } from '@zeltjs/graphql';
+import { generateGraphqlSdl } from '@zeltjs/graphql/codegen';
 import { valibotAdapter } from '@zeltjs/validator-valibot/openapi';
 import { beforeAll, describe, expect, it } from 'vitest';
 

--- a/integration/graphql-dogfooding/src/app.ts
+++ b/integration/graphql-dogfooding/src/app.ts
@@ -8,6 +8,9 @@ import { StorefrontFieldsResolver } from './graphql/storefront-fields.resolver';
 import { StorefrontMutationResolver } from './graphql/storefront-mutation.resolver';
 
 export const graphqlRuntimeModule = 'src/generated/graphql-runtime.js';
+const graphqlRuntimeImport = './generated/graphql-runtime.js';
+
+const loadGraphqlRuntime = (): Promise<unknown> => import(/* @vite-ignore */ graphqlRuntimeImport);
 
 export const createGraphqlDogfoodingApp = () =>
   createApp([
@@ -26,6 +29,7 @@ export const createGraphqlDogfoodingApp = () =>
                 OrderFieldsResolver,
                 StorefrontMutationResolver,
               ],
+              runtimeLoader: loadGraphqlRuntime,
               runtimeModule: graphqlRuntimeModule,
             }),
           ],

--- a/integration/graphql-schema-first/e2e/generated.ts
+++ b/integration/graphql-schema-first/e2e/generated.ts
@@ -1,7 +1,7 @@
 import { mkdir, rm } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
-import { generateGraphqlSdl } from '@zeltjs/graphql';
+import { generateGraphqlSdl } from '@zeltjs/graphql/codegen';
 
 import { createGraphqlSchemaFirstApp, graphqlRuntimeModule } from '../src/app';
 

--- a/integration/graphql-schema-first/src/app.ts
+++ b/integration/graphql-schema-first/src/app.ts
@@ -4,6 +4,9 @@ import { graphql } from '@zeltjs/graphql';
 import { StorefrontResolver } from './graphql/storefront.resolver';
 
 export const graphqlRuntimeModule = 'src/generated/graphql-runtime.js';
+const graphqlRuntimeImport = './generated/graphql-runtime.js';
+
+const loadGraphqlRuntime = (): Promise<unknown> => import(/* @vite-ignore */ graphqlRuntimeImport);
 
 export const createGraphqlSchemaFirstApp = () =>
   createApp([
@@ -12,6 +15,7 @@ export const createGraphqlSchemaFirstApp = () =>
         graphql({
           path: '/graphql',
           resolvers: [StorefrontResolver],
+          runtimeLoader: loadGraphqlRuntime,
           runtimeModule: graphqlRuntimeModule,
         }),
       ],

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## Unreleased
+
+### Breaking Changes
+
+- Build-time GraphQL APIs now belong to `@zeltjs/graphql/codegen`. Update root
+  imports of `graphqlPlugin`, SDL/runtime generators, schema-first generators,
+  metadata inspection, and GraphQL type conversion helpers to the codegen
+  subpath.
+- Runtime module strings are no longer converted through Node filesystem APIs.
+  Prefer `runtimeLoader: () => import(...)` or pass a generated manifest via
+  `runtime`; keep `runtimeModule` as the codegen output path when generation is
+  required.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -40,8 +40,6 @@ Schema-first:
 Application code may use these APIs directly:
 
 - `graphql()`
-- `graphqlPlugin()`
-- `generateGraphqlSdl()`
 - `Resolver`
 - `Query`
 - `Mutation`
@@ -50,9 +48,12 @@ Application code may use these APIs directly:
 - `gqlScalar()`
 - `GqlOutput`
 
-`graphql()` creates an executable HTTP endpoint and requires `runtimeModule`.
-If you only need SDL generation, use `generateSdlForResolvers()` or the build
-plugin instead of creating a runtime-less endpoint.
+`graphql()` creates an executable HTTP endpoint and requires `runtime`,
+`runtimeLoader`, or the legacy `runtimeModule` loader. Prefer `runtimeLoader`
+when the manifest is generated into a separate module.
+
+Build-time APIs such as `graphqlPlugin()`, `generateGraphqlSdl()`, and
+`generateSdlForResolvers()` are exported only from `@zeltjs/graphql/codegen`.
 
 ### Generated-code API
 
@@ -67,25 +68,15 @@ Use `args(schema)` in code-first mode. Use generated helpers such as
 
 ### Advanced and internal-ish API
 
-These APIs remain exported for runtime tests, build tooling, and advanced
-integrations, but they are not the normal app-authoring surface:
+Runtime integration APIs remain on `@zeltjs/graphql`:
 
 - `createGraphqlExecutor()`
 - `executeGraphqlRequest()`
 - `GraphqlRuntimeManifest`
 - `GeneratedGraphqlRuntime`
-- `generateSdlForResolvers()`
-- `generateGraphqlRuntimeForResolvers()`
-- `generateSchemaFirstCodegen()`
-- `generateSchemaFirstGraphqlRuntimeForResolvers()`
-- GraphQL metadata getters
-- GraphQL type conversion helpers
 
-Future package boundaries may split these into subpath exports:
-
-- `@zeltjs/graphql/runtime`
-- `@zeltjs/graphql/codegen`
-- `@zeltjs/graphql/internal`
+Generation, TypeScript inspection, GraphQL metadata getters, and type
+conversion helpers are available from `@zeltjs/graphql/codegen`.
 
 ## Code-first
 
@@ -120,6 +111,7 @@ export const app = createApp([
       graphql({
         path: '/graphql',
         resolvers: [ProductResolver],
+        runtimeLoader: () => import('./dist/graphql-runtime.js'),
         runtimeModule: './dist/graphql-runtime.js',
       }),
     ],
@@ -182,25 +174,47 @@ should come from generated helpers, not handwritten generic arguments.
 
 ## Build flow
 
-GraphQL endpoints require a generated runtime module.
+GraphQL endpoints require a generated runtime manifest. `runtimeModule` tells
+the codegen plugin where to write it; `runtimeLoader` tells the runtime how to
+load it without assuming a Node filesystem.
+
+```ts
+import { graphqlPlugin } from '@zeltjs/graphql/codegen';
+```
 
 ### Code-first
 
 1. Write resolvers.
-2. Configure `graphql({ runtimeModule })`.
+2. Configure `graphql({ runtimeModule, runtimeLoader })`.
 3. Run `zelt build` or `graphqlPlugin()`.
 4. The plugin generates `graphql-runtime.js` and a sibling `.graphql` file.
-5. The runtime loads the generated module.
+5. The caller-supplied loader loads the generated module.
 
 ### Schema-first
 
 1. Write `schema.graphql`.
 2. Run `zelt graphql codegen --schema ... --out ...`.
 3. Write resolvers using generated `Gql` helpers.
-4. Configure `graphql({ runtimeModule })`.
+4. Configure `graphql({ runtimeModule, runtimeLoader })`.
 5. Run `zelt build` or `graphqlPlugin({ mode: 'schema-first', ... })`.
 6. The plugin generates `graphql-runtime.js` and a sibling `.graphql` file.
-7. The runtime loads the generated module.
+7. The caller-supplied loader loads the generated module.
+
+## Migration from the root codegen exports
+
+Move build-time imports to the codegen subpath:
+
+```ts
+// before
+import { generateGraphqlSdl, graphqlPlugin } from '@zeltjs/graphql';
+
+// after
+import { generateGraphqlSdl, graphqlPlugin } from '@zeltjs/graphql/codegen';
+```
+
+For portable runtime loading, add `runtimeLoader`. A string-only
+`runtimeModule` remains available for compatibility, but it is passed directly
+to `import()` and is no longer resolved against `process.cwd()`.
 
 Automatic schema-first codegen during `zelt dev` is not part of this release
 boundary. Use `zelt graphql codegen` explicitly for now.

--- a/packages/graphql/src/codegen.ts
+++ b/packages/graphql/src/codegen.ts
@@ -1,5 +1,31 @@
+export type { GqlSchemaResolver, GraphqlArgsSchemaRef } from './analyze-gql-args.lib';
+export type { GraphqlControllerMetadata } from './graphql-metadata.lib';
+export { getGraphqlControllerMetadata, getResolverMetadata } from './graphql-metadata.lib';
+export type {
+  GenerateGraphqlSdlOptions,
+  GenerateGraphqlSdlResult,
+  GraphqlPluginOptions,
+} from './graphql-plugin.lib';
+export { generateGraphqlSdl, graphqlPlugin } from './graphql-plugin.lib';
+export type { GenerateSdlOptions } from './graphql-sdl-generator.lib';
+export {
+  generateGraphqlRuntimeForResolvers,
+  generateSdlForResolvers,
+} from './graphql-sdl-generator.lib';
+export type { GraphqlArg, GraphqlSchemaAdapter } from './json-schema-to-graphql-args.lib';
 export type {
   SchemaFirstCodegenOptions,
   SchemaFirstCodegenResult,
 } from './schema-first-codegen.lib';
 export { generateSchemaFirstCodegen, renderSchemaFirstCodegen } from './schema-first-codegen.lib';
+export type {
+  GenerateSchemaFirstResolverChecksOptions,
+  GenerateSchemaFirstResolverChecksResult,
+} from './schema-first-resolver-checks.lib';
+export {
+  generateSchemaFirstResolverChecks,
+  renderSchemaFirstResolverChecks,
+} from './schema-first-resolver-checks.lib';
+export { generateSchemaFirstGraphqlRuntimeForResolvers } from './schema-first-runtime.lib';
+export type { GraphqlTypeContext, GraphqlTypeResult } from './type-to-graphql.lib';
+export { typeInfoToGraphqlType } from './type-to-graphql.lib';

--- a/packages/graphql/src/entry-boundary.test.ts
+++ b/packages/graphql/src/entry-boundary.test.ts
@@ -1,0 +1,70 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const buildTimeExports = [
+  'generateGraphqlSdl',
+  'graphqlPlugin',
+  'generateSdlForResolvers',
+  'generateGraphqlRuntimeForResolvers',
+  'generateSchemaFirstCodegen',
+  'generateSchemaFirstResolverChecks',
+  'generateSchemaFirstGraphqlRuntimeForResolvers',
+  'typeInfoToGraphqlType',
+] as const;
+
+const forbiddenRuntimeDependencyPattern =
+  /(?:from\s+|import\s*\()['"](?:node:(?:fs|path|url)|@zeltjs\/decorator-metadata\/inspect)/;
+
+const resolveSourceModule = (fromFile: string, specifier: string): string =>
+  resolve(dirname(fromFile), `${specifier.replace(/\.js$/, '')}.ts`);
+
+const collectLocalSpecifiers = (file: string, source: string): readonly string[] => {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, false);
+  return sourceFile.statements.flatMap((statement) => {
+    if (!ts.isImportDeclaration(statement) && !ts.isExportDeclaration(statement)) return [];
+    const specifier = statement.moduleSpecifier;
+    return specifier && ts.isStringLiteral(specifier) && specifier.text.startsWith('.')
+      ? [specifier.text]
+      : [];
+  });
+};
+
+const collectReachableSource = async (entryFile: string): Promise<ReadonlyMap<string, string>> => {
+  const sources = new Map<string, string>();
+  const pending = [entryFile];
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (!file || sources.has(file)) continue;
+    const source = await readFile(file, 'utf8');
+    sources.set(file, source);
+    for (const specifier of collectLocalSpecifiers(file, source)) {
+      pending.push(resolveSourceModule(file, specifier));
+    }
+  }
+  return sources;
+};
+
+describe('GraphQL public entry boundary', () => {
+  it('exports build-time APIs only from the codegen entry', async () => {
+    const runtime: Record<string, unknown> = await import('./index');
+    const codegen: Record<string, unknown> = await import('./codegen');
+
+    for (const name of buildTimeExports) {
+      expect(runtime, `${name} must not be exported from @zeltjs/graphql`).not.toHaveProperty(name);
+      expect(codegen, `${name} must be exported from @zeltjs/graphql/codegen`).toHaveProperty(name);
+    }
+  });
+
+  it('does not reach Node file APIs or decorator inspection from the runtime entry', async () => {
+    const entryFile = resolve(__dirname, 'index.ts');
+    const sources = await collectReachableSource(entryFile);
+    const violations = [...sources.entries()].flatMap(([file, source]) =>
+      forbiddenRuntimeDependencyPattern.test(source) ? [file.replace(`${__dirname}/`, '')] : [],
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/graphql/src/graphql-child.lib.ts
+++ b/packages/graphql/src/graphql-child.lib.ts
@@ -9,6 +9,11 @@ import { Controller, http, Post, request } from '@zeltjs/core';
 
 import type { GraphqlResolverClass } from './graphql-metadata.lib';
 import { setGraphqlControllerMetadata } from './graphql-metadata.lib';
+import type {
+  GeneratedGraphqlRuntime,
+  GraphqlRuntimeLoader,
+  GraphqlRuntimeSource,
+} from './graphql-runtime.lib';
 import {
   createGraphqlExecutor,
   getGraphqlRuntimeState,
@@ -17,11 +22,20 @@ import {
   setGraphqlRuntimeState,
 } from './graphql-runtime.lib';
 
-export type GraphqlOptions = {
+type GraphqlBaseOptions = {
   readonly path: string;
   readonly resolvers: readonly GraphqlResolverClass[];
-  readonly runtimeModule: string;
+  /** Build-time output path consumed by graphqlPlugin(). */
+  readonly runtimeModule?: string;
 };
+
+export type GraphqlOptions = GraphqlBaseOptions &
+  (
+    | { readonly runtime: GeneratedGraphqlRuntime; readonly runtimeLoader?: never }
+    | { readonly runtime?: never; readonly runtimeLoader: GraphqlRuntimeLoader }
+    /** @deprecated Prefer runtime or runtimeLoader for portable runtime loading. */
+    | { readonly runtime?: never; readonly runtimeLoader?: never; readonly runtimeModule: string }
+  );
 
 export type GraphqlChildOptions = HttpMountableFeatureModule;
 
@@ -61,7 +75,7 @@ export class GraphqlHttpFeature implements HttpMountableFeatureModule {
     this.controller = GraphqlEndpointController;
     setGraphqlControllerMetadata(GraphqlEndpointController, {
       resolvers: options.resolvers,
-      runtimeModule: options.runtimeModule,
+      ...(options.runtimeModule !== undefined && { runtimeModule: options.runtimeModule }),
     });
   }
 
@@ -88,7 +102,7 @@ export class GraphqlHttpFeature implements HttpMountableFeatureModule {
   readonly realize = async (
     runtimeContext: ServiceResolver,
   ): Promise<HttpMountableCapabilities> => {
-    const generatedRuntime = await loadGeneratedGraphqlRuntime(this.options.runtimeModule);
+    const generatedRuntime = await loadGeneratedGraphqlRuntime(this.runtimeSource());
     const resolverInstances = new Map<string, object>();
     for (const resolver of this.options.resolvers) {
       resolverInstances.set(resolver.name, await runtimeContext.get(resolver));
@@ -106,6 +120,12 @@ export class GraphqlHttpFeature implements HttpMountableFeatureModule {
 
     return http({ path: this.path, controllers: [this.controller] }).realize(runtimeContext);
   };
+
+  private runtimeSource(): GraphqlRuntimeSource {
+    if (this.options.runtime) return this.options.runtime;
+    if (this.options.runtimeLoader) return this.options.runtimeLoader;
+    return this.options.runtimeModule;
+  }
 
   /** @throws {E | Error} */
   private createController(): ControllerClass {

--- a/packages/graphql/src/graphql-child.test.ts
+++ b/packages/graphql/src/graphql-child.test.ts
@@ -2,15 +2,8 @@ import { getClassMetadata } from '@zeltjs/decorator-metadata';
 import { describe, expect, it } from 'vitest';
 
 import type { GraphqlResolverClass } from './graphql-metadata.lib';
-import {
-  getGraphqlControllerMetadata,
-  getResolverMetadata,
-  graphql,
-  Mutation,
-  Query,
-  ResolveField,
-  Resolver,
-} from './index';
+import { getGraphqlControllerMetadata, getResolverMetadata } from './graphql-metadata.lib';
+import { graphql, Mutation, Query, ResolveField, Resolver } from './index';
 
 type UserPublic = {
   readonly id: string;
@@ -38,7 +31,13 @@ class UserResolver {
 describe('graphql HTTP child helper', () => {
   it('returns an HTTP-mountable feature module with a GraphQL controller', () => {
     const runtimeModule = './dist/graphql-runtime.js';
-    const child = graphql({ path: '/graphql', resolvers: [UserResolver], runtimeModule });
+    const runtimeLoader = async () => ({ graphqlRuntime: {} });
+    const child = graphql({
+      path: '/graphql',
+      resolvers: [UserResolver],
+      runtimeLoader,
+      runtimeModule,
+    });
 
     expect(child.path).toBe('/graphql');
     expect(child.blueprint().getControllers()).toHaveLength(1);
@@ -59,11 +58,11 @@ describe('graphql HTTP child helper', () => {
     });
   });
 
-  const _assertRuntimeModuleRequired = (): void => {
-    // @ts-expect-error runtimeModule is required for GraphQL HTTP endpoints.
+  const _assertRuntimeSourceRequired = (): void => {
+    // @ts-expect-error runtimeLoader or runtime is required for GraphQL HTTP endpoints.
     graphql({ path: '/graphql', resolvers: [UserResolver] });
   };
-  void _assertRuntimeModuleRequired;
+  void _assertRuntimeSourceRequired;
 });
 
 describe('resolver name collision detection', () => {
@@ -87,7 +86,7 @@ describe('resolver name collision detection', () => {
       graphql({
         path: '/graphql',
         resolvers: [resolverA, resolverB],
-        runtimeModule: './dist/graphql-runtime.js',
+        runtime: { schemaSdl: '', bindings: {} },
       }),
     ).toThrow(/duplicate.*resolver.*DuplicateName/i);
   });

--- a/packages/graphql/src/graphql-runtime.lib.ts
+++ b/packages/graphql/src/graphql-runtime.lib.ts
@@ -1,6 +1,3 @@
-import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
-
 import type { ExecutionResult, GraphQLSchema, ValidationRule } from 'graphql';
 import {
   buildSchema,
@@ -47,6 +44,10 @@ export type GeneratedGraphqlRuntime = {
 
 export type GraphqlRuntimeManifest = GeneratedGraphqlRuntime;
 
+export type GraphqlRuntimeLoader = () => unknown | Promise<unknown>;
+
+export type GraphqlRuntimeSource = GeneratedGraphqlRuntime | GraphqlRuntimeLoader | string;
+
 export type GraphqlRequestPayload = {
   readonly query: string;
   readonly variables?: Readonly<Record<string, unknown>> | null;
@@ -78,17 +79,6 @@ export const setGraphqlRuntimeState = (controller: object, state: GraphqlRuntime
 
 export const getGraphqlRuntimeState = (controller: object): GraphqlRuntimeState | undefined =>
   runtimeRegistry.get(controller);
-
-const toImportSpecifier = (runtimeModule: string): string => {
-  if (
-    runtimeModule.startsWith('file:') ||
-    runtimeModule.startsWith('node:') ||
-    /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(runtimeModule)
-  ) {
-    return runtimeModule;
-  }
-  return pathToFileURL(resolve(runtimeModule)).href;
-};
 
 const _isPlainObject = (value: unknown): boolean =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -312,15 +302,25 @@ export const parseGraphqlRequestPayload = (value: unknown): GraphqlRequestPayloa
 
 /** @throws {Error} */
 export const loadGeneratedGraphqlRuntime = async (
-  runtimeModule: string,
+  source: GraphqlRuntimeSource,
 ): Promise<GeneratedGraphqlRuntime> => {
-  const mod: unknown = await import(toImportSpecifier(runtimeModule));
-  const modObject = toObject(mod);
-  const runtime = modObject
-    ? parseGeneratedGraphqlRuntime(readProperty(modObject, 'graphqlRuntime'))
-    : undefined;
+  const loaded: unknown =
+    typeof source === 'function'
+      ? await source()
+      : typeof source === 'string'
+        ? await import(source)
+        : source;
+  const loadedObject = toObject(loaded);
+  const runtime =
+    parseGeneratedGraphqlRuntime(loaded) ??
+    (loadedObject
+      ? parseGeneratedGraphqlRuntime(readProperty(loadedObject, 'graphqlRuntime'))
+      : undefined);
   if (!runtime) {
-    throw new Error(`GraphQL runtime module must export graphqlRuntime: ${runtimeModule}`);
+    const sourceLabel = typeof source === 'string' ? `: ${source}` : '';
+    throw new Error(
+      `GraphQL runtime source must be a manifest or export graphqlRuntime${sourceLabel}`,
+    );
   }
   return runtime;
 };

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -6,7 +6,6 @@
  * README for application code.
  */
 export type { StandardSchemaV1 } from '@standard-schema/spec';
-export type { GqlSchemaResolver, GraphqlArgsSchemaRef } from './analyze-gql-args.lib';
 export type { StandardSchemaIssue } from './args.lib';
 export {
   args,
@@ -21,22 +20,11 @@ export { Mutation, Query, ResolveField, Resolver } from './graphql.decorator';
 export type { GraphqlChildOptions, GraphqlOptions } from './graphql-child.lib';
 export { graphql } from './graphql-child.lib';
 export type {
-  GraphqlControllerMetadata,
   GraphqlOperationKind,
   GraphqlOperationMetadata,
   GraphqlResolverClass,
   GraphqlResolverMetadata,
 } from './graphql-metadata.lib';
-export {
-  getGraphqlControllerMetadata,
-  getResolverMetadata,
-} from './graphql-metadata.lib';
-export type {
-  GenerateGraphqlSdlOptions,
-  GenerateGraphqlSdlResult,
-  GraphqlPluginOptions,
-} from './graphql-plugin.lib';
-export { generateGraphqlSdl, graphqlPlugin } from './graphql-plugin.lib';
 export type {
   CreateGraphqlExecutorOptions,
   ExecuteGraphqlRequestOptions,
@@ -44,32 +32,12 @@ export type {
   GeneratedGraphqlRuntime,
   GraphqlExecutor,
   GraphqlRequestPayload,
+  GraphqlRuntimeLoader,
   GraphqlRuntimeManifest,
+  GraphqlRuntimeSource,
 } from './graphql-runtime.lib';
 export {
   createGraphqlExecutor,
   executeGraphqlRequest,
   graphqlRequestPayloadSchema,
 } from './graphql-runtime.lib';
-export type { GenerateSdlOptions } from './graphql-sdl-generator.lib';
-export {
-  generateGraphqlRuntimeForResolvers,
-  generateSdlForResolvers,
-} from './graphql-sdl-generator.lib';
-export type { GraphqlArg, GraphqlSchemaAdapter } from './json-schema-to-graphql-args.lib';
-export type {
-  SchemaFirstCodegenOptions,
-  SchemaFirstCodegenResult,
-} from './schema-first-codegen.lib';
-export { generateSchemaFirstCodegen, renderSchemaFirstCodegen } from './schema-first-codegen.lib';
-export type {
-  GenerateSchemaFirstResolverChecksOptions,
-  GenerateSchemaFirstResolverChecksResult,
-} from './schema-first-resolver-checks.lib';
-export {
-  generateSchemaFirstResolverChecks,
-  renderSchemaFirstResolverChecks,
-} from './schema-first-resolver-checks.lib';
-export { generateSchemaFirstGraphqlRuntimeForResolvers } from './schema-first-runtime.lib';
-export type { GraphqlTypeContext, GraphqlTypeResult } from './type-to-graphql.lib';
-export { typeInfoToGraphqlType } from './type-to-graphql.lib';

--- a/packages/graphql/src/runtime.test.ts
+++ b/packages/graphql/src/runtime.test.ts
@@ -443,7 +443,7 @@ describe('graphql HTTP runtime', () => {
           graphql({
             path: '/graphql',
             resolvers: [RuntimeViewerResolver],
-            runtimeModule: pathToFileURL(runtimeModulePath).href,
+            runtimeLoader: () => import(/* @vite-ignore */ pathToFileURL(runtimeModulePath).href),
           }),
         ],
       }),
@@ -511,7 +511,7 @@ describe('graphql HTTP runtime', () => {
           graphql({
             path: '/graphql',
             resolvers: [SeqResolver],
-            runtimeModule: pathToFileURL(runtimeModulePath).href,
+            runtimeLoader: () => import(/* @vite-ignore */ pathToFileURL(runtimeModulePath).href),
           }),
         ],
       }),

--- a/website/docs/graphql.md
+++ b/website/docs/graphql.md
@@ -37,8 +37,6 @@ Schema-first:
 Supported experimental app-authoring APIs:
 
 - `graphql()`
-- `graphqlPlugin()`
-- `generateGraphqlSdl()`
 - `Resolver`
 - `Query`
 - `Mutation`
@@ -52,18 +50,13 @@ Generated-code APIs are exported for schema-first helpers only:
 - `readGraphqlArgs()`
 - `validateGraphqlArgs()`
 
-Advanced APIs such as `createGraphqlExecutor()`, `executeGraphqlRequest()`,
-`GraphqlRuntimeManifest`, `GeneratedGraphqlRuntime`, `generateSdlForResolvers()`,
-`generateGraphqlRuntimeForResolvers()`, `generateSchemaFirstCodegen()`,
-`generateSchemaFirstGraphqlRuntimeForResolvers()`, metadata getters, and type
-conversion helpers are not the normal application authoring surface.
-
-Future package boundaries may split these into `@zeltjs/graphql/runtime`,
-`@zeltjs/graphql/codegen`, and `@zeltjs/graphql/internal`.
+Build-time APIs such as `graphqlPlugin()`, `generateGraphqlSdl()`,
+`generateSdlForResolvers()`, schema-first codegen, metadata inspection, and
+type conversion are exported from `@zeltjs/graphql/codegen` only.
 
 ## Code-first
 
-```ts
+```ts no-check
 import { createApp, http } from '@zeltjs/core';
 import { args, graphql, Query, Resolver } from '@zeltjs/graphql';
 import * as v from 'valibot';
@@ -91,6 +84,7 @@ export const app = createApp([
       graphql({
         path: '/graphql',
         resolvers: [ProductResolver],
+        runtimeLoader: () => import('./dist/graphql-runtime.js'),
         runtimeModule: './dist/graphql-runtime.js',
       }),
     ],
@@ -148,25 +142,35 @@ should come from generated helpers, not handwritten generic arguments.
 
 ## Build flow
 
-GraphQL endpoints require a generated runtime module.
+GraphQL endpoints require a generated runtime manifest. `runtimeModule` is the
+codegen output path; `runtimeLoader` is the portable runtime loading hook.
+
+```ts no-check
+import { graphqlPlugin } from '@zeltjs/graphql/codegen';
+```
 
 Code-first:
 
 1. Write resolvers.
-2. Configure `graphql({ runtimeModule })`.
+2. Configure `graphql({ runtimeModule, runtimeLoader })`.
 3. Run `zelt build` or `graphqlPlugin()`.
 4. The plugin generates `graphql-runtime.js` and a sibling `.graphql` file.
-5. The runtime loads the generated module.
+5. The caller-supplied loader loads the generated module.
 
 Schema-first:
 
 1. Write `schema.graphql`.
 2. Run `zelt graphql codegen --schema ... --out ...`.
 3. Write resolvers using generated `Gql` helpers.
-4. Configure `graphql({ runtimeModule })`.
+4. Configure `graphql({ runtimeModule, runtimeLoader })`.
 5. Run `zelt build` or `graphqlPlugin({ mode: 'schema-first', ... })`.
 6. The plugin generates `graphql-runtime.js` and a sibling `.graphql` file.
-7. The runtime loads the generated module.
+7. The caller-supplied loader loads the generated module.
+
+Move generation imports from `@zeltjs/graphql` to
+`@zeltjs/graphql/codegen`. String-only `runtimeModule` loading remains for
+compatibility, but the string is passed directly to `import()` and is not
+resolved against the Node working directory.
 
 Automatic schema-first codegen during `zelt dev` is not part of this release
 boundary. Use `zelt graphql codegen` explicitly for now.


### PR DESCRIPTION
## Summary

- keep `@zeltjs/graphql` focused on runtime APIs
- move GraphQL generation, TypeScript inspection, and plugin APIs to `@zeltjs/graphql/codegen`
- replace Node path conversion in runtime loading with portable manifest/loader inputs
- add boundary regression tests, migration documentation, and updated integration fixtures

## Why

The root GraphQL entry re-exported build-time modules and pulled `node:fs`, `node:path`, `node:url`, and TypeScript inspection code into the runtime distribution graph. Runtime loading also converted filesystem paths with Node builtins. This prevented the package boundary from matching Zelt's portable-runtime architecture.

## Impact

Build-time imports such as `graphqlPlugin` and `generateGraphqlSdl` move from `@zeltjs/graphql` to `@zeltjs/graphql/codegen`. Runtime applications can now pass a generated manifest through `runtime` or load one through `runtimeLoader`. The legacy `runtimeModule` option remains available and also continues to identify the codegen output path.

## Validation

- `pnpm precommit`
  - TypeScript project references passed
  - 24 project builds passed without Nx cache
  - lint, circular dependency, core layer, docs, dist import, and throw-trace checks passed
  - 147 test files passed, 1 skipped; 1048 tests passed, 2 skipped
- GraphQL dogfooding integration: 2 tests passed
- GraphQL schema-first integration: prepare/typecheck passed; 2 tests passed
- direct ESM import and CJS require passed for root and codegen entries
- `pnpm verify-dist:runtime-contracts`: GraphQL `node:fs`, `node:path`, and `node:url` violations are removed; the known GraphQL `node:async_hooks` violation remains for C3 platform-context isolation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786322218&installation_id=133048706&pr_number=308&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F308&signature=57f3fb99fc4d1d56dd8353174d33ed97e18e5142e65b5430bb87bf1ea03ca62b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * GraphQLランタイムを、動的ローダーまたは生成済みランタイムとして指定できるようになりました。
  * ビルド時のGraphQL APIを専用の`codegen`エントリーポイントから利用できるようになりました。

* **ドキュメント**
  * ランタイム設定、コード生成、移行手順に関する説明を更新しました。

* **破壊的変更**
  * 一部のビルド時APIのインポート元が変更されました。
  * 従来のランタイムモジュール指定は互換性用途となり、動的ローダーの利用が推奨されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->