### PR TITLE
fix(openapi): align generated response contracts

### DIFF
--- a/examples/drizzle-todo/package.json
+++ b/examples/drizzle-todo/package.json
@@ -17,7 +17,8 @@
     "better-sqlite3": "12.9.0",
     "drizzle-orm": "0.45.2",
     "valibot": "catalog:",
-    "@zeltjs/openapi": "workspace:*"
+    "@zeltjs/openapi": "workspace:*",
+    "@zeltjs/validator-valibot": "workspace:*"
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.13",

--- a/examples/drizzle-todo/zelt.config.ts
+++ b/examples/drizzle-todo/zelt.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig } from '@zeltjs/cli';
 import { openapiPlugin } from '@zeltjs/openapi';
+import { valibotAdapter } from '@zeltjs/validator-valibot/openapi';
 
 export default defineConfig({
   app: () => import('./src/app').then((m) => m.app),
-  plugins: [openapiPlugin({ outDir: './generated', tsconfig: './tsconfig.json' })],
+  plugins: [
+    openapiPlugin({
+      outDir: './generated',
+      tsconfig: './tsconfig.json',
+      schemaAdapter: valibotAdapter,
+    }),
+  ],
 
   build: {
     entry: './src/node.ts',

--- a/examples/hello/generated/openapi.json
+++ b/examples/hello/generated/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "zelt app",
+    "title": "Zelt API",
     "version": "0.0.0"
   },
   "paths": {
@@ -19,11 +19,11 @@
         ],
         "responses": {
           "200": {
-            "description": "",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GreetResponse"
+                  "$ref": "#/components/schemas/HelloController_greet_Response"
                 }
               }
             }
@@ -38,24 +38,24 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GreetBody"
+                "$ref": "#/components/schemas/HelloController_greetPost_Request"
               }
             }
           }
         },
         "responses": {
           "201": {
-            "description": "",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GreetResponse"
+                  "$ref": "#/components/schemas/HelloController_greetPost_Response"
                 }
               }
             }
           },
           "400": {
-            "description": "validation failed",
+            "description": "Validation failed",
             "content": {
               "application/json": {
                 "schema": {
@@ -70,6 +70,43 @@
   },
   "components": {
     "schemas": {
+      "HelloController_greet_Response": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "HelloController_greetPost_Request": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "excited": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "HelloController_greetPost_Response": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
       "ValidationErrorBody": {
         "type": "object",
         "properties": {
@@ -106,37 +143,7 @@
         "required": [
           "code",
           "issues"
-        ],
-        "$schema": "http://json-schema.org/draft-07/schema#"
-      },
-      "GreetResponse": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "message"
-        ],
-        "additionalProperties": false,
-        "definitions": {}
-      },
-      "GreetBody": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "excited": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "name"
-        ],
-        "$schema": "http://json-schema.org/draft-07/schema#"
+        ]
       }
     }
   }

--- a/examples/hello/package.json
+++ b/examples/hello/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx src/main.ts",
     "dev:node": "tsx src/node.ts",
+    "generate:openapi": "tsx scripts/generate-openapi.ts",
     "typecheck": "tsc --noEmit",
     "contract:build": "tsx ../../packages/contract/src/cli.ts build",
     "contract:watch": "tsx ../../packages/contract/src/cli.ts watch"
@@ -16,6 +17,8 @@
     "@zeltjs/cli": "workspace:*",
     "@zeltjs/core": "workspace:*",
     "@zeltjs/openapi": "workspace:*",
+    "@zeltjs/validator-valibot": "workspace:*",
+    "@valibot/to-json-schema": "catalog:",
     "@zeltjs/hono-client": "workspace:*",
     "tsdown": "catalog:",
     "valibot": "catalog:"

--- a/examples/hello/scripts/generate-openapi.ts
+++ b/examples/hello/scripts/generate-openapi.ts
@@ -1,0 +1,10 @@
+import { generateOpenApi } from '@zeltjs/openapi';
+import { valibotAdapter } from '@zeltjs/validator-valibot/openapi';
+
+import { app } from '../src/app';
+
+await generateOpenApi(app.http, {
+  distDir: './generated',
+  tsconfig: './tsconfig.json',
+  schemaAdapter: valibotAdapter,
+});

--- a/examples/hello/tsconfig.json
+++ b/examples/hello/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "erasableSyntaxOnly": false
   },
