### PR TITLE
chore: remove unnecessary experimentalDecorators from package tsconfigs

### DIFF
--- a/packages/adapter-cloudflare-workers/tsconfig.json
+++ b/packages/adapter-cloudflare-workers/tsconfig.json
@@ -8,7 +8,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "experimentalDecorators": true,
     "erasableSyntaxOnly": false,
     "types": ["@cloudflare/workers-types", "node"]
   },

--- a/packages/auth-session/tsconfig.json
+++ b/packages/auth-session/tsconfig.json
@@ -8,7 +8,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "experimentalDecorators": true,
     "erasableSyntaxOnly": false,
     "types": ["node"]
   },

--- a/packages/validator-valibot/tsconfig.json
+++ b/packages/validator-valibot/tsconfig.json
@@ -8,7 +8,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "experimentalDecorators": true,
     "erasableSyntaxOnly": false,
     "types": ["node"]
   },


### PR DESCRIPTION
## Summary

Remove leftover `experimentalDecorators: true` from 3 package tsconfigs:

- `packages/auth-session/tsconfig.json`
- `packages/validator-valibot/tsconfig.json`
- `packages/adapter-cloudflare-workers/tsconfig.json`

## Why

- All decorator implementations in this repo use TC39 standard signatures (`ClassDecoratorContext`); there is no legacy-signature (`target, key, descriptor`) code.
- Runtime emit is handled by tsdown with `transform: { decoratorVersion: '2022-03' }`, so the tsconfig flag only affected `tsc` typechecking.
- Keeping the flag made `tsc` typecheck with legacy decorator semantics that diverge from actual runtime behavior, leaving room for legacy-only code to pass typecheck but break at runtime.
- The flag came in with the initial package scaffolds; git history shows no change that required it.

`erasableSyntaxOnly: false` is kept in each package since decorators are non-erasable syntax.

## Verification

- `tsc -b --force` passes for all 3 packages without the flag
- Package tests pass after a proper tsdown rebuild (auth-session 14, validator-valibot 7, adapter-cloudflare-workers 18)
- `pnpm run precommit` (full verification) passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790648258&installation_model_id=21678&pr_number=314&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F314&signature=80bd5440efbb8c4cc4ae47ee16c7166610d7d63ed0d8b8b7fe82181d919ba52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * TypeScriptのコンパイラ設定を整理し、不要になった実験的デコレータ機能の設定を削除しました。
  * 既存のビルド設定や公開機能への変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->