### PR TITLE
chore: add package descriptions for npm search display

### DIFF
--- a/packages/adapter-bun/package.json
+++ b/packages/adapter-bun/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/adapter-bun",
   "version": "0.0.0",
+  "description": "Bun adapter for the Zelt framework",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/adapter-cloudflare-workers",
   "version": "0.0.0",
+  "description": "Cloudflare Workers adapter for the Zelt framework",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/adapter-electron/package.json
+++ b/packages/adapter-electron/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/adapter-electron",
   "version": "0.0.0",
+  "description": "Electron adapter for the Zelt framework",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/adapter-lambda/package.json
+++ b/packages/adapter-lambda/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/adapter-lambda",
   "version": "0.0.0",
+  "description": "AWS Lambda adapter for the Zelt framework",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/adapter-node",
   "version": "0.0.0",
+  "description": "Node.js adapter for the Zelt framework",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/auth-jwt/package.json
+++ b/packages/auth-jwt/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/auth-jwt",
   "version": "0.0.0",
+  "description": "JWT authentication middleware for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/auth-session/package.json
+++ b/packages/auth-session/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/auth-session",
   "version": "0.0.0",
+  "description": "Session management middleware for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/core",
   "version": "0.0.0",
+  "description": "Core TypeScript application framework with built-in dependency injection for the Zelt framework",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/db",
   "version": "0.0.0",
+  "description": "ORM-agnostic database abstraction with transaction propagation for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/eventbus/package.json
+++ b/packages/eventbus/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/eventbus",
   "version": "0.0.0",
+  "description": "Event bus abstraction for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/graphql",
   "version": "0.0.0",
+  "description": "GraphQL support for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/hono-client/package.json
+++ b/packages/hono-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/hono-client",
   "version": "0.0.0",
+  "description": "Type-safe Hono client generator for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/kv",
   "version": "0.0.0",
+  "description": "Key-value store abstraction for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/openapi",
   "version": "0.0.0",
+  "description": "OpenAPI schema generator for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/rate-limit/package.json
+++ b/packages/rate-limit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/rate-limit",
   "version": "0.0.0",
+  "description": "Rate limiting middleware for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/redis",
   "version": "0.0.0",
+  "description": "Redis integration for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/testing",
   "version": "0.0.0",
+  "description": "Testing utilities for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/validator-valibot/package.json
+++ b/packages/validator-valibot/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zeltjs/validator-valibot",
   "version": "0.0.0",
+  "description": "Valibot OpenAPI schema adapter for Zelt applications",
   "type": "module",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

npm search results display `package.json`'s `description` field, falling back to the first lines of the README when it is missing. 18 of the 21 publishable packages lacked a `description`, so raw HTML (`<p align="center">…`) and badge markdown were rendered in npm search results.

This PR adds a one-line `description` to every publishable package that was missing one, matching the style of the already-configured packages (`@zeltjs/cli`, `@zeltjs/eslint-plugin`, `@zeltjs/decorator-metadata`).

## Changes

- Adapter packages: "<Runtime> adapter for the Zelt framework"
- Feature packages: role-specific one-liners, e.g. `@zeltjs/db` → "ORM-agnostic database abstraction with transaction propagation for Zelt applications"
- No Markdown/HTML/badges in any description; plain text only

## Notes

- npm search display updates on the next publish of each package
- `pnpm run precommit` passed end-to-end (build, typecheck, lint, 1067 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790053887&installation_model_id=21678&pr_number=313&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F313&signature=018c347bc10b6bdd64477f7a511983c5de064a6990d65f378d01077ff28a6be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 各種パッケージに説明情報を追加し、用途や提供機能をパッケージ一覧で確認しやすくしました。
  * アダプター、認証、データベース、イベント、GraphQL、OpenAPI、Redis、テストなど、主要パッケージの役割が明確になりました。
  * パッケージの実行時の動作や提供機能に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->