-  "include": ["src/**/*", "generated/**/*"]
+  "include": ["src/**/*", "scripts/**/*", "generated/**/*"]
 }

--- a/examples/hello/zelt.config.ts
+++ b/examples/hello/zelt.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from '@zeltjs/cli';
 import { honoClientPlugin } from '@zeltjs/hono-client';
 import { openapiPlugin } from '@zeltjs/openapi';
+import { valibotAdapter } from '@zeltjs/validator-valibot/openapi';
 
 export default defineConfig({
   app: () => import('./src/app').then((m) => m.app),
   plugins: [
-    openapiPlugin({ outDir: './generated', tsconfig: './tsconfig.json' }),
+    openapiPlugin({
+      outDir: './generated',
+      tsconfig: './tsconfig.json',
+      schemaAdapter: valibotAdapter,
+    }),
     honoClientPlugin({ outDir: './generated' }),
   ],
 

--- a/integration/hello-world/e2e/fixtures/openapi.expected.json
+++ b/integration/hello-world/e2e/fixtures/openapi.expected.json
@@ -324,6 +324,16 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorBody"
+                }
+              }
+            }
           }
         }
       }
@@ -338,7 +348,9 @@
             "type": "string"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "HelloController_asyncGreeting_Response": {
         "type": "object",
@@ -347,7 +359,9 @@
             "type": "string"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "HelloController_streamGreeting_Response": {
         "type": "object",
@@ -356,7 +370,9 @@
             "type": "string"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "HelloController_greet_Response": {
         "type": "object",
@@ -365,7 +381,9 @@
             "type": "string"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "MiddlewareController_withLogging_Response": {
         "type": "object",
@@ -374,7 +392,9 @@
             "type": "boolean"
           }
         },
-        "required": ["ok"]
+        "required": [
+          "ok"
+        ]
       },
       "MiddlewareController_skipLogging_Response": {
         "type": "object",
@@ -383,7 +403,9 @@
             "type": "boolean"
           }
         },
-        "required": ["ok"]
+        "required": [
+          "ok"
+        ]
       },
       "MiddlewareController_withHeader_Response": {
         "type": "object",
@@ -392,7 +414,9 @@
             "type": "boolean"
           }
         },
-        "required": ["ok"]
+        "required": [
+          "ok"
+        ]
       },
       "PipesController_getUserById_Response": {
         "type": "object",
@@ -404,7 +428,10 @@
             "type": "string"
           }
         },
-        "required": ["id", "greeting"]
+        "required": [
+          "id",
+          "greeting"
+        ]
       },
       "PipesController_transformValue_Response": {
         "type": "object",
@@ -419,7 +446,11 @@
             "type": "string"
           }
         },
-        "required": ["original", "upper", "lower"]
+        "required": [
+          "original",
+          "upper",
+          "lower"
+        ]
       },
       "InterceptorsController_override_Response": {
         "type": "object",
@@ -428,7 +459,9 @@
             "type": "string"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "InterceptorsController_transform_Response": {
         "type": "string"
@@ -449,7 +482,9 @@
             "type": "string"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "UsersController_create_Request": {
         "type": "object",
@@ -464,7 +499,10 @@
             "type": "number"
           }
         },
-        "required": ["name", "email"],
+        "required": [
+          "name",
+          "email"
+        ],
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
       "UsersController_create_Response": {
@@ -483,7 +521,49 @@
             "type": "string"
           }
         },
-        "required": ["name", "email", "id"]
+        "required": [
+          "name",
+          "email",
+          "id"
+        ]
+      },
+      "ValidationErrorBody": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "const": "VALIDATION_FAILED"
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "array",
+                  "items": {}
+                }
+              },
+              "required": [
+                "kind",
+                "type",
+                "message"
+              ]
+            }
+          }
+        },
+        "required": [
+          "code",
+          "issues"
+        ]
       }
     }
   }

