### PR TITLE
feat(cli): folder group collapse with edge aggregation in studio

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -499,7 +499,11 @@ export default tseslint.config(
     // truth for the shape; a narrow cast is the least-bad option here.
     // Repay: once DependencyGraph is defined via a valibot schema (single
     // source of truth), replace these casts with schema-derived validation.
-    files: ['packages/cli/studio-ui/src/app.tsx', 'packages/cli/studio-ui/src/positions.lib.ts'],
+    files: [
+      'packages/cli/studio-ui/src/app.tsx',
+      'packages/cli/studio-ui/src/positions.lib.ts',
+      'packages/cli/studio-ui/src/settings.lib.ts',
+    ],
     rules: {
       '@9wick/strict-type-rules/no-as-assertion': 'off',
     },

--- a/packages/cli/studio-ui/src/app.tsx
+++ b/packages/cli/studio-ui/src/app.tsx
@@ -1,11 +1,20 @@
 import type { Edge, Node, NodeProps } from '@xyflow/react';
 import { Background, Controls, Handle, Position, ReactFlow } from '@xyflow/react';
 import type { JSX } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import type { DependencyGraph } from '../../src/studio/graph/graph.types';
+import { dirOf } from './collapse.lib';
 import { hideNodeModules } from './graph-filter.lib';
-import type { CardData, FlowNode, GroupData } from './graph-to-flow.lib';
+import type { CardData, FlowNode, GroupData, ModuleData } from './graph-to-flow.lib';
 import { graphToFlow } from './graph-to-flow.lib';
 import { findGraphNode } from './inspector.lib';
 import { InspectorPanel } from './inspector-panel';
@@ -13,8 +22,11 @@ import { applyStudioNodeChanges } from './node-changes.lib';
 import type { PositionScope } from './positions.lib';
 import { loadPositions, savePosition } from './positions.lib';
 import {
+  defaultCollapsedDirs,
+  loadCollapsedDirs,
   loadGroupByFolder,
   loadHideNodeModules,
+  saveCollapsedDirs,
   saveGroupByFolder,
   saveHideNodeModules,
 } from './settings.lib';
@@ -34,14 +46,64 @@ const CardNode = ({ data }: NodeProps<Node<CardData, 'card'>>): JSX.Element => (
   </div>
 );
 
-// フォルダは表示上のグルーピング枠のみで、エッジは card 間にしか引かれないため Handle 不要
-const FolderNode = ({ data }: NodeProps<Node<GroupData, 'folder'>>): JSX.Element => (
-  <div className="folder">
-    <span className="folder-label">{data.label}</span>
-  </div>
-);
+// nodeTypes はモジュールスコープで一度だけ定義する必要がある（毎レンダー再生成すると
+// React Flow が custom node を再マウントする）ため、折りたたみトグルは props でなく
+// context 経由で FolderNode/ModuleNode に注入する
+const CollapseToggleContext = createContext<(dir: string) => void>(() => {});
 
-const nodeTypes = { card: CardNode, folder: FolderNode };
+// メンバーはクラス単位のため "1 class" / "N classes" で表記する
+const classCountLabel = (count: number): string => `${count} ${count === 1 ? 'class' : 'classes'}`;
+
+// フォルダは表示上のグルーピング枠。エッジは card 間にしか引かれないため Handle 不要。
+// data.label は pnpm ハッシュ等を短縮した表示用文字列のため、折りたたみ操作は data.dir（フルパス、collapsedDirs のキー）で行う
+const FolderNode = ({ data }: NodeProps<Node<GroupData, 'folder'>>): JSX.Element => {
+  const toggleCollapsed = useContext(CollapseToggleContext);
+  return (
+    <div className="folder">
+      <div className="folder-header">
+        <span className="folder-label" title={data.dir}>
+          {data.label}
+        </span>
+        <button
+          type="button"
+          className="folder-collapse-btn"
+          title={`Collapse ${data.dir}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            toggleCollapsed(data.dir);
+          }}
+        >
+          −
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// 折りたたみグループの合成ノード。エッジがここへ束ねられるため card と同じく Handle が要る。
+// 表示は短縮ラベルのみなので、フルパスは title（ホバー）で確認できるようにする
+const ModuleNode = ({ data }: NodeProps<Node<ModuleData, 'module'>>): JSX.Element => {
+  const toggleCollapsed = useContext(CollapseToggleContext);
+  return (
+    <button
+      type="button"
+      className="module"
+      title={data.dir}
+      onClick={(event) => {
+        event.stopPropagation();
+        toggleCollapsed(data.dir);
+      }}
+    >
+      <Handle type="target" position={Position.Top} />
+      <span className="module-expand">+</span>
+      <strong>{data.label}</strong>
+      <small>{classCountLabel(data.memberCount)}</small>
+      <Handle type="source" position={Position.Bottom} />
+    </button>
+  );
+};
+
+const nodeTypes = { card: CardNode, folder: FolderNode, module: ModuleNode };
 
 // reload のカスタムヘッダは cross-site だと CORS preflight を通過できないため、
 // サーバ側の CSRF 判定（same-origin の証明）に使われる
@@ -72,6 +134,36 @@ const useToggleSetting = (
     [save],
   );
   return [value, toggle];
+};
+
+// 保存値が無い初回だけ、到着したグラフの dir 一覧から node_modules 系を自動折りたたみする。
+// 一度でも保存されていれば（空集合＝全展開を含め）以後はユーザーの選択を優先する
+const useCollapsedDirs = (
+  graph: DependencyGraph | undefined,
+): [ReadonlySet<string>, (dir: string) => void] => {
+  const [collapsedDirs, setCollapsedDirs] = useState<ReadonlySet<string>>(
+    () => loadCollapsedDirs() ?? new Set(),
+  );
+  const hasAppliedDefault = useRef(loadCollapsedDirs() !== undefined);
+
+  useEffect(() => {
+    if (hasAppliedDefault.current || graph === undefined) return;
+    const dirs = Array.from(new Set(graph.nodes.map((node) => dirOf(node.filePath))));
+    setCollapsedDirs(defaultCollapsedDirs(dirs));
+    hasAppliedDefault.current = true;
+  }, [graph]);
+
+  const toggleDir = useCallback((dir: string) => {
+    setCollapsedDirs((prev) => {
+      const next = new Set(prev);
+      if (next.has(dir)) next.delete(dir);
+      else next.add(dir);
+      saveCollapsedDirs(next);
+      return next;
+    });
+  }, []);
+
+  return [collapsedDirs, toggleDir];
 };
 
 const useGraphFetch = () => {
@@ -129,16 +221,18 @@ const useStudioGraph = () => {
     () => (graph === undefined ? undefined : hideModules ? hideNodeModules(graph) : graph),
     [graph, hideModules],
   );
+  const [collapsedDirs, toggleCollapsedDir] = useCollapsedDirs(filteredGraph);
 
-  // フィルタ/グルーピングトグル変更後に nodes/edges を再導出する
+  // フィルタ/グルーピング/折りたたみトグル変更後に nodes/edges を再導出する
   useEffect(() => {
     if (filteredGraph === undefined) return;
     const flow = graphToFlow(filteredGraph, loadPositions(positionScope), {
       grouped: groupByFolder,
+      collapsedDirs,
     });
     setNodes(flow.nodes);
     setEdges(flow.edges);
-  }, [filteredGraph, groupByFolder, positionScope]);
+  }, [filteredGraph, groupByFolder, positionScope, collapsedDirs]);
 
   return {
     nodes,
@@ -153,6 +247,7 @@ const useStudioGraph = () => {
     toggleGroupByFolder,
     positionScope,
     filteredGraph,
+    toggleCollapsedDir,
   };
 };
 
@@ -236,6 +331,7 @@ export const App = (): JSX.Element => {
     toggleGroupByFolder,
     positionScope,
     filteredGraph,
+    toggleCollapsedDir,
   } = useStudioGraph();
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
   // フィルタ/リロードで消えたノードは自動的にパネルも消える（selectedId 自体はクリアしない）
@@ -255,14 +351,16 @@ export const App = (): JSX.Element => {
         onToggleGroupByFolder={toggleGroupByFolder}
       />
       {error !== undefined && <pre className="error">{error}</pre>}
-      <GraphCanvas
-        nodes={nodes}
-        edges={edges}
-        setNodes={setNodes}
-        positionScope={positionScope}
-        onSelect={setSelectedId}
-        onDeselect={() => setSelectedId(undefined)}
-      />
+      <CollapseToggleContext.Provider value={toggleCollapsedDir}>
+        <GraphCanvas
+          nodes={nodes}
+          edges={edges}
+          setNodes={setNodes}
+          positionScope={positionScope}
+          onSelect={setSelectedId}
+          onDeselect={() => setSelectedId(undefined)}
+        />
+      </CollapseToggleContext.Provider>
       {selectedNode !== undefined && (
         <InspectorPanel node={selectedNode} onClose={() => setSelectedId(undefined)} />
       )}

--- a/packages/cli/studio-ui/src/app.tsx
+++ b/packages/cli/studio-ui/src/app.tsx
@@ -221,7 +221,10 @@ const useStudioGraph = () => {
     () => (graph === undefined ? undefined : hideModules ? hideNodeModules(graph) : graph),
     [graph, hideModules],
   );
-  const [collapsedDirs, toggleCollapsedDir] = useCollapsedDirs(filteredGraph);
+  // デフォルト折りたたみの算出はフィルタ前の graph から行う。filteredGraph 起点だと
+  // hide node_modules 有効時に node_modules 系 dir がデフォルト集合から漏れ、
+  // フィルタ解除後に全展開で現れてしまう
+  const [collapsedDirs, toggleCollapsedDir] = useCollapsedDirs(graph);
 
   // フィルタ/グルーピング/折りたたみトグル変更後に nodes/edges を再導出する
   useEffect(() => {

--- a/packages/cli/studio-ui/src/collapse.lib.test.ts
+++ b/packages/cli/studio-ui/src/collapse.lib.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DependencyGraph } from '../../src/studio/graph/graph.types';
+import { collapseView, dirOf, displayDirLabel, groupIdOf } from './collapse.lib';
+
+const graph: DependencyGraph = {
+  version: 2,
+  nodes: [
+    { id: 'src/foo/a.ts#A', className: 'A', filePath: 'src/foo/a.ts', kind: 'controller' },
+    { id: 'src/foo/c.ts#C', className: 'C', filePath: 'src/foo/c.ts', kind: 'service' },
+    { id: 'src/bar/b.ts#B', className: 'B', filePath: 'src/bar/b.ts', kind: 'service' },
+    { id: 'src/bar/d.ts#D', className: 'D', filePath: 'src/bar/d.ts', kind: 'service' },
+  ],
+  edges: [
+    { from: 'src/foo/a.ts#A', to: 'src/bar/b.ts#B', kind: 'injects' },
+    { from: 'src/foo/c.ts#C', to: 'src/bar/d.ts#D', kind: 'injects' },
+    { from: 'src/foo/a.ts#A', to: 'src/foo/c.ts#C', kind: 'injects' },
+    { from: 'src/bar/b.ts#B', to: 'src/bar/d.ts#D', kind: 'injects' },
+  ],
+};
+
+describe('dirOf', () => {
+  it('returns the directory portion of a file path', () => {
+    expect(dirOf('src/foo/a.ts')).toBe('src/foo');
+  });
+
+  it('returns the whole string when there is no slash (e.g. "(unknown)")', () => {
+    expect(dirOf('(unknown)')).toBe('(unknown)');
+  });
+});
+
+describe('groupIdOf', () => {
+  it('prefixes the dir with "folder:"', () => {
+    expect(groupIdOf('src/foo')).toBe('folder:src/foo');
+  });
+});
+
+describe('displayDirLabel', () => {
+  it('returns the dir unchanged when it has no node_modules segment', () => {
+    expect(displayDirLabel('src/usecase')).toBe('src/usecase');
+  });
+
+  it('collapses a pnpm-hashed nested path down to the scoped package name', () => {
+    const dir =
+      'node_modules/.pnpm/@zeltjs+rate-limit@file+..+..+packages+rate-limit_@zeltjs+core@file+..+..+packages+core_b6cdb2bde8c859a81ae30c51a943ff80/node_modules/@zeltjs/rate-limit/dist';
+    expect(displayDirLabel(dir)).toBe('@zeltjs/rate-limit');
+  });
+
+  it('takes one segment for an unscoped package, dropping trailing segments like dist', () => {
+    expect(displayDirLabel('node_modules/pkg/dist/lib')).toBe('pkg');
+  });
+
+  it('takes two segments for a scoped package directly under node_modules', () => {
+    expect(displayDirLabel('node_modules/@zeltjs/rate-limit/dist')).toBe('@zeltjs/rate-limit');
+  });
+
+  it('uses the last node_modules segment when there are nested node_modules', () => {
+    expect(displayDirLabel('node_modules/a/node_modules/b/node_modules/c/dist')).toBe('c');
+  });
+
+  it('falls back to the full dir when node_modules is the last segment (nothing after it)', () => {
+    expect(displayDirLabel('vendor/node_modules')).toBe('vendor/node_modules');
+  });
+});
+
+describe('collapseView', () => {
+  it('is equivalent to the input when nothing is collapsed', () => {
+    const view = collapseView(graph, new Set());
+
+    expect(view.visibleNodes).toEqual(graph.nodes);
+    expect(view.collapsedGroups).toEqual([]);
+    expect(view.edges).toEqual([
+      { from: 'src/foo/a.ts#A', to: 'src/bar/b.ts#B', kind: 'injects', count: 1 },
+      { from: 'src/foo/c.ts#C', to: 'src/bar/d.ts#D', kind: 'injects', count: 1 },
+      { from: 'src/foo/a.ts#A', to: 'src/foo/c.ts#C', kind: 'injects', count: 1 },
+      { from: 'src/bar/b.ts#B', to: 'src/bar/d.ts#D', kind: 'injects', count: 1 },
+    ]);
+  });
+
+  it('collapses member nodes of a collapsed dir into a single folder group', () => {
+    const view = collapseView(graph, new Set(['src/foo']));
+
+    expect(view.visibleNodes.map((n) => n.id)).toEqual(['src/bar/b.ts#B', 'src/bar/d.ts#D']);
+    expect(view.collapsedGroups).toEqual([{ dir: 'src/foo', memberCount: 2 }]);
+  });
+
+  it('aggregates parallel edges between the same endpoints and kind into a count', () => {
+    const view = collapseView(graph, new Set(['src/foo', 'src/bar']));
+
+    // a->b と c->d はどちらも folder:src/foo -> folder:src/bar (injects) に丸め込まれ集約される
+    expect(view.edges).toContainEqual({
+      from: 'folder:src/foo',
+      to: 'folder:src/bar',
+      kind: 'injects',
+      count: 2,
+    });
+  });
+
+  it('drops edges that become self-loops within the same collapsed group', () => {
+    const view = collapseView(graph, new Set(['src/foo', 'src/bar']));
+
+    // src/foo/a->src/foo/c と src/bar/b->src/bar/d はどちらも自己ループになり除去される
+    expect(view.edges.some((e) => e.from === e.to)).toBe(false);
+    expect(view.edges).toHaveLength(1);
+  });
+
+  it('keeps edges of different kinds separate even between the same endpoints', () => {
+    const twoKindGraph: DependencyGraph = {
+      version: 2,
+      nodes: [
+        { id: 'src/foo/a.ts#A', className: 'A', filePath: 'src/foo/a.ts', kind: 'controller' },
+        { id: 'src/bar/b.ts#B', className: 'B', filePath: 'src/bar/b.ts', kind: 'middleware' },
+      ],
+      edges: [
+        { from: 'src/foo/a.ts#A', to: 'src/bar/b.ts#B', kind: 'injects' },
+        { from: 'src/foo/a.ts#A', to: 'src/bar/b.ts#B', kind: 'applies-middleware' },
+      ],
+    };
+
+    const view = collapseView(twoKindGraph, new Set(['src/foo', 'src/bar']));
+    expect([...view.edges].sort((x, y) => x.kind.localeCompare(y.kind))).toEqual([
+      { from: 'folder:src/foo', to: 'folder:src/bar', kind: 'applies-middleware', count: 1 },
+      { from: 'folder:src/foo', to: 'folder:src/bar', kind: 'injects', count: 1 },
+    ]);
+  });
+
+  it('rewrites only the collapsed endpoint when just one side is collapsed', () => {
+    const view = collapseView(graph, new Set(['src/foo']));
+
+    expect(view.edges).toContainEqual({
+      from: 'folder:src/foo',
+      to: 'src/bar/b.ts#B',
+      kind: 'injects',
+      count: 1,
+    });
+    expect(view.edges).toContainEqual({
+      from: 'src/bar/b.ts#B',
+      to: 'src/bar/d.ts#D',
+      kind: 'injects',
+      count: 1,
+    });
+  });
+
+  it('ignores collapsedDirs entries that do not correspond to any node', () => {
+    const view = collapseView(graph, new Set(['does/not/exist']));
+
+    expect(view.visibleNodes).toEqual(graph.nodes);
+    expect(view.collapsedGroups).toEqual([]);
+  });
+});

--- a/packages/cli/studio-ui/src/collapse.lib.test.ts
+++ b/packages/cli/studio-ui/src/collapse.lib.test.ts
@@ -104,6 +104,19 @@ describe('collapseView', () => {
     expect(view.edges).toHaveLength(1);
   });
 
+  it('preserves a pre-existing self-loop when nothing is collapsed', () => {
+    const selfLoopGraph: DependencyGraph = {
+      version: 2,
+      nodes: [{ id: 'src/foo/a.ts#A', className: 'A', filePath: 'src/foo/a.ts', kind: 'service' }],
+      edges: [{ from: 'src/foo/a.ts#A', to: 'src/foo/a.ts#A', kind: 'injects' }],
+    };
+
+    const view = collapseView(selfLoopGraph, new Set());
+    expect(view.edges).toEqual([
+      { from: 'src/foo/a.ts#A', to: 'src/foo/a.ts#A', kind: 'injects', count: 1 },
+    ]);
+  });
+
   it('keeps edges of different kinds separate even between the same endpoints', () => {
     const twoKindGraph: DependencyGraph = {
       version: 2,

--- a/packages/cli/studio-ui/src/collapse.lib.ts
+++ b/packages/cli/studio-ui/src/collapse.lib.ts
@@ -1,0 +1,89 @@
+import type { DependencyGraph, GraphEdgeKind, GraphNode } from '../../src/studio/graph/graph.types';
+
+// filePath はファイル単位、グループはディレクトリ単位。"(unknown)" は
+// スラッシュを含まないため自身がグループ key になり、まとまって表示される
+export const dirOf = (filePath: string): string => {
+  const parts = filePath.split('/');
+  return parts.length > 1 ? parts.slice(0, -1).join('/') : filePath;
+};
+
+// card node の id（クラス由来の任意文字列）と衝突しないよう prefix する
+export const groupIdOf = (dir: string): string => `folder:${dir}`;
+
+// pnpm の node_modules/.pnpm/<hash>/node_modules/<pkg> はハッシュでノードが埋まり読めなくなるため、
+// 表示専用にパッケージ名だけへ短縮する。グルーピング key は dir のフルパスのまま変えない
+export const displayDirLabel = (dir: string): string => {
+  const segments = dir.split('/');
+  const lastNodeModulesIndex = segments.lastIndexOf('node_modules');
+  if (lastNodeModulesIndex === -1) return dir;
+
+  const after = segments.slice(lastNodeModulesIndex + 1);
+  if (after.length === 0) return dir;
+
+  // scoped package (@scope/name) は 2 segment、それ以外は 1 segment がパッケージ名
+  const packageSegmentCount = after[0]?.startsWith('@') ? 2 : 1;
+  return after.slice(0, packageSegmentCount).join('/');
+};
+
+export type AggregatedEdge = {
+  readonly from: string;
+  readonly to: string;
+  readonly kind: GraphEdgeKind;
+  readonly count: number;
+};
+
+export type CollapsedView = {
+  readonly visibleNodes: readonly GraphNode[];
+  readonly collapsedGroups: readonly { readonly dir: string; readonly memberCount: number }[];
+  readonly edges: readonly AggregatedEdge[];
+};
+
+// 折りたたみ対象 dir に属するノードはグループ id に丸め込み、それ以外はそのまま素通しする
+const endpointOf = (
+  nodeId: string,
+  dirById: ReadonlyMap<string, string>,
+  collapsedDirs: ReadonlySet<string>,
+): string => {
+  const dir = dirById.get(nodeId);
+  return dir !== undefined && collapsedDirs.has(dir) ? groupIdOf(dir) : nodeId;
+};
+
+// dagre レイアウトの外で使う純粋なビュー変換: 折りたたみ dir のノードを単一グループへ集約し、
+// エッジは丸め込み後の (from, to, kind) 単位で集約する。グラフ JSON 自体は変更しない
+export const collapseView = (
+  graph: DependencyGraph,
+  collapsedDirs: ReadonlySet<string>,
+): CollapsedView => {
+  const dirById = new Map(graph.nodes.map((node) => [node.id, dirOf(node.filePath)]));
+
+  // グラフに存在しない dir が collapsedDirs に含まれていても member 0 のため自然に無視される
+  const memberCountByDir = new Map<string, number>();
+  for (const dir of dirById.values()) {
+    if (!collapsedDirs.has(dir)) continue;
+    memberCountByDir.set(dir, (memberCountByDir.get(dir) ?? 0) + 1);
+  }
+  const collapsedGroups = Array.from(memberCountByDir.entries()).map(([dir, memberCount]) => ({
+    dir,
+    memberCount,
+  }));
+
+  const visibleNodes = graph.nodes.filter((node) => !collapsedDirs.has(dirById.get(node.id) ?? ''));
+
+  // 丸め込み後に両端が同一グループになったエッジは自己ループとして除去する
+  const aggregated = new Map<string, AggregatedEdge>();
+  for (const edge of graph.edges) {
+    const from = endpointOf(edge.from, dirById, collapsedDirs);
+    const to = endpointOf(edge.to, dirById, collapsedDirs);
+    if (from === to) continue;
+    const key = `${from}->${to}#${edge.kind}`;
+    const existing = aggregated.get(key);
+    aggregated.set(
+      key,
+      existing
+        ? { ...existing, count: existing.count + 1 }
+        : { from, to, kind: edge.kind, count: 1 },
+    );
+  }
+
+  return { visibleNodes, collapsedGroups, edges: Array.from(aggregated.values()) };
+};

--- a/packages/cli/studio-ui/src/collapse.lib.ts
+++ b/packages/cli/studio-ui/src/collapse.lib.ts
@@ -48,6 +48,31 @@ const endpointOf = (
   return dir !== undefined && collapsedDirs.has(dir) ? groupIdOf(dir) : nodeId;
 };
 
+// 丸め込みで両端が同一グループになったエッジのみ自己ループとして除去する。
+// 元から from === to のエッジ(将来のエッジ種別で発生しうる)は表示対象として残す
+const aggregateEdges = (
+  edges: DependencyGraph['edges'],
+  dirById: ReadonlyMap<string, string>,
+  collapsedDirs: ReadonlySet<string>,
+): readonly AggregatedEdge[] => {
+  const aggregated = new Map<string, AggregatedEdge>();
+  for (const edge of edges) {
+    const from = endpointOf(edge.from, dirById, collapsedDirs);
+    const to = endpointOf(edge.to, dirById, collapsedDirs);
+    const remapped = from !== edge.from || to !== edge.to;
+    if (remapped && from === to) continue;
+    const key = `${from}->${to}#${edge.kind}`;
+    const existing = aggregated.get(key);
+    aggregated.set(
+      key,
+      existing
+        ? { ...existing, count: existing.count + 1 }
+        : { from, to, kind: edge.kind, count: 1 },
+    );
+  }
+  return Array.from(aggregated.values());
+};
+
 // dagre レイアウトの外で使う純粋なビュー変換: 折りたたみ dir のノードを単一グループへ集約し、
 // エッジは丸め込み後の (from, to, kind) 単位で集約する。グラフ JSON 自体は変更しない
 export const collapseView = (
@@ -69,21 +94,9 @@ export const collapseView = (
 
   const visibleNodes = graph.nodes.filter((node) => !collapsedDirs.has(dirById.get(node.id) ?? ''));
 
-  // 丸め込み後に両端が同一グループになったエッジは自己ループとして除去する
-  const aggregated = new Map<string, AggregatedEdge>();
-  for (const edge of graph.edges) {
-    const from = endpointOf(edge.from, dirById, collapsedDirs);
-    const to = endpointOf(edge.to, dirById, collapsedDirs);
-    if (from === to) continue;
-    const key = `${from}->${to}#${edge.kind}`;
-    const existing = aggregated.get(key);
-    aggregated.set(
-      key,
-      existing
-        ? { ...existing, count: existing.count + 1 }
-        : { from, to, kind: edge.kind, count: 1 },
-    );
-  }
-
-  return { visibleNodes, collapsedGroups, edges: Array.from(aggregated.values()) };
+  return {
+    visibleNodes,
+    collapsedGroups,
+    edges: aggregateEdges(graph.edges, dirById, collapsedDirs),
+  };
 };

--- a/packages/cli/studio-ui/src/graph-to-flow.lib.test.ts
+++ b/packages/cli/studio-ui/src/graph-to-flow.lib.test.ts
@@ -132,6 +132,91 @@ describe('graphToFlow', () => {
     });
   });
 
+  describe('collapsed groups (grouped: true, collapsedDirs)', () => {
+    it('replaces member cards of a collapsed dir with a single module node reusing the folder id', () => {
+      const flow = graphToFlow(graph, {}, { grouped: true, collapsedDirs: new Set(['src/foo']) });
+
+      expect(flow.nodes.some((n) => n.id === 'src/foo/a.ts#A')).toBe(false);
+      expect(flow.nodes.some((n) => n.id === 'src/foo/c.ts#C')).toBe(false);
+      const moduleNode = flow.nodes.find((n) => n.id === 'folder:src/foo');
+      expect(moduleNode?.type).toBe('module');
+      expect(moduleNode?.data).toEqual(
+        expect.objectContaining({ label: 'src/foo', memberCount: 2 }),
+      );
+
+      // 折りたたまれていない dir は従来どおり folder subflow + card のまま
+      expect(flow.nodes.find((n) => n.id === 'folder:src/bar')?.type).toBe('folder');
+      expect(flow.nodes.some((n) => n.id === 'src/bar/b.ts#B')).toBe(true);
+    });
+
+    it('reuses saved positions keyed by the folder id for the module node', () => {
+      const flow = graphToFlow(
+        graph,
+        { 'folder:src/foo': { x: 321, y: 654 } },
+        { grouped: true, collapsedDirs: new Set(['src/foo']) },
+      );
+
+      const moduleNode = flow.nodes.find((n) => n.id === 'folder:src/foo');
+      expect(moduleNode?.position).toEqual({ x: 321, y: 654 });
+    });
+
+    it('routes edges through the collapsed group id and aggregates parallel edges with a count', () => {
+      const flow = graphToFlow(graph, {}, { grouped: true, collapsedDirs: new Set(['src/foo']) });
+
+      // a->c (共に src/foo) は自己ループとして消え、a->b は folder:src/foo -> B に丸め込まれる
+      expect(flow.edges).toHaveLength(1);
+      expect(flow.edges[0]).toEqual(
+        expect.objectContaining({ source: 'folder:src/foo', target: 'src/bar/b.ts#B' }),
+      );
+    });
+
+    it('is unaffected by collapsedDirs in flat mode', () => {
+      const flow = graphToFlow(graph, {}, { grouped: false, collapsedDirs: new Set(['src/foo']) });
+
+      expect(flow.nodes.some((n) => n.type === 'folder' || n.type === 'module')).toBe(false);
+      expect(flow.nodes).toHaveLength(3);
+    });
+
+    it('defaults to no collapse when collapsedDirs is omitted', () => {
+      const withOption = graphToFlow(graph, {}, { grouped: true });
+      expect(withOption.nodes.some((n) => n.type === 'module')).toBe(false);
+    });
+
+    it('shortens a pnpm-hashed dir to the package name for both module and folder header labels, keeping the full dir separately', () => {
+      const pnpmDir =
+        'node_modules/.pnpm/@zeltjs+rate-limit@file+..+..+packages+rate-limit_hash/node_modules/@zeltjs/rate-limit/dist';
+      const pnpmGraph: DependencyGraph = {
+        version: 2,
+        nodes: [
+          {
+            id: `${pnpmDir}/index.ts#R`,
+            className: 'R',
+            filePath: `${pnpmDir}/index.ts`,
+            kind: 'service',
+          },
+          { id: 'src/a.ts#A', className: 'A', filePath: 'src/a.ts', kind: 'controller' },
+        ],
+        edges: [],
+      };
+
+      const collapsedFlow = graphToFlow(
+        pnpmGraph,
+        {},
+        { grouped: true, collapsedDirs: new Set([pnpmDir]) },
+      );
+      const moduleNode = collapsedFlow.nodes.find((n) => n.id === `folder:${pnpmDir}`);
+      expect(moduleNode?.data).toEqual(
+        expect.objectContaining({ label: '@zeltjs/rate-limit', dir: pnpmDir, memberCount: 1 }),
+      );
+
+      const expandedFlow = graphToFlow(pnpmGraph, {}, { grouped: true, collapsedDirs: new Set() });
+      const folderNode = expandedFlow.nodes.find((n) => n.id === `folder:${pnpmDir}`);
+      expect(folderNode?.data).toEqual(
+        expect.objectContaining({ label: '@zeltjs/rate-limit', dir: pnpmDir }),
+      );
+    });
+  });
+
   it('maps edge kind into id and className', () => {
     const graph: DependencyGraph = {
       version: 2,

--- a/packages/cli/studio-ui/src/graph-to-flow.lib.ts
+++ b/packages/cli/studio-ui/src/graph-to-flow.lib.ts
@@ -3,6 +3,8 @@ import dagre from '@dagrejs/dagre';
 import type { Edge, Node } from '@xyflow/react';
 
 import type { DependencyGraph, GraphEdge, GraphNode } from '../../src/studio/graph/graph.types';
+import type { AggregatedEdge } from './collapse.lib';
+import { collapseView, dirOf, displayDirLabel, groupIdOf } from './collapse.lib';
 
 export type SavedPositions = Readonly<Record<string, { readonly x: number; readonly y: number }>>;
 
@@ -13,24 +15,25 @@ export type CardData = {
   readonly unresolved: boolean;
 };
 
-export type GroupData = { readonly label: string };
+// label は表示用に短縮済み（displayDirLabel）、dir は折りたたみ操作やツールチップ用のフルパス
+export type GroupData = { readonly label: string; readonly dir: string };
 
-export type FlowNode = Node<CardData, 'card'> | Node<GroupData, 'folder'>;
+// 折りたたみグループを表す合成ノード。id はグループと共通の folder:<dir> のため positions が引き継がれる
+export type ModuleData = {
+  readonly label: string;
+  readonly dir: string;
+  readonly memberCount: number;
+};
+
+export type FlowNode =
+  | Node<CardData, 'card'>
+  | Node<GroupData, 'folder'>
+  | Node<ModuleData, 'module'>;
 
 const NODE_WIDTH = 240;
 const NODE_HEIGHT = 80;
 const GROUP_PADDING = 24;
 const GROUP_HEADER = 32;
-
-// filePath はファイル単位、グループはディレクトリ単位。"(unknown)" は
-// スラッシュを含まないため自身がグループ key になり、まとまって表示される
-const dirOf = (filePath: string): string => {
-  const parts = filePath.split('/');
-  return parts.length > 1 ? parts.slice(0, -1).join('/') : filePath;
-};
-
-// card node の id（クラス由来の任意文字列）と衝突しないよう prefix する
-const groupIdOf = (dir: string): string => `folder:${dir}`;
 
 type Point = { readonly x: number; readonly y: number };
 type Size = { readonly width: number; readonly height: number };
@@ -154,12 +157,109 @@ const edgesOf = (graph: DependencyGraph): Edge[] =>
     className: `edge-${edge.kind}`,
   }));
 
+// count>1 は折りたたみで束ねられた元エッジ本数。ラベルは集約が起きたときだけ出す
+const aggregatedEdgesToFlow = (edges: readonly AggregatedEdge[]): Edge[] =>
+  edges.map((edge) => ({
+    id: `${edge.from}->${edge.to}#${edge.kind}`,
+    source: edge.from,
+    target: edge.to,
+    animated: false,
+    className: `edge-${edge.kind}`,
+    label: edge.count > 1 ? `×${edge.count}` : undefined,
+  }));
+
+// 折りたたみグループはメンバーを内部レイアウトしないため、固定サイズの単一ノードとして扱う
+const collapsedGroupSizesOf = (
+  expandedGroupSizes: ReadonlyMap<string, Size>,
+  collapsedDirIds: ReadonlySet<string>,
+): Map<string, Size> => {
+  const sizes = new Map(expandedGroupSizes);
+  for (const dir of collapsedDirIds) sizes.set(dir, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  return sizes;
+};
+
+const positionOf = (
+  id: string,
+  saved: SavedPositions,
+  groupLayout: ReadonlyMap<string, Point>,
+): Point => saved[id] ?? groupLayout.get(id) ?? { x: 0, y: 0 };
+
+const groupNodesOf = (
+  expandedDirIds: ReadonlyMap<string, string[]>,
+  groupSizes: ReadonlyMap<string, Size>,
+  saved: SavedPositions,
+  groupLayout: ReadonlyMap<string, Point>,
+): FlowNode[] =>
+  Array.from(expandedDirIds.keys()).map((dir) => {
+    const id = groupIdOf(dir);
+    const size = groupSizes.get(dir) ?? { width: NODE_WIDTH, height: NODE_HEIGHT };
+    return {
+      id,
+      type: 'folder',
+      position: positionOf(id, saved, groupLayout),
+      data: { label: displayDirLabel(dir), dir },
+      style: { width: size.width, height: size.height },
+    };
+  });
+
+// id はグループと共通の folder:<dir> を再利用するため、展開時の座標がそのまま引き継がれる
+const moduleNodesOf = (
+  collapsedDirIds: ReadonlySet<string>,
+  nodeIdsByDir: ReadonlyMap<string, string[]>,
+  groupSizes: ReadonlyMap<string, Size>,
+  saved: SavedPositions,
+  groupLayout: ReadonlyMap<string, Point>,
+): FlowNode[] =>
+  Array.from(collapsedDirIds).map((dir) => {
+    const id = groupIdOf(dir);
+    const size = groupSizes.get(dir) ?? { width: NODE_WIDTH, height: NODE_HEIGHT };
+    return {
+      id,
+      type: 'module',
+      position: positionOf(id, saved, groupLayout),
+      data: { label: displayDirLabel(dir), dir, memberCount: nodeIdsByDir.get(dir)?.length ?? 0 },
+      style: { width: size.width, height: size.height },
+    };
+  });
+
+// 折りたたみ dir 所属ノードは module ノードに丸め込まれるため描画しない
+const cardNodesOf = (
+  nodes: readonly GraphNode[],
+  collapsedDirIds: ReadonlySet<string>,
+  dirById: ReadonlyMap<string, string>,
+  relativePositions: ReadonlyMap<string, Point>,
+): FlowNode[] =>
+  nodes
+    .filter((node) => !collapsedDirIds.has(dirById.get(node.id) ?? dirOf(node.filePath)))
+    .map((node) => ({
+      id: node.id,
+      type: 'card',
+      position: relativePositions.get(node.id) ?? { x: 0, y: 0 },
+      parentId: groupIdOf(dirById.get(node.id) ?? dirOf(node.filePath)),
+      extent: 'parent',
+      data: cardDataOf(node),
+    }));
+
 const graphToFlowGrouped = (
   graph: DependencyGraph,
   saved: SavedPositions,
+  collapsedDirs: ReadonlySet<string>,
 ): { nodes: FlowNode[]; edges: Edge[] } => {
   const { nodeIdsByDir, dirById } = groupMembership(graph.nodes);
-  const { relativePositions, groupSizes } = layoutGroupMembers(nodeIdsByDir, graph.edges, saved);
+  // 存在しない dir 名は nodeIdsByDir に無いため、ここで自然に無視される
+  const collapsedDirIds = new Set(
+    Array.from(nodeIdsByDir.keys()).filter((dir) => collapsedDirs.has(dir)),
+  );
+  const expandedDirIds = new Map(
+    Array.from(nodeIdsByDir.entries()).filter(([dir]) => !collapsedDirIds.has(dir)),
+  );
+
+  const { relativePositions, groupSizes: expandedGroupSizes } = layoutGroupMembers(
+    expandedDirIds,
+    graph.edges,
+    saved,
+  );
+  const groupSizes = collapsedGroupSizesOf(expandedGroupSizes, collapsedDirIds);
 
   const groupEdges = groupEdgesOf(graph.edges, dirById);
   const groupSizesById = new Map(
@@ -168,27 +268,15 @@ const graphToFlowGrouped = (
   const groupLayout = runDagre(groupSizesById, groupEdges, { nodesep: 60, ranksep: 120 });
 
   // React Flow は parent node が配列内で child より前に来る必要がある
-  const groupNodes: FlowNode[] = Array.from(nodeIdsByDir.keys()).map((dir) => {
-    const id = groupIdOf(dir);
-    const size = groupSizes.get(dir) ?? { width: NODE_WIDTH, height: NODE_HEIGHT };
-    return {
-      id,
-      type: 'folder',
-      position: saved[id] ?? groupLayout.get(id) ?? { x: 0, y: 0 },
-      data: { label: dir },
-      style: { width: size.width, height: size.height },
-    };
-  });
-  const cardNodes: FlowNode[] = graph.nodes.map((node) => ({
-    id: node.id,
-    type: 'card',
-    position: relativePositions.get(node.id) ?? { x: 0, y: 0 },
-    parentId: groupIdOf(dirById.get(node.id) ?? dirOf(node.filePath)),
-    extent: 'parent',
-    data: cardDataOf(node),
-  }));
+  const groupNodes = groupNodesOf(expandedDirIds, groupSizes, saved, groupLayout);
+  const moduleNodes = moduleNodesOf(collapsedDirIds, nodeIdsByDir, groupSizes, saved, groupLayout);
+  const cardNodes = cardNodesOf(graph.nodes, collapsedDirIds, dirById, relativePositions);
 
-  return { nodes: [...groupNodes, ...cardNodes], edges: edgesOf(graph) };
+  const collapsed = collapseView(graph, collapsedDirs);
+  return {
+    nodes: [...groupNodes, ...moduleNodes, ...cardNodes],
+    edges: aggregatedEdgesToFlow(collapsed.edges),
+  };
 };
 
 // グルーピング導入前と同じフラット表示: グループ枠は作らず、全ノードを 1 回の dagre で配置する
@@ -211,11 +299,17 @@ const graphToFlowFlat = (
   return { nodes, edges: edgesOf(graph) };
 };
 
-export type GraphToFlowOptions = { readonly grouped: boolean };
+export type GraphToFlowOptions = {
+  readonly grouped: boolean;
+  // flat モードでは折りたたみ表示自体が存在しないため無視される
+  readonly collapsedDirs?: ReadonlySet<string>;
+};
 
 export const graphToFlow = (
   graph: DependencyGraph,
   saved: SavedPositions,
   options: GraphToFlowOptions,
 ): { nodes: FlowNode[]; edges: Edge[] } =>
-  options.grouped ? graphToFlowGrouped(graph, saved) : graphToFlowFlat(graph, saved);
+  options.grouped
+    ? graphToFlowGrouped(graph, saved, options.collapsedDirs ?? new Set())
+    : graphToFlowFlat(graph, saved);

--- a/packages/cli/studio-ui/src/settings.lib.test.ts
+++ b/packages/cli/studio-ui/src/settings.lib.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  defaultCollapsedDirs,
+  loadCollapsedDirs,
   loadGroupByFolder,
   loadHideNodeModules,
+  saveCollapsedDirs,
   saveGroupByFolder,
   saveHideNodeModules,
 } from './settings.lib';
@@ -63,6 +66,49 @@ describe('settings', () => {
     it('falls back to true when the parsed JSON is not a boolean', () => {
       window.localStorage.setItem(`zelt-studio:group-by-folder:${window.location.host}`, '"yes"');
       expect(loadGroupByFolder()).toBe(true);
+    });
+  });
+
+  describe('collapsedDirs', () => {
+    it('returns undefined when nothing is saved (caller falls back to defaultCollapsedDirs)', () => {
+      expect(loadCollapsedDirs()).toBeUndefined();
+    });
+
+    it('round-trips the saved set', () => {
+      saveCollapsedDirs(new Set(['src/foo', 'node_modules/pkg']));
+      expect(loadCollapsedDirs()).toEqual(new Set(['src/foo', 'node_modules/pkg']));
+
+      saveCollapsedDirs(new Set());
+      expect(loadCollapsedDirs()).toEqual(new Set());
+    });
+
+    it('falls back to undefined on corrupted storage', () => {
+      window.localStorage.setItem(
+        `zelt-studio:collapsed-dirs:${window.location.host}`,
+        '{not json',
+      );
+      expect(loadCollapsedDirs()).toBeUndefined();
+    });
+
+    it('falls back to undefined when the parsed JSON is not a string array', () => {
+      window.localStorage.setItem(
+        `zelt-studio:collapsed-dirs:${window.location.host}`,
+        JSON.stringify([1, 2, 3]),
+      );
+      expect(loadCollapsedDirs()).toBeUndefined();
+    });
+  });
+
+  describe('defaultCollapsedDirs', () => {
+    it('collapses only node_modules-like dirs, leaving the rest expanded', () => {
+      const dirs = ['src/foo', 'node_modules/pkg', 'src/bar/node_modules/dep'];
+      expect(defaultCollapsedDirs(dirs)).toEqual(
+        new Set(['node_modules/pkg', 'src/bar/node_modules/dep']),
+      );
+    });
+
+    it('returns an empty set when no dir looks like node_modules', () => {
+      expect(defaultCollapsedDirs(['src/foo', 'src/bar'])).toEqual(new Set());
     });
   });
 });

--- a/packages/cli/studio-ui/src/settings.lib.ts
+++ b/packages/cli/studio-ui/src/settings.lib.ts
@@ -1,3 +1,5 @@
+import { isNodeModulesPath } from './graph-filter.lib';
+
 // boolean flag の load/save パターンが複数の設定項目で重複するため、
 // 破損データ時のフォールバックと警告メッセージの組み立てだけ共通化する
 const loadBooleanFlag = (key: string, defaultValue: boolean, label: string): boolean => {
@@ -37,3 +39,35 @@ export const loadGroupByFolder = (): boolean =>
 
 export const saveGroupByFolder = (value: boolean): void =>
   saveBooleanFlag(groupByFolderKey(), value);
+
+const collapsedDirsKey = (): string => `zelt-studio:collapsed-dirs:${window.location.host}`;
+
+const isStringArray = (value: unknown): boolean =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+// 未保存(初回)と「保存された空集合(全展開)」を区別する必要があるため、
+// boolean flag と違い呼び出し側に default 値を持たせず undefined を返す
+export const loadCollapsedDirs = (): ReadonlySet<string> | undefined => {
+  try {
+    const raw = window.localStorage.getItem(collapsedDirsKey());
+    if (raw === null) return undefined;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isStringArray(parsed)) {
+      console.warn('zelt studio: saved collapsed-dirs have an unexpected shape, ignoring');
+      return undefined;
+    }
+    return new Set(parsed as readonly string[]);
+  } catch (error) {
+    // 破損データで UI を落とさないが、折りたたみ状態が消えた原因を追えるよう痕跡は残す
+    console.warn('zelt studio: failed to load collapsed-dirs', error);
+    return undefined;
+  }
+};
+
+export const saveCollapsedDirs = (value: ReadonlySet<string>): void =>
+  window.localStorage.setItem(collapsedDirsKey(), JSON.stringify(Array.from(value)));
+
+// node_modules は依存が大量で読む価値が低いため初回のみ折りたたんでおき、
+// それ以外の dir はユーザーが明示的に折りたたむまで展開したままにする
+export const defaultCollapsedDirs = (dirs: readonly string[]): ReadonlySet<string> =>
+  new Set(dirs.filter((dir) => isNodeModulesPath(dir)));

--- a/packages/cli/studio-ui/src/styles.css
+++ b/packages/cli/studio-ui/src/styles.css
@@ -23,7 +23,44 @@ html, body, #root { height: 100%; margin: 0; font-family: ui-sans-serif, system-
 .kind-service .badge { background: #e2e8f0; color: #334155; }
 .unresolved { border-style: dashed; border-color: #ef4444; }
 .folder { width: 100%; height: 100%; border: 1px dashed #94a3b8; border-radius: 12px; background: rgba(241, 245, 249, 0.5); }
-.folder-label { display: block; padding: 6px 10px; font-family: ui-monospace, monospace; font-size: 10px; color: #64748b; }
+.folder-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 4px 6px 4px 10px; }
+.folder-label { font-family: ui-monospace, monospace; font-size: 10px; color: #64748b; }
+.folder-collapse-btn {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  line-height: 1;
+  padding: 0;
+  border: 1px solid #94a3b8;
+  border-radius: 4px;
+  background: #ffffff;
+  color: #64748b;
+  font-size: 11px;
+  cursor: pointer;
+}
+.folder-collapse-btn:hover { background: #e2e8f0; }
+/* 折りたたみグループの合成ノード。folder の視覚言語（点線・くすんだ配色）を引き継ぎつつ、
+   card と混同しないよう実線の塗りつぶしにして「1 枚に束ねられた」印象にする */
+.module {
+  width: 240px;
+  height: 80px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px dashed #94a3b8;
+  background: #eef2f7;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 2px;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+}
+.module:hover { background: #e2e8f0; }
+.module-expand { align-self: flex-end; font-size: 11px; color: #64748b; margin-top: -18px; }
+.module strong { font-size: 13px; color: #334155; word-break: break-all; }
+.module small { color: #6b7280; font-size: 10px; }
 /* read-only 表示のため接続ハンドルは不可視化する（エッジ描画自体には Handle が必要） */
 .react-flow__handle { opacity: 0; pointer-events: none; }
 .react-flow__edge.edge-applies-middleware .react-flow__edge-path { stroke: #10b981; stroke-dasharray: 6 4; }


### PR DESCRIPTION
## Summary

studio UI にフォルダグループの折りたたみ/展開とエッジ集約を追加する(セマンティックズームの第一歩)。大きなグラフでも node_modules や興味のないフォルダをモジュール単位に畳んで俯瞰できるようにする。

## Changes

グラフ JSON は無変更(表示は UI 責務の原則を維持)。変更は `packages/cli/studio-ui` のみ。

- **collapse.lib.ts(新規)**: `collapseView` 純関数 — 折りたたみ dir 所属ノードをグループ境界に再アンカーし、(from, to, kind) で集約(count 付き)、グループ内エッジは除去。`displayDirLabel` — pnpm ハッシュ入り `node_modules` パスをパッケージ名(例: `@zeltjs/rate-limit`)に表示専用で短縮。グルーピング key はフルパス dir を維持
- **UI**: 展開中グループのヘッダに折りたたみボタン(−)。折りたたみグループは単一のモジュールノード(短縮ラベル+クラス数、ホバーでフルパス)になり、クリックで再展開。集約エッジは元 2 本以上で `×N` ラベル、kind 別スタイル(実線 = injects / 破線 = applies-middleware)は維持
- **デフォルトと永続化**: `node_modules` 系 dir は初回から折りたたみ。折りたたみ状態は localStorage 永続化。ノード位置永続化は既存の `folder:<dir>` id を再利用するため折りたたみ前後で位置が保たれる

## Screenshots

### Before(#316 時点のグルーピング表示)

node_modules のグループがフルパスのまま展開され、ノイズが大きい。

![before](https://file.app1.9wick.com/u/NO5xTd.png)

### After: 初期表示

node_modules 系はパッケージ名のモジュールノードに畳まれ、src 系は展開。

![after default](https://file.app1.9wick.com/u/xXgoJ5.png)

### After: src/usecase を折りたたみ

`4 classes` のモジュールノードと `×3` 集約エッジ。

![after collapsed](https://file.app1.9wick.com/u/f8fBfm.png)

## Testing

- collapse.lib 16 件を含む studio-ui 66 テスト(TDD で実装)、precommit フル検証(全体テスト・lint・typecheck・verify-dist)グリーン
- integration の EC バックエンドで実駆動確認: デフォルト折りたたみ / − ボタン / クリック展開 / ×3 集約 / 再展開での完全復元 / console error なし

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790721187&installation_model_id=21678&pr_number=317&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F317&signature=4a86e3133587a6ed391f76e7c444565e035b093801edf7bcd904f843860bad52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Studio UIでフォルダを折りたたみ、依存関係グラフを整理して表示できるようになりました。
  - 折りたたまれたフォルダは、含まれるモジュール数とともにまとめて表示されます。
  - エッジは集約され、複数の依存関係がある場合は件数を表示します。
  - 折りたたみ状態を保存し、次回表示時に復元できるようになりました。
  - `node_modules`関連のフォルダは初期状態で自動的に折りたたまれます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->