### PR TITLE
isolate platform primitives

### DIFF
--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -12,9 +12,9 @@ Cloudflare Workers adapter for Zelt.
 pnpm add @zeltjs/adapter-cloudflare-workers
 ```
 
-This adapter uses `AsyncLocalStorage` from `node:async_hooks`, so the
-`nodejs_compat` compatibility flag (or the narrower `nodejs_als`) must be
-enabled in your `wrangler.toml` / `wrangler.jsonc`:
+Zelt's core context propagation uses `AsyncLocalStorage`, so the
+`nodejs_compat` compatibility flag (or the narrower `nodejs_als`) must still
+be enabled in your `wrangler.toml` / `wrangler.jsonc`:
 
 ```toml
 compatibility_flags = ["nodejs_compat"]

--- a/packages/adapter-cloudflare-workers/src/cloudflare-runtime-context.lib.test.ts
+++ b/packages/adapter-cloudflare-workers/src/cloudflare-runtime-context.lib.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CloudflareRuntimeContext } from './cloudflare-runtime-context.lib';
+import {
+  getCloudflareRuntimeContext,
+  runWithCloudflareRuntimeContext,
+  tryGetCloudflareRuntimeContext,
+} from './cloudflare-runtime-context.lib';
+
+const createContext = (name: string): CloudflareRuntimeContext => ({
+  env: Object.assign(Object.create(null), { NAME: name }) as Env & { NAME: string },
+  ctx: {} as ExecutionContext,
+});
+
+describe('Cloudflare runtime context', () => {
+  it('is unavailable outside request execution', () => {
+    expect(tryGetCloudflareRuntimeContext()).toBeUndefined();
+    expect(() => getCloudflareRuntimeContext()).toThrow(/outside entry execution/);
+  });
+
+  it('propagates and isolates concurrent asynchronous executions', async () => {
+    const [first, second] = await Promise.all([
+      runWithCloudflareRuntimeContext(createContext('first'), async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return (getCloudflareRuntimeContext().env as Env & { NAME: string }).NAME;
+      }),
+      runWithCloudflareRuntimeContext(createContext('second'), async () => {
+        await Promise.resolve();
+        return (getCloudflareRuntimeContext().env as Env & { NAME: string }).NAME;
+      }),
+    ]);
+
+    expect([first, second]).toEqual(['first', 'second']);
+    expect(tryGetCloudflareRuntimeContext()).toBeUndefined();
+  });
+});

--- a/packages/adapter-cloudflare-workers/src/cloudflare-runtime-context.lib.ts
+++ b/packages/adapter-cloudflare-workers/src/cloudflare-runtime-context.lib.ts
@@ -1,16 +1,15 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-import { ZeltContextNotAvailableError } from '@zeltjs/core';
+import { createContextStorage, ZeltContextNotAvailableError } from '@zeltjs/core';
 
 export type CloudflareRuntimeContext = {
   readonly env: Env;
   readonly ctx: ExecutionContext;
 };
 