--- a/integration/hello-world/e2e/fixtures/openapi.expected.json
+++ b/integration/hello-world/e2e/fixtures/openapi.expected.json
@@ -348,9 +348,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "message"
-        ]
+        "required": ["message"]
       },
       "HelloController_asyncGreeting_Response": {
         "type": "object",
@@ -359,9 +357,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "message"
-        ]
+        "required": ["message"]
       },
       "HelloController_streamGreeting_Response": {
         "type": "object",
@@ -370,9 +366,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "message"
-        ]
+        "required": ["message"]
       },
       "HelloController_greet_Response": {
         "type": "object",
@@ -381,9 +375,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "message"
-        ]
+        "required": ["message"]
       },
       "MiddlewareController_withLogging_Response": {
         "type": "object",
@@ -392,9 +384,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "ok"
-        ]
+        "required": ["ok"]
       },
       "MiddlewareController_skipLogging_Response": {
         "type": "object",
@@ -403,9 +393,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "ok"
-        ]
+        "required": ["ok"]
       },
       "MiddlewareController_withHeader_Response": {
         "type": "object",
@@ -414,9 +402,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "ok"
-        ]
+        "required": ["ok"]
       },
       "PipesController_getUserById_Response": {
         "type": "object",
@@ -428,10 +414,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "greeting"
-        ]
+        "required": ["id", "greeting"]
       },
       "PipesController_transformValue_Response": {
         "type": "object",
@@ -446,11 +429,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "original",
-          "upper",
-          "lower"
-        ]
+        "required": ["original", "upper", "lower"]
       },
       "InterceptorsController_override_Response": {
         "type": "object",
@@ -459,9 +438,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "message"
-        ]
+        "required": ["message"]
       },
       "InterceptorsController_transform_Response": {
         "type": "string"
@@ -482,9 +459,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "message"
-        ]
+        "required": ["message"]
       },
       "UsersController_create_Request": {
         "type": "object",
@@ -499,10 +474,7 @@
             "type": "number"
           }
         },
-        "required": [
-          "name",
-          "email"
-        ],
+        "required": ["name", "email"],
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
       "UsersController_create_Response": {
@@ -521,11 +493,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "name",
-          "email",
-          "id"
-        ]
+        "required": ["name", "email", "id"]
       },
       "ValidationErrorBody": {
         "type": "object",
@@ -552,18 +520,11 @@
                   "items": {}
                 }
               },
-              "required": [
-                "kind",
-                "type",
-                "message"
-              ]
+              "required": ["kind", "type", "message"]
             }
           }
         },
-        "required": [
-          "code",
-          "issues"
-        ]
+        "required": ["code", "issues"]
       }
     }
   }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -27,6 +27,7 @@ const config: KnipConfig = {
         'src/controllers.ts',
         'src/middlewares/*.ts',
         'src/test/*.e2e.test.ts',
+        'scripts/generate-openapi.ts',
       ],
       ignore: ['generated/**'],
       ignoreDependencies: [
@@ -36,6 +37,7 @@ const config: KnipConfig = {
         '@zeltjs/cli',
         '@zeltjs/core',
         '@zeltjs/validator-valibot',
+        '@valibot/to-json-schema',
         'tsdown',
         'valibot',
       ],

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
     "test:integration": "./integration/scripts/run-tests.sh dist",
     "test:runtime-contracts": "node --test scripts/verify-dist-runtime-contracts.test.mjs",
     "typecheck": "tsc -b",
-    "precommit": "pnpm --filter @zeltjs/eslint-plugin build && ./scripts/format-staged.sh && pnpx lint-staged && pnpm typecheck && pnpm lint:cycle && pnpm nx run-many -t build --skip-nx-cache && pnpm test:runtime-contracts && pnpm verify-dist:runtime-contracts && pnpm lint && pnpm --filter '@examples/*' typecheck && pnpm --filter website verify:docs && pnpm verify-dist && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
+    "precommit": "pnpm --filter @zeltjs/eslint-plugin build && ./scripts/format-staged.sh && pnpx lint-staged && pnpm typecheck && pnpm lint:cycle && pnpm nx run-many -t build --skip-nx-cache && pnpm test:runtime-contracts && pnpm verify-dist:runtime-contracts && pnpm lint && pnpm --filter '@examples/*' typecheck && pnpm verify-generated:openapi && pnpm --filter website verify:docs && pnpm verify-dist && pnpm check:no-neverthrow-leak && pnpm throw-trace && pnpm test && npx precommit-verify save",
     "prepare": "pnpx lefthook install",
     "codepolicy:diff": "time codepolicy --filter=diff 2>&1 | tee codepolicy.diff.log",
     "throw-trace": "./scripts/throw-trace.sh",
     "verify-dist": "node scripts/verify-dist-imports.mjs",
-    "verify-dist:runtime-contracts": "node scripts/verify-dist-runtime-contracts.mjs"
+    "verify-dist:runtime-contracts": "node scripts/verify-dist-runtime-contracts.mjs",
+    "verify-generated:openapi": "pnpm --filter @examples/hello generate:openapi && git diff --exit-code -- examples/hello/generated/openapi.json"
   },
   "devDependencies": {
     "@9wick/eslint-plugin-strict-type-rules": "^1.5.0",

--- a/packages/openapi/src/generate-openapi.lib.test.ts
+++ b/packages/openapi/src/generate-openapi.lib.test.ts
@@ -1,0 +1,97 @@
+import type { MethodInfo, TypeInfo } from '@zeltjs/decorator-metadata/inspect';
+import { describe, expect, it } from 'vitest';
+import type { ControllerRouteInfo, RouteInfo } from './generate-openapi.lib';
+import { buildResponseSchemaFromTypeInfo } from './generate-openapi.lib';
+
+const controller: ControllerRouteInfo = { basePath: '/items', name: 'Items', routes: [] };
+const route: RouteInfo = {
+  method: 'GET',
+  path: '/',
+  fullPath: '/items',
+  methodName: 'find',
+};
+
+const typedResponse = (body: TypeInfo, status: number): TypeInfo => ({
+  kind: 'object',
+  properties: [
+    { name: '_data', type: body, optional: false },
+    { name: '_status', type: { kind: 'literal', value: status }, optional: false },
+    { name: '_format', type: { kind: 'literal', value: 'json' }, optional: false },
+  ],
+});
+
+const method = (returnType: TypeInfo): MethodInfo => ({
+  name: 'find',
+  pos: undefined,
+  props: [],
+  params: [],
+  returnType,
+});
+
+describe('OpenAPI response contracts', () => {
+  it('uses the status carried by TypedResponse', () => {
+    const schemas = {};
+    const responses = buildResponseSchemaFromTypeInfo(
+      controller,
+      route,
+      method(typedResponse({ kind: 'primitive', type: 'string' }, 201)),
+      schemas,
+    );
+
+    expect(responses).toEqual({
+      '201': {
+        description: 'OK',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/Items_find_Response' },
+          },
+        },
+      },
+    });
+    expect(schemas).toEqual({ Items_find_Response: { type: 'string' } });
+  });
+
+  it('emits each status from a union response', () => {
+    const schemas = {};
+    const responses = buildResponseSchemaFromTypeInfo(
+      controller,
+      route,
+      method({
+        kind: 'union',
+        types: [
+          typedResponse({ kind: 'primitive', type: 'string' }, 200),
+          typedResponse({ kind: 'primitive', type: 'null' }, 404),
+        ],
+      }),
+      schemas,
+    );
+
+    expect(Object.keys(responses)).toEqual(['200', '404']);
+    expect(Object.keys(schemas)).toEqual([
+      'Items_find_Response_200_0',
+      'Items_find_Response_404_1',
+    ]);
+  });
+
+  it('treats a plain object return as a 200 JSON response', () => {
+    const schemas = {};
+    const responses = buildResponseSchemaFromTypeInfo(
+      controller,
+      route,
+      method({
+        kind: 'object',
+        properties: [{ name: 'id', type: { kind: 'primitive', type: 'number' }, optional: false }],
+      }),
+      schemas,
+    );
+
+    expect(Object.keys(responses)).toEqual(['200']);
+    expect(schemas).toEqual({
+      Items_find_Response: {
+        type: 'object',
+        properties: { id: { type: 'number' } },
+        required: ['id'],
+      },
+    });
+  });
+});

--- a/packages/openapi/src/generate-openapi.lib.ts
+++ b/packages/openapi/src/generate-openapi.lib.ts
@@ -105,6 +105,27 @@ const buildPathParams = (
 const isVoidType = (type: TypeInfo): boolean =>
   type.kind === 'primitive' && type.type === 'undefined';
 
+const VALIDATION_ERROR_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    code: { const: 'VALIDATION_FAILED' },
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          kind: { type: 'string' },
+          type: { type: 'string' },
+          message: { type: 'string' },
+          path: { type: 'array', items: {} },
+        },
+        required: ['kind', 'type', 'message'],
+      },
+    },
+  },
+  required: ['code', 'issues'],
+};
+
 const findMethodInfo = (metadata: ClassMetadata, methodName: string): MethodInfo | undefined =>
   metadata.methods.find((m) => m.name === methodName);
 