-const storage = new AsyncLocalStorage<CloudflareRuntimeContext>();
+const storage = createContextStorage<CloudflareRuntimeContext>('zelt:cloudflare-runtime');
 
 /** @throws {ZeltContextNotAvailableError} */
 export const getCloudflareRuntimeContext = (): CloudflareRuntimeContext => {
-  const context = storage.getStore();
+  const context = storage.get();
   if (!context) {
     throw new ZeltContextNotAvailableError({
       primitive: 'CloudflareBindings.get',
@@ -26,7 +25,7 @@ export const runWithCloudflareRuntimeContext = <T>(
 ): T => storage.run(context, fn);
 
 export const tryGetCloudflareRuntimeContext = (): CloudflareRuntimeContext | undefined =>
-  storage.getStore();
+  storage.get();
 
 declare global {
   interface Env {}

--- a/packages/auth-session/src/session.context.lib.ts
+++ b/packages/auth-session/src/session.context.lib.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
+import { createContextStorage } from '@zeltjs/core';
 
 import type { SessionMetadata, SessionSchema } from './session.types';
 
@@ -13,10 +13,10 @@ export interface SessionContext {
   isDirty: boolean;
 }
 
-const sessionStorage = new AsyncLocalStorage<SessionContext>();
+const sessionStorage = createContextStorage<SessionContext>('zelt:auth-session');
 
 export const getSessionContext = (): SessionContext | undefined => {
-  return sessionStorage.getStore();
+  return sessionStorage.get();
 };
 
 export const runWithSessionContext = <R>(context: SessionContext, fn: () => R): R => {

--- a/packages/auth-session/src/session.crypto.lib.ts
+++ b/packages/auth-session/src/session.crypto.lib.ts
@@ -1,15 +1,44 @@
-import { createHmac, randomBytes } from 'node:crypto';
+const encoder = new TextEncoder();
+
+const toBase64Url = (bytes: Uint8Array): string => {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+};
+
+const fromBase64Url = (value: string): Uint8Array<ArrayBuffer> => {
+  const base64 = value.replaceAll('-', '+').replaceAll('_', '/');
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+};
+
+const importHmacKey = (secret: string, usage: KeyUsage): Promise<CryptoKey> =>
+  crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, [
+    usage,
+  ]);
 
 export const generateSessionId = (): string => {
-  return randomBytes(32).toString('hex');
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
 };
 
-export const signSessionId = (sessionId: string, secret: string): string => {
-  const signature = createHmac('sha256', secret).update(sessionId).digest('base64url');
-  return `${sessionId}.${signature}`;
+export const signSessionId = async (sessionId: string, secret: string): Promise<string> => {
+  const key = await importHmacKey(secret, 'sign');
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(sessionId));
+  return `${sessionId}.${toBase64Url(new Uint8Array(signature))}`;
 };
 
-export const verifyAndExtractSessionId = (signedId: string, secret: string): string | null => {
+export const verifyAndExtractSessionId = async (
+  signedId: string,
+  secret: string,
+): Promise<string | null> => {
   const parts = signedId.split('.');
   if (parts.length !== 2) {
     return null;
@@ -17,15 +46,21 @@ export const verifyAndExtractSessionId = (signedId: string, secret: string): str
 
   const sessionId = parts[0];
   const signature = parts[1];
-  if (sessionId === undefined || signature === undefined) {
+  if (
+    sessionId === undefined ||
+    signature === undefined ||
+    sessionId.length === 0 ||
+    !/^[A-Za-z0-9_-]{43}$/.test(signature)
+  ) {
     return null;
   }
 
-  const expectedSignature = createHmac('sha256', secret).update(sessionId).digest('base64url');
-
-  if (signature !== expectedSignature) {
-    return null;
-  }
-
-  return sessionId;
+  const key = await importHmacKey(secret, 'verify');
+  const valid = await crypto.subtle.verify(
+    'HMAC',
+    key,
+    fromBase64Url(signature),
+    encoder.encode(sessionId),
+  );
+  return valid ? sessionId : null;
 };

--- a/packages/auth-session/src/session.crypto.test.ts
+++ b/packages/auth-session/src/session.crypto.test.ts
@@ -19,35 +19,41 @@ describe('session.crypto', () => {
   });
 
   describe('signSessionId / verifyAndExtractSessionId', () => {
-    it('should sign and verify a session ID', () => {
+    it('should sign and verify a session ID', async () => {
       const sessionId = generateSessionId();
-      const signed = signSessionId(sessionId, secret);
+      const signed = await signSessionId(sessionId, secret);
 
       expect(signed).toContain('.');
       expect(signed.startsWith(sessionId)).toBe(true);
 
-      const extracted = verifyAndExtractSessionId(signed, secret);
+      const extracted = await verifyAndExtractSessionId(signed, secret);
       expect(extracted).toBe(sessionId);
     });
 
-    it('should return null for invalid format', () => {
-      expect(verifyAndExtractSessionId('no-dot-here', secret)).toBeNull();
-      expect(verifyAndExtractSessionId('too.many.dots', secret)).toBeNull();
+    it('should preserve the existing HMAC-SHA-256 Base64URL format', async () => {
+      await expect(signSessionId('session-123', secret)).resolves.toBe(
+        'session-123.oaU0Ut7Fi0EnHT67P1a8hnJTIpEH8jGrbSnLPshkFHE',
+      );
     });
 
-    it('should return null for tampered signature', () => {
+    it('should return null for invalid format', async () => {
+      await expect(verifyAndExtractSessionId('no-dot-here', secret)).resolves.toBeNull();
+      await expect(verifyAndExtractSessionId('too.many.dots', secret)).resolves.toBeNull();
+    });
+
+    it('should return null for tampered signature', async () => {
       const sessionId = generateSessionId();
-      const signed = signSessionId(sessionId, secret);
+      const signed = await signSessionId(sessionId, secret);
       const tampered = `${signed.slice(0, -5)}xxxxx`;
 
-      expect(verifyAndExtractSessionId(tampered, secret)).toBeNull();
+      await expect(verifyAndExtractSessionId(tampered, secret)).resolves.toBeNull();
     });
 
-    it('should return null for wrong secret', () => {
+    it('should return null for wrong secret', async () => {
       const sessionId = generateSessionId();
-      const signed = signSessionId(sessionId, secret);
+      const signed = await signSessionId(sessionId, secret);
 
-      expect(verifyAndExtractSessionId(signed, 'wrong-secret')).toBeNull();
+      await expect(verifyAndExtractSessionId(signed, 'wrong-secret')).resolves.toBeNull();
     });
   });
 });

--- a/packages/auth-session/src/session.middleware.ts
+++ b/packages/auth-session/src/session.middleware.ts
@@ -54,7 +54,7 @@ export class SessionMiddleware {
     if (ctx.isDirty || ctx.isNew) {
       ctx.session.meta.expiresAt = Date.now() + this.config.ttlSec * 1000;
       await this.store.set(sessionId, ctx.session, { ttlSec: this.config.ttlSec });
-      const signedId = signSessionId(sessionId, this.config.secret);
+      const signedId = await signSessionId(sessionId, this.config.secret);
       return this.buildSetCookieHeader(signedId);
     }
 
@@ -69,7 +69,7 @@ export class SessionMiddleware {
     const signedId = req.cookie(this.config.cookieName);
 
     if (signedId) {
-      const sessionId = verifyAndExtractSessionId(signedId, this.config.secret);
+      const sessionId = await verifyAndExtractSessionId(signedId, this.config.secret);
       if (sessionId) {
         const stored = await this.store.get<StoredSession>(sessionId);
         if (stored && stored.meta.expiresAt > Date.now()) {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+* **core:** add `createContextStorage()` for typed asynchronous context shared by
+  framework integrations. Existing application APIs require no migration.
+
 ### ⚠ BREAKING CHANGES
 
 * **di:** `inject(token, options)` is no longer part of the Zelt API. Code using

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -31,6 +31,26 @@ A portable TypeScript application framework with built-in DI. Swap adapters to r
 | AWS Lambda | `@zeltjs/adapter-lambda` |
 | Electron | `@zeltjs/adapter-electron` |
 
+## Runtime Context Storage
+
+Framework integrations can share request-scoped state through Zelt's runtime
+context instead of importing a platform-specific async-context API:
+
+```typescript
+import { createContextStorage } from '@zeltjs/core';
+
+const traceStorage = createContextStorage<string>('my-package:trace-id');
+
+const result = await traceStorage.run('trace-123', async () => {
+  await Promise.resolve();
+  return traceStorage.get();
+});
+```
+
+`run()` propagates the value across asynchronous work, isolates concurrent
+executions, and restores an outer value after nested execution. `get()`
+returns `undefined` outside an active context.
+
 ## Installation
 
 ```bash

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -166,8 +166,8 @@ export { Weekly } from './features/scheduler/schedule/weekly.decorator';
 export type { SchedulerClass } from './features/scheduler/scheduler.types';
 export type { TaskFunction, TaskOptions } from './features/task';
 export { TaskService } from './features/task';
-export type { Lifecycle } from './kernel';
-export { LifecycleManager, runInContext } from './kernel';
+export type { ContextStorage, Lifecycle } from './kernel';
+export { createContextStorage, LifecycleManager, runInContext } from './kernel';
 // DI primitives
 // DI
 export { Injectable, inject } from './kernel/di';

--- a/packages/core/src/kernel/index.ts
+++ b/packages/core/src/kernel/index.ts
@@ -17,7 +17,9 @@ export {
 } from './errors';
 export {
   type ContextKey,
+  type ContextStorage,
   createContextKey,
+  createContextStorage,
   createInjectableClassDecorator,
   createReadyValue,
   disposeReadyValue,

--- a/packages/core/src/kernel/internal/context-storage.lib.test.ts
+++ b/packages/core/src/kernel/internal/context-storage.lib.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { createContextStorage } from './context-storage.lib';
+
+describe('createContextStorage', () => {
+  it('returns undefined outside a context', () => {
+    const storage = createContextStorage<string>('test:outside');
+
+    expect(storage.get()).toBeUndefined();
+  });
+
+  it('propagates a value across an asynchronous boundary', async () => {
+    const storage = createContextStorage<string>('test:async');
+
+    const value = await storage.run('inside', async () => {
+      await Promise.resolve();
+      return storage.get();
+    });
+
+    expect(value).toBe('inside');
+    expect(storage.get()).toBeUndefined();
+  });
+
+  it('isolates concurrent values', async () => {
+    const storage = createContextStorage<string>('test:concurrent');
+
+    const [a, b] = await Promise.all([
+      storage.run('A', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return storage.get();
+      }),
+      storage.run('B', async () => storage.get()),
+    ]);
+
+    expect([a, b]).toEqual(['A', 'B']);
+  });
+
+  it('restores a parent value after a nested run', () => {
+    const storage = createContextStorage<string>('test:nested');
+
+    storage.run('outer', () => {
+      storage.run('inner', () => expect(storage.get()).toBe('inner'));
+      expect(storage.get()).toBe('outer');
+    });
+  });
+
+  it('isolates different storage keys', () => {
+    const first = createContextStorage<string>('test:first');
+    const second = createContextStorage<number>('test:second');
+
+    first.run('value', () => {
+      second.run(42, () => {
+        expect(first.get()).toBe('value');
+        expect(second.get()).toBe(42);
+      });
+    });
+  });
+});

--- a/packages/core/src/kernel/internal/context-storage.lib.ts
+++ b/packages/core/src/kernel/internal/context-storage.lib.ts
@@ -1,0 +1,26 @@
+import {
+  createContextKey,
+  getInternal,
+  hasContext,
+  runInContext,
+  setInternal,
+} from './context-key.lib';
+
+export interface ContextStorage<T> {
+  get(): T | undefined;
+  run<R>(value: T, fn: () => R): R;
+}
+
+/** @throws {ZeltContextNotAvailableError} */
+export const createContextStorage = <T>(name: string): ContextStorage<T> => {
+  const key = createContextKey<T>(name);
+
+  return {
+    get: () => (hasContext() ? getInternal(key) : undefined),
+    run: (value, fn) =>
+      runInContext(() => {
+        setInternal(key, value);
+        return fn();
+      }),
+  };
+};

--- a/packages/core/src/kernel/internal/index.ts
+++ b/packages/core/src/kernel/internal/index.ts
@@ -7,6 +7,8 @@ export {
   runInRootContext,
   setInternal,
 } from './context-key.lib';
+export type { ContextStorage } from './context-storage.lib';
+export { createContextStorage } from './context-storage.lib';
 export type { InjectableClassDecoratorHooks } from './decorator-helpers.lib';
 export { createInjectableClassDecorator } from './decorator-helpers.lib';
 export type { ReadyValue } from './ready-value.lib';

--- a/packages/db/src/database-service.test.ts
+++ b/packages/db/src/database-service.test.ts
@@ -17,8 +17,10 @@ class MockDatabaseService extends DatabaseService<{ query: (sql: string) => stri
     client: { query: (sql: string) => string },
     fn: (tx: { query: (sql: string) => string }) => Promise<T>,
   ): Promise<T> {
-    this.transactionCalls.push({ client });
-    return fn(client);
+    const transactionNumber = this.transactionCalls.length + 1;
+    const tx = { query: (sql: string) => `tx-${transactionNumber}: ${sql}` };
+    this.transactionCalls.push({ client, tx });
+    return fn(tx);
   }
 
   async shutdown() {
@@ -56,7 +58,7 @@ describe('DatabaseService', () => {
         return service.client.query('SELECT * FROM users');
       });
 
-      expect(result).toBe('result: SELECT * FROM users');
+      expect(result).toBe('tx-1: SELECT * FROM users');
       expect(service.transactionCalls).toHaveLength(1);
     });
 
@@ -97,6 +99,25 @@ describe('DatabaseService', () => {
         outerClientAfterNested = service.client;
         expect(outerClientAfterNested).toBe(outerClient);
       });
+    });
+
+    it('isolates concurrent transaction clients', async () => {
+      const [first, second] = await Promise.all([
+        service.withTransaction(async () => {
+          const before = service.client.query('before');
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return [before, service.client.query('after')];
+        }),
+        service.withTransaction(async () => {
+          const before = service.client.query('before');
+          await Promise.resolve();
+          return [before, service.client.query('after')];
+        }),
+      ]);
+
+      expect(first).toEqual(['tx-1: before', 'tx-1: after']);
+      expect(second).toEqual(['tx-2: before', 'tx-2: after']);
+      expect(service.client.query('outside')).toBe('result: outside');
     });
   });
 

--- a/packages/db/src/database.service.ts
+++ b/packages/db/src/database.service.ts
@@ -1,11 +1,9 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-
 import type { Lifecycle } from '@zeltjs/core';
-import { inject, LifecycleManager } from '@zeltjs/core';
+import { createContextStorage, inject, LifecycleManager } from '@zeltjs/core';
 
 export abstract class DatabaseService<TDatabase> implements Lifecycle<{ client: TDatabase }> {
   private readonly ready;
-  private readonly txStorage = new AsyncLocalStorage<TDatabase>();
+  private readonly txStorage = createContextStorage<TDatabase>('zelt:db:transaction');
 
   constructor(lifecycle = inject(LifecycleManager)) {
     this.ready = lifecycle.register(this);
@@ -22,11 +20,11 @@ export abstract class DatabaseService<TDatabase> implements Lifecycle<{ client: 
   abstract shutdown(): Promise<void>;
 
   get client(): TDatabase {
-    return this.txStorage.getStore() ?? this.ready.client;
+    return this.txStorage.get() ?? this.ready.client;
   }
 
   withTransaction<T>(fn: () => Promise<T>): Promise<T> {
-    const current = this.txStorage.getStore();
+    const current = this.txStorage.get();
     const targetClient = current ?? this.ready.client;
 
     return this.transaction(targetClient, (tx) => this.txStorage.run(tx, fn));

--- a/packages/db/src/decorator.test.ts
+++ b/packages/db/src/decorator.test.ts
@@ -25,6 +25,10 @@ class MockDatabaseService extends DatabaseService<{ id: string }> {
 const mockService = new MockDatabaseService();
 
 vi.mock('@zeltjs/core', () => ({
+  createContextStorage: () => ({
+    get: () => undefined,
+    run: (_value: unknown, fn: () => unknown) => fn(),
+  }),
   inject: vi.fn((cls: unknown) => {
     if (cls === MockDatabaseService) return mockService;
     return { register: vi.fn() };

--- a/packages/db/src/middleware.test.ts
+++ b/packages/db/src/middleware.test.ts
@@ -25,6 +25,10 @@ class MockDatabaseService extends DatabaseService<{ id: string }> {
 const mockService = new MockDatabaseService();
 
 vi.mock('@zeltjs/core', () => ({
+  createContextStorage: () => ({
+    get: () => undefined,
+    run: (_value: unknown, fn: () => unknown) => fn(),
+  }),
   inject: vi.fn((cls: unknown) => {
     if (cls === MockDatabaseService) return mockService;
     return { register: vi.fn() };

--- a/packages/graphql/src/args.lib.ts
+++ b/packages/graphql/src/args.lib.ts
@@ -1,6 +1,5 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-
 import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { createContextStorage } from '@zeltjs/core';
 
 export type StandardSchemaIssue = StandardSchemaV1.Issue;
 
@@ -11,7 +10,8 @@ export class GraphqlArgsValidationError extends Error {
   }
 }
 
-const graphqlArgsStorage = new AsyncLocalStorage<Readonly<Record<string, unknown>>>();
+const graphqlArgsStorage =
+  createContextStorage<Readonly<Record<string, unknown>>>('zelt:graphql:args');
 
 const isThenable = (value: unknown): boolean => {
   if (value === null) return false;
@@ -25,7 +25,7 @@ export const runWithGraphqlArgs = <T>(args: Readonly<Record<string, unknown>>, f
 
 /** @throws {Error} */
 const getGraphqlArgsContext = (): Readonly<Record<string, unknown>> => {
-  const rawArgs = graphqlArgsStorage.getStore();
+  const rawArgs = graphqlArgsStorage.get();
   if (rawArgs === undefined) {
     throw new Error(
       'args() requires a GraphQL args context; call it only as a resolver method default parameter.',

--- a/packages/graphql/src/args.test.ts
+++ b/packages/graphql/src/args.test.ts
@@ -56,6 +56,22 @@ describe('args', () => {
 
     expect(output).toEqual({ id: 'product-1' });
   });
+
+  it('isolates concurrent GraphQL args across asynchronous boundaries', async () => {
+    const [first, second] = await Promise.all([
+      runWithGraphqlArgs({ id: 'first' }, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return readGraphqlArgs<{ readonly id: string }>().id;
+      }),
+      runWithGraphqlArgs({ id: 'second' }, async () => {
+        await Promise.resolve();
+        return readGraphqlArgs<{ readonly id: string }>().id;
+      }),
+    ]);
+
+    expect([first, second]).toEqual(['first', 'second']);
+    expect(() => readGraphqlArgs()).toThrow(/requires a GraphQL args context/);
+  });
 });
 
 type UserPublic = {


### PR DESCRIPTION
## Summary

- add a typed `createContextStorage()` primitive backed by the core runtime context
- migrate auth-session, database transactions, GraphQL args, and Cloudflare runtime state away from direct `node:async_hooks` imports
- replace session ID generation and HMAC signing with Web Crypto while preserving the existing cookie signature format

## Why

Runtime packages each owned a separate Node-specific `AsyncLocalStorage`, and auth-session directly imported `node:crypto`. Those imports leaked platform dependencies into portable runtime entrypoints.

Centralizing asynchronous context propagation in core gives integrations one runtime boundary. Web Crypto removes the direct Node crypto dependency without adding adapter configuration.

## Impact

- C3-owned runtime-contract violations drop from 10 to 0 across ESM and CJS
- `SessionMiddleware` remains asynchronous and existing signed cookies remain compatible
- Cloudflare Workers still require `nodejs_als` or `nodejs_compat` for core context propagation
- `createContextStorage()` is an additive public API for framework integrations

## Validation

- `pnpm precommit`
  - typecheck
  - cycle and core-layer checks
  - uncached build for 24 projects
  - ESLint/Oxlint
  - example and documentation checks
  - distribution import verification
  - throw-trace
  - 148 test files passed, 1 skipped; 1056 tests passed, 2 skipped
- `pnpm verify-dist:runtime-contracts`
  - C3-owned violations: 0
  - the command remains red from separately owned C1/C2 and existing CLI violations

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786323383&installation_id=133048706&pr_number=309&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F309&signature=0476377ba5d5f91821afae0e111425b0c5db85e995f8681ce6b117e2da1cab2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 非同期処理中の実行コンテキスト共有機能を追加し、ネストや並行実行でも状態を安全に分離・復元できるようになりました。
  * Cloudflare Workers、データベーストランザクション、GraphQL引数、セッション処理でコンテキスト管理を統一しました。
  * セッションIDの生成・署名・検証がWeb Crypto APIに対応しました。

* **ドキュメント**
  * コンテキスト共有機能の利用方法を追加しました。
  * Cloudflare Workersで必要な互換性設定の説明を更新しました。

* **テスト**
  * 非同期処理、並行実行、ネスト実行時の分離と復元を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->