@@ -169,7 +190,71 @@ const buildRequestBody = async (
   };
 };
 
-const buildResponseSchemaFromTypeInfo = (
+type TypedResponseInfo = {
+  readonly body: TypeInfo;
+  readonly status: number;
+  readonly format: string;
+};
+
+const literalProperty = (type: TypeInfo, name: string): string | number | boolean | undefined => {
+  if (type.kind !== 'object') return undefined;
+  const property = type.properties.find((candidate) => candidate.name === name);
+  return property?.type.kind === 'literal' ? property.type.value : undefined;
+};
+
+const typedResponseInfo = (type: TypeInfo): TypedResponseInfo | undefined => {
+  if (type.kind !== 'object') return undefined;
+  const body = type.properties.find((property) => property.name === '_data')?.type;
+  const status = literalProperty(type, '_status');
+  const format = literalProperty(type, '_format');
+  if (!body || typeof status !== 'number' || typeof format !== 'string') return undefined;
+  return { body, status, format };
+};
+
+const flattenResponseTypes = (type: TypeInfo): readonly TypeInfo[] => {
+  if (type.kind === 'promise') return flattenResponseTypes(type.inner);
+  if (type.kind === 'union') return type.types.flatMap(flattenResponseTypes);
+  return [type];
+};
+
+const responseContentType = (format: string): string | undefined => {
+  if (format === 'json') return 'application/json';
+  if (format === 'text') return 'text/plain';
+  return format === 'body' ? 'application/octet-stream' : undefined;
+};
+
+const normalizeResponseType = (type: TypeInfo): TypedResponseInfo => {
+  const typed = typedResponseInfo(type);
+  if (typed) return typed;
+  return { body: type, status: 200, format: 'json' };
+};
+
+const buildResponseEntry = (
+  controller: ControllerRouteInfo,
+  route: RouteInfo,
+  responseType: TypeInfo,
+  suffix: string,
+  schemas: SchemaMap,
+): readonly [string, unknown] => {
+  const normalized = normalizeResponseType(responseType);
+  const status = String(normalized.status);
+  const { schema } = typeInfoToJsonSchema(normalized.body);
+  const contentType = responseContentType(normalized.format);
+  if (Object.keys(schema).length === 0 || !contentType) {
+    return [status, { description: 'OK' }];
+  }
+  const refName = `${controller.name}_${route.methodName}_Response${suffix}`;
+  schemas[refName] = schema;
+  return [
+    status,
+    {
+      description: 'OK',
+      content: { [contentType]: { schema: { $ref: `#/components/schemas/${refName}` } } },
+    },
+  ];
+};
+
+export const buildResponseSchemaFromTypeInfo = (
   controller: ControllerRouteInfo,
   route: RouteInfo,
   methodInfo: MethodInfo | undefined,
@@ -179,19 +264,22 @@ const buildResponseSchemaFromTypeInfo = (
     return { '200': { description: 'OK' } };
   }
 
-  const { schema } = typeInfoToJsonSchema(methodInfo.returnType);
-  if (Object.keys(schema).length === 0) {
-    return { '200': { description: 'OK' } };
+  const responseTypes = flattenResponseTypes(methodInfo.returnType);
+  const responses: Record<string, unknown> = {};
+  for (const [index, responseType] of responseTypes.entries()) {
+    const typed = typedResponseInfo(responseType);
+    const status = String(typed?.status ?? 200);
+    const suffix = responseTypes.length > 1 ? `_${status}_${index}` : '';
+    const [responseStatus, response] = buildResponseEntry(
+      controller,
+      route,
+      responseType,
+      suffix,
+      schemas,
+    );
+    responses[responseStatus] = response;
   }
-
-  const refName = `${controller.name}_${route.methodName}_Response`;
-  schemas[refName] = schema;
-  return {
-    '200': {
-      description: 'OK',
-      content: { 'application/json': { schema: { $ref: `#/components/schemas/${refName}` } } },
-    },
-  };
+  return responses;
 };
 
 type SchemaContext = {
@@ -226,7 +314,17 @@ const buildOperation = async (
   );
   if (reqBody) op['requestBody'] = reqBody;
 
-  op['responses'] = buildResponseSchemaFromTypeInfo(controller, route, methodInfo, schemas);
+  const responses = buildResponseSchemaFromTypeInfo(controller, route, methodInfo, schemas);
+  if (ref.kind !== 'none') {
+    schemas['ValidationErrorBody'] = VALIDATION_ERROR_SCHEMA;
+    responses['400'] ??= {
+      description: 'Validation failed',
+      content: {
+        'application/json': { schema: { $ref: '#/components/schemas/ValidationErrorBody' } },
+      },
+    };
+  }
+  op['responses'] = responses;
 
   return op;
 };

--- a/packages/openapi/src/openapi-plugin.lib.ts
+++ b/packages/openapi/src/openapi-plugin.lib.ts
@@ -3,6 +3,8 @@ import type { HttpStaticCapabilities } from '@zeltjs/core';
 
 import type { GenerateOpenApiOptions } from './generate-openapi.lib';
 import { generateOpenApi } from './generate-openapi.lib';
+import type { SchemaResolver } from './resolve-schema.lib';
+import type { SchemaAdapter } from './schema.types';
 
 type HttpStaticApp = {
   readonly http: HttpStaticCapabilities;
@@ -13,6 +15,8 @@ export type OpenApiPluginOptions = {
   readonly tsconfig?: string;
   readonly title?: string;
   readonly version?: string;
+  readonly schemaAdapter?: SchemaAdapter;
+  readonly schemaResolver?: SchemaResolver;
 };
 
 const buildGenerateOptions = (options: OpenApiPluginOptions): GenerateOpenApiOptions => ({
@@ -20,6 +24,8 @@ const buildGenerateOptions = (options: OpenApiPluginOptions): GenerateOpenApiOpt
   ...(options.tsconfig !== undefined && { tsconfig: options.tsconfig }),
   ...(options.title !== undefined && { title: options.title }),
   ...(options.version !== undefined && { version: options.version }),
+  ...(options.schemaAdapter !== undefined && { schemaAdapter: options.schemaAdapter }),
+  ...(options.schemaResolver !== undefined && { schemaResolver: options.schemaResolver }),
 });
 
 /** @throws {ZeltDecoratorUsageError | UnsupportedTypeScriptVersionError | Error} */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@zeltjs/openapi':
         specifier: workspace:*
         version: link:../../packages/openapi
+      '@zeltjs/validator-valibot':
+        specifier: workspace:*
+        version: link:../../packages/validator-valibot
       better-sqlite3:
         specifier: 12.9.0
         version: 12.9.0
@@ -157,6 +160,9 @@ importers:
 
   examples/hello:
     dependencies:
+      '@valibot/to-json-schema':
+        specifier: 'catalog:'
+        version: 1.6.0(valibot@1.3.1(typescript@6.0.2))
       '@zeltjs/adapter-node':
         specifier: workspace:*
         version: link:../../packages/adapter-node
@@ -172,6 +178,9 @@ importers:
       '@zeltjs/openapi':
         specifier: workspace:*
         version: link:../../packages/openapi
+      '@zeltjs/validator-valibot':
+        specifier: workspace:*
+        version: link:../../packages/validator-valibot
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2)


### PR DESCRIPTION
## Summary

- forward schema adapters and resolvers through the OpenAPI plugin
- derive response status and content type from TypedResponse, including union responses
- emit the known validation 400 response contract
- configure Valibot adapters in examples and regenerate the committed hello OpenAPI document
- add a precommit freshness gate that regenerates hello OpenAPI and rejects drift

## Verification

- `pnpm precommit`
- 150 test files passed, 1070 tests passed
- all 78 distribution runtime contracts passed
- `pnpm verify-generated:openapi`
- `pnpm knip`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786353404&installation_id=133048706&pr_number=311&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F311&signature=08f4964f23b258a2746e577e5fadb7c6cbefd0fcec67e891c189fe533dd67cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Valibot を使ったスキーマ変換で、OpenAPI ドキュメント生成をサポートします。
  - 複数のレスポンスステータスやレスポンス形式、ユニオン型を OpenAPI に正しく反映します。
  - リクエスト検証エラー時の 400 レスポンスを自動生成します。
- **改善**
  - サンプルアプリに OpenAPI 生成スクリプトを追加し、生成物の差分確認も可能にしました。
- **テスト**
  - レスポンス生成の挙動を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->