### PR TITLE
feat(core)!: middleware options via .with() bindings and optionsOf()

### DIFF
--- a/integration/hello-world/src/interceptor.middleware.ts
+++ b/integration/hello-world/src/interceptor.middleware.ts
@@ -1,5 +1,11 @@
 import type { Next } from '@zeltjs/core';
-import { Middleware, requestContext, response } from '@zeltjs/core';
+import {
+  Middleware,
+  MiddlewareWithOptions,
+  optionsOf,
+  requestContext,
+  response,
+} from '@zeltjs/core';
 
 @Middleware
 export class OverrideMiddleware {
@@ -19,8 +25,8 @@ export class TransformMiddleware {
 }
 
 @Middleware
-export class StatusMiddleware {
-  async use(next: Next, options: { statusCode: 200 | 400 | 500 }) {
+export class StatusMiddleware extends MiddlewareWithOptions<{ statusCode: 200 | 400 | 500 }> {
+  async use(next: Next, options = optionsOf(StatusMiddleware)) {
     await next();
     const c = requestContext();
     const original = await c.res.json();
@@ -29,8 +35,11 @@ export class StatusMiddleware {
 }
 
 @Middleware
-export class HeaderMiddleware {
-  async use(next: Next, options: { headerName: string; headerValue: string }, res = response()) {
+export class HeaderMiddleware extends MiddlewareWithOptions<{
+  headerName: string;
+  headerValue: string;
+}> {
+  async use(next: Next, options = optionsOf(HeaderMiddleware), res = response()) {
     res.header(options.headerName, options.headerValue);
     await next();
     return undefined;

--- a/integration/hello-world/src/interceptors.controller.ts
+++ b/integration/hello-world/src/interceptors.controller.ts
@@ -36,13 +36,13 @@ export class InterceptorsController {
     return this.helloService.greeting();
   }
 
-  @UseMiddleware(StatusMiddleware, { statusCode: 400 })
+  @UseMiddleware(StatusMiddleware.with({ statusCode: 400 }))
   @Get('/status')
   status() {
     return this.helloService.greeting();
   }
 
-  @UseMiddleware(HeaderMiddleware, { headerName: 'Authorization', headerValue: 'jwt' })
+  @UseMiddleware(HeaderMiddleware.with({ headerName: 'Authorization', headerValue: 'jwt' }))
   @Get('/header')
   header() {
     return { message: this.helloService.greeting() };

--- a/integration/hello-world/src/middleware.controller.ts
+++ b/integration/hello-world/src/middleware.controller.ts
@@ -16,7 +16,7 @@ export class MiddlewareController {
     return { ok: true };
   }
 
-  @UseMiddleware(HeaderMiddleware, { headerName: 'X-Custom', headerValue: 'test-value' })
+  @UseMiddleware(HeaderMiddleware.with({ headerName: 'X-Custom', headerValue: 'test-value' }))
   @Get('/with-header')
   withHeader() {
     return { ok: true };

--- a/integration/hello-world/src/transform.middleware.ts
+++ b/integration/hello-world/src/transform.middleware.ts
@@ -1,5 +1,5 @@
 import type { Next } from '@zeltjs/core';
-import { Middleware, response } from '@zeltjs/core';
+import { Middleware, MiddlewareWithOptions, optionsOf, response } from '@zeltjs/core';
 
 @Middleware
 export class TransformMiddleware {
@@ -10,8 +10,11 @@ export class TransformMiddleware {
 }
 
 @Middleware
-export class HeaderMiddleware {
-  async use(next: Next, options: { headerName: string; headerValue: string }, res = response()) {
+export class HeaderMiddleware extends MiddlewareWithOptions<{
+  headerName: string;
+  headerValue: string;
+}> {
+  async use(next: Next, options = optionsOf(HeaderMiddleware), res = response()) {
     res.header(options.headerName, options.headerValue);
     await next();
     return undefined;

--- a/integration/scopes/e2e/options-binding.spec.ts
+++ b/integration/scopes/e2e/options-binding.spec.ts
@@ -1,0 +1,70 @@
+import { Controller, UseMiddleware } from '@zeltjs/core';
+import { onTest, shutdownAll } from '@zeltjs/testing';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { app } from '../src/app';
+import { UserAuthMiddleware } from '../src/user-auth.middleware';
+
+type AuthResponse = {
+  id: string;
+  role: string;
+};
+
+describe('Middleware with Options binding', () => {
+  let testApp: Awaited<ReturnType<(typeof app)['createRuntime']>>;
+
+  beforeAll(async () => {
+    testApp = await onTest(app);
+  });
+
+  afterAll(async () => {
+    await shutdownAll();
+  });
+
+  it('connects @UseMiddleware and resultOf() through a shared const binding', async () => {
+    const res = await testApp.http.request('/options/admin/me');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AuthResponse;
+    expect(body).toEqual({ id: 'user-admin', role: 'admin' });
+  });
+
+  it('runs two distinct bindings of the same middleware class independently', async () => {
+    const adminRes = await testApp.http.request('/options/admin/me');
+    const memberRes = await testApp.http.request('/options/member/me');
+
+    const admin = (await adminRes.json()) as AuthResponse;
+    const member = (await memberRes.json()) as AuthResponse;
+
+    expect(admin).toEqual({ id: 'user-admin', role: 'admin' });
+    expect(member).toEqual({ id: 'user-member', role: 'member' });
+  });
+
+  it('resolves both bindings independently within a single request when applied together', async () => {
+    const res = await testApp.http.request('/options/both/me');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { admin: AuthResponse; member: AuthResponse };
+
+    expect(body.admin).toEqual({ id: 'user-admin', role: 'admin' });
+    expect(body.member).toEqual({ id: 'user-member', role: 'member' });
+  });
+
+  it('fails when resultOf() reads a binding that is not applied to the route', async () => {
+    // Only memberAuth is applied to this route; reading adminAuth's result
+    // must fail because that exact binding never ran here.
+    const res = await testApp.http.request('/options/member-only/read-unapplied-binding');
+    expect(res.status).toBe(500);
+  });
+
+  it('rejects registering an options-required middleware without .with() (type-level)', () => {
+    const registerBare = () => {
+      // @ts-expect-error UserAuthMiddleware requires options — the bare class
+      // has no options for it to run with, so registering it without .with()
+      // must be a type error.
+      @UseMiddleware(UserAuthMiddleware)
+      @Controller('/options/type-error-test')
+      class TypeErrorController {}
+      return TypeErrorController;
+    };
+    void registerBare;
+  });
+});

--- a/integration/scopes/src/app.ts
+++ b/integration/scopes/src/app.ts
@@ -1,11 +1,24 @@
 import { createApp, http } from '@zeltjs/core';
 
 import { AssignIdMiddleware, MiddlewareController } from './middleware.controller';
+import {
+  AdminBoundController,
+  BothBoundController,
+  MemberBoundController,
+  MemberOnlyController,
+} from './options-binding.controller';
 import { ScopesController } from './scopes.controller';
 
 export const app = createApp([
   http({
-    controllers: [ScopesController, MiddlewareController],
+    controllers: [
+      ScopesController,
+      MiddlewareController,
+      AdminBoundController,
+      MemberBoundController,
+      BothBoundController,
+      MemberOnlyController,
+    ],
     middlewares: [AssignIdMiddleware],
   }),
 ]);

--- a/integration/scopes/src/options-binding.controller.ts
+++ b/integration/scopes/src/options-binding.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, resultOf, UseMiddleware } from '@zeltjs/core';
+
+import { adminAuth, memberAuth } from './user-auth.middleware';
+
+// Doc's adminAuth scenario: the const bound at the class is the same const
+// read via resultOf() in the handler.
+@UseMiddleware(adminAuth)
+@Controller('/options/admin')
+export class AdminBoundController {
+  @Get('/me')
+  me() {
+    const admin = resultOf(adminAuth);
+    return { id: admin.id, role: admin.role };
+  }
+}
+
+// A second, independent binding of the same UserAuthMiddleware class.
+// Verifies that two .with() calls on one class don't share results/options.
+@UseMiddleware(memberAuth)
+@Controller('/options/member')
+export class MemberBoundController {
+  @Get('/me')
+  me() {
+    const member = resultOf(memberAuth);
+    return { id: member.id, role: member.role };
+  }
+}
+
+// Both bindings applied to the same route: each must resolve independently
+// within a single request, not collide because they share a class.
+@Controller('/options/both')
+export class BothBoundController {
+  @Get('/me')
+  @UseMiddleware(adminAuth)
+  @UseMiddleware(memberAuth)
+  me() {
+    const admin = resultOf(adminAuth);
+    const member = resultOf(memberAuth);
+    return { admin, member };
+  }
+}
+
+// Only memberAuth is applied here; reading adminAuth's result must fail
+// because that exact binding never ran on this route.
+@UseMiddleware(memberAuth)
+@Controller('/options/member-only')
+export class MemberOnlyController {
+  @Get('/read-unapplied-binding')
+  me() {
+    const admin = resultOf(adminAuth);
+    return { id: admin.id, role: admin.role };
+  }
+}

--- a/integration/scopes/src/user-auth.middleware.ts
+++ b/integration/scopes/src/user-auth.middleware.ts
@@ -1,0 +1,34 @@
+import type { Next } from '@zeltjs/core';
+import { Middleware, MiddlewareWithOptions, optionsOf } from '@zeltjs/core';
+
+export type RoleAuthOptions = {
+  role: string;
+};
+
+export type AuthenticatedUser = {
+  id: string;
+  role: string;
+};
+
+// Mirrors the doc's "Middleware with Options" example: a middleware that
+// needs configuration extends MiddlewareWithOptions<TOptions> and reads it
+// via optionsOf() as a use() parameter default. It hands its result
+// downstream via next(value) so resultOf() at the applied binding's exact
+// identity can read it back.
+@Middleware
+export class UserAuthMiddleware extends MiddlewareWithOptions<RoleAuthOptions> {
+  async use(
+    next: Next<AuthenticatedUser>,
+    opts = optionsOf(UserAuthMiddleware),
+  ): Promise<Response | undefined> {
+    await next({ id: `user-${opts.role}`, role: opts.role });
+    return undefined;
+  }
+}
+
+// Two distinct bindings of the same class. Each .with() call is its own
+// middleware identity — sharing these consts (not re-calling .with()) is
+// what lets @UseMiddleware and resultOf()/optionsOf() agree on which
+// binding they mean.
+export const adminAuth = UserAuthMiddleware.with({ role: 'admin' });
+export const memberAuth = UserAuthMiddleware.with({ role: 'member' });

--- a/packages/core/src/features/http/app.test.ts
+++ b/packages/core/src/features/http/app.test.ts
@@ -8,14 +8,14 @@ import type { Lifecycle } from '../../kernel';
 import { inject, LifecycleManager, runInContext } from '../../kernel';
 import { ErrorHandler } from './error/error-handler.decorator';
 import { http } from './http.feature';
-import { fromHonoMiddleware } from './middleware';
+import { fromHonoMiddleware, MiddlewareWithOptions } from './middleware';
 import { Middleware } from './middleware/middleware.decorator';
 import type { Next } from './middleware/middleware.types';
 import { SecureHeadersMiddleware } from './middleware/secure-headers/secure-headers.middleware';
 import { SkipMiddleware } from './middleware/skip-middleware.decorator';
 import { UseMiddleware } from './middleware/use-middleware.decorator';
 import { registerAfterResponseCallback } from './request';
-import { request, resultOf } from './request/injection';
+import { optionsOf, request, resultOf } from './request/injection';
 import { response } from './response';
 import { Controller } from './routing/controller.decorator';
 import { Get, Post } from './routing/http-method.decorator';
@@ -1816,12 +1816,9 @@ describe('warmup option', () => {
     type RateLimitOptions = { limit: number; windowSec: number };
 
     @Middleware
-    class RateLimitMiddleware {
-      async use(
-        next: Next,
-        options: RateLimitOptions,
-        res = response(),
-      ): Promise<Response | undefined> {
+    class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+      async use(next: Next, res = response()): Promise<Response | undefined> {
+        const options = optionsOf(RateLimitMiddleware);
         res.header('X-RateLimit-Limit', String(options.limit));
         res.header('X-RateLimit-Window', String(options.windowSec));
         await next();
@@ -1831,20 +1828,58 @@ describe('warmup option', () => {
 
     @Controller('/api')
     class ApiController {
-      @UseMiddleware(RateLimitMiddleware, { limit: 100, windowSec: 60 })
       @Get('/')
       get() {
         return { ok: true };
       }
     }
 
-    const app = createApp([http({ controllers: [ApiController] })]);
+    const app = createApp([
+      http({
+        controllers: [ApiController],
+        middlewares: [RateLimitMiddleware.with({ limit: 100, windowSec: 60 })],
+      }),
+    ]);
     const readyApp = await app.createRuntime();
 
     const res = await readyApp.http.request('/api/');
     expect(res.status).toBe(200);
     expect(res.headers.get('X-RateLimit-Limit')).toBe('100');
     expect(res.headers.get('X-RateLimit-Window')).toBe('60');
+    await readyApp.shutdown();
+  });
+
+  it('applies a binding with @UseMiddleware and reads its result via the shared const, as documented', async () => {
+    type AuthOptions = { role: string };
+
+    @Middleware
+    class UserAuthMiddleware extends MiddlewareWithOptions<AuthOptions> {
+      async use(
+        next: Next<{ id: number; role: string }>,
+        opts = optionsOf(UserAuthMiddleware),
+      ): Promise<Response | undefined> {
+        await next({ id: 1, role: opts.role });
+        return undefined;
+      }
+    }
+
+    const adminAuth = UserAuthMiddleware.with({ role: 'admin' });
+
+    @UseMiddleware(adminAuth)
+    @Controller('/admin')
+    class AdminController {
+      @Get('/me')
+      me(admin = resultOf(adminAuth)) {
+        return { id: admin.id, role: admin.role };
+      }
+    }
+
+    const app = createApp([http({ controllers: [AdminController] })]);
+    const readyApp = await app.createRuntime();
+
+    const res = await readyApp.http.request('/admin/me');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: 1, role: 'admin' });
     await readyApp.shutdown();
   });
 });

--- a/packages/core/src/features/http/middleware/index.ts
+++ b/packages/core/src/features/http/middleware/index.ts
@@ -1,4 +1,5 @@
 export { fromHonoMiddleware } from './from-hono-middleware.lib';
+export type { MiddlewareOptionsClass, MiddlewareOptionsOf } from './middleware.types';
 export type { SkippedMiddlewareSets } from './middleware-guard.lib';
 export {
   attachSkippedMiddlewares,
@@ -7,3 +8,4 @@ export {
   oncePerRequest,
   resolveMiddleware,
 } from './middleware-guard.lib';
+export { MiddlewareWithOptions } from './middleware-with-options.lib';

--- a/packages/core/src/features/http/middleware/middleware-guard.lib.ts
+++ b/packages/core/src/features/http/middleware/middleware-guard.lib.ts
@@ -4,7 +4,7 @@ import { findTargetHandler } from 'hono/utils/handler';
 
 import type { ResolverHandle } from '../../../kernel';
 import { createContextKey, getInternal, setInternal } from '../../../kernel';
-import { recordMiddlewareResult } from '../request/injection';
+import { recordMiddlewareOptions, recordMiddlewareResult } from '../request/injection';
 import type { HonoMiddleware, MiddlewareIdentifier, MiddlewareInput } from './middleware.types';
 
 const SKIPPED_MIDDLEWARES = Symbol('zelt:skipped-middlewares');
@@ -30,42 +30,50 @@ export const middlewareIdentity = (input: MiddlewareInput): MiddlewareIdentifier
   return input.middleware;
 };
 
-// next() is Hono's own zero-arg callback; wrapping it lets middleware pass a
-// value through next(value) without changing what Hono itself receives.
-// arguments.length (not `value === undefined`) distinguishes an explicit
-// undefined payload from a bare next() call.
+// Wraps Hono's zero-arg next() so middleware can pass a value through
+// next(value); arguments.length distinguishes an explicit next(undefined) — a
+// legitimate Next<undefined> contract — from a bare next(). Results are keyed
+// by the registered value itself: for a binding, the bound object, never its
+// class, which would collide two bindings of the same class.
 /** @throws {ZeltContextNotAvailableError} */
 const captureNextResult = (
-  identifier: MiddlewareIdentifier,
+  key: MiddlewareInput,
   next: () => Promise<void>,
 ): ((...args: unknown[]) => Promise<void>) => {
   return async (...args: unknown[]) => {
     if (args.length > 0) {
-      recordMiddlewareResult(identifier, args[0]);
+      recordMiddlewareResult(key, args[0]);
     }
     await next();
   };
 };
 
-/** @throws {ZeltLifecycleStateError | TypeError} */
+/** @throws {ZeltContextNotAvailableError | ZeltLifecycleStateError | TypeError} */
 export const resolveMiddleware = (
   middleware: MiddlewareInput,
   resolver: ResolverHandle,
 ): HonoMiddleware => {
-  const identifier = middlewareIdentity(middleware);
   if (typeof middleware === 'function') {
     if (!checkMiddlewareClass(middleware)) {
       throw new TypeError('Invalid middleware class. Missing use() method.');
     }
     const instance = resolver.get(middleware);
-    return async (_c, next) => await instance.use(captureNextResult(identifier, next));
+    return async (_c, next) => await instance.use(captureNextResult(middleware, next));
   }
   if (!checkMiddlewareClass(middleware.middleware)) {
     throw new TypeError('Invalid middleware class. Missing use() method.');
   }
   const instance = resolver.get(middleware.middleware);
-  return async (_c, next) =>
-    await instance.use(captureNextResult(identifier, next), middleware.options);
+  return async (_c, next) => {
+    // recordMiddlewareOptions's contract: restore in a finally around the WHOLE
+    // use() call, not just after next() — see its doc for why.
+    const restoreOptions = recordMiddlewareOptions(middleware.middleware, middleware.options);
+    try {
+      return await instance.use(captureNextResult(middleware, next));
+    } finally {
+      restoreOptions();
+    }
+  };
 };
 
 export const attachSkippedMiddlewares = (handler: object, skipped: SkippedMiddlewareSets): void => {

--- a/packages/core/src/features/http/middleware/middleware-with-options.lib.test.ts
+++ b/packages/core/src/features/http/middleware/middleware-with-options.lib.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { MiddlewareOptionsOf, Next } from './middleware.types';
+import { MiddlewareWithOptions } from './middleware-with-options.lib';
+
+type RateLimitOptions = { limit: number; windowSec: number };
+
+class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+  async use(next: Next): Promise<undefined> {
+    await next();
+    return undefined;
+  }
+}
+
+class ExtendedRateLimitMiddleware extends RateLimitMiddleware {}
+
+describe('MiddlewareWithOptions.with()', () => {
+  it('returns a binding carrying the class and the given options', () => {
+    const bound = RateLimitMiddleware.with({ limit: 100, windowSec: 60 });
+    expect(bound.middleware).toBe(RateLimitMiddleware);
+    expect(bound.options).toEqual({ limit: 100, windowSec: 60 });
+  });
+
+  it('produces a distinct identity on every call, even with identical options', () => {
+    const first = RateLimitMiddleware.with({ limit: 1, windowSec: 1 });
+    const second = RateLimitMiddleware.with({ limit: 1, windowSec: 1 });
+    expect(first).not.toBe(second);
+  });
+
+  it('resolves the bound class from a one-level subclass', () => {
+    const bound = ExtendedRateLimitMiddleware.with({ limit: 1, windowSec: 1 });
+    expect(bound.middleware).toBe(ExtendedRateLimitMiddleware);
+    expect(bound.options).toEqual({ limit: 1, windowSec: 1 });
+  });
+
+  it('preserves the concrete class (not widened to MiddlewareClass) so optionsOf()/resultOf() can recover it', () => {
+    const bound = RateLimitMiddleware.with({ limit: 1, windowSec: 1 });
+    expectTypeOf(bound.middleware).toEqualTypeOf<typeof RateLimitMiddleware>();
+  });
+});
+
+describe('MiddlewareOptionsOf', () => {
+  it('extracts the TOptions a subclass was declared with', () => {
+    expectTypeOf<
+      MiddlewareOptionsOf<typeof RateLimitMiddleware>
+    >().toEqualTypeOf<RateLimitOptions>();
+  });
+});

--- a/packages/core/src/features/http/middleware/middleware-with-options.lib.ts
+++ b/packages/core/src/features/http/middleware/middleware-with-options.lib.ts
@@ -3,6 +3,7 @@ import type {
   BoundMiddleware,
   MiddlewareOptionsOf,
 } from './middleware.types';
+import { BOUND_MIDDLEWARE_BRAND } from './middleware.types';
 
 /**
  * Base class for middleware that needs configuration. Bind options with the
@@ -25,6 +26,6 @@ export abstract class MiddlewareWithOptions<TOptions = undefined> {
     options: MiddlewareOptionsOf<C>,
   ): BoundMiddleware<C> {
     // biome-ignore lint/complexity/noThisInStatic: `this` IS the calling subclass — biome's fix substitutes the base class, binding every subclass's options to it
-    return { middleware: this, options };
+    return { middleware: this, options, [BOUND_MIDDLEWARE_BRAND]: true };
   }
 }

--- a/packages/core/src/features/http/middleware/middleware-with-options.lib.ts
+++ b/packages/core/src/features/http/middleware/middleware-with-options.lib.ts
@@ -1,0 +1,30 @@
+import type {
+  AnyMiddlewareWithOptionsClass,
+  BoundMiddleware,
+  MiddlewareOptionsOf,
+} from './middleware.types';
+
+/**
+ * Base class for middleware that needs configuration. Bind options with the
+ * static `.with()` factory; the returned value is the middleware's identity
+ * everywhere it's used (`@UseMiddleware`, `middlewares:`, `optionsOf()`,
+ * `resultOf()`), so store it in a `const` and reuse that reference — calling
+ * `.with()` again, even with identical options, produces a different identity.
+ */
+export abstract class MiddlewareWithOptions<TOptions = undefined> {
+  // Structural contract with OptionsPhantom in middleware.types.ts — keep the
+  // two in sync. Must stay a plain (non-`protected`/`private`) member: TS
+  // compares protected/private members nominally, so the structural
+  // OptionsPhantom pattern could never match one.
+  declare readonly __optionsPhantom: (options: TOptions) => void;
+
+  // No abstract use() — it would recreate the self-reference cycle that
+  // MiddlewareOptionsClass (middleware.types.ts) exists to avoid.
+  static with<C extends AnyMiddlewareWithOptionsClass>(
+    this: C,
+    options: MiddlewareOptionsOf<C>,
+  ): BoundMiddleware<C> {
+    // biome-ignore lint/complexity/noThisInStatic: `this` IS the calling subclass — biome's fix substitutes the base class, binding every subclass's options to it
+    return { middleware: this, options };
+  }
+}

--- a/packages/core/src/features/http/middleware/middleware.types.ts
+++ b/packages/core/src/features/http/middleware/middleware.types.ts
@@ -63,6 +63,19 @@ export type MiddlewareOptionsOf<C> = C extends new (
   ? T
   : never;
 
+// BoundMiddleware is otherwise just { middleware, options } — purely
+// structural, so without this brand any object literal shaped like one would
+// satisfy the type, letting options: unknown skip all validation (e.g.
+// `{ middleware: RateLimitMiddleware, options: { limit: 'nope' } }` registered
+// directly via @UseMiddleware/middlewares:, bypassing MiddlewareWithOptions
+// entirely). Real (not `declare`d) so MiddlewareWithOptions.with(), the only
+// legitimate producer, can actually set it — a `declare`-only phantom can't be
+// assigned in a plain object literal without an inline `as`, which is banned.
+// Not re-exported from middleware/index.ts or the package's public index.ts:
+// packages/core's package.json "exports" only exposes dist/index.js, so code
+// outside this package can never import this symbol to forge one.
+export const BOUND_MIDDLEWARE_BRAND: unique symbol = Symbol('zelt:bound-middleware');
+
 // Produced by MiddlewareWithOptions.with(options); this value (not the class)
 // is what identifies the binding everywhere — @UseMiddleware, middlewares:,
 // optionsOf(), resultOf() — since one class can be bound to several option sets.
@@ -73,6 +86,7 @@ export type BoundMiddleware<
 > = {
   readonly middleware: TClass;
   readonly options: unknown;
+  [BOUND_MIDDLEWARE_BRAND]: true;
 };
 
 export type MiddlewareInput = MiddlewareClass | BoundMiddleware;

--- a/packages/core/src/features/http/middleware/middleware.types.ts
+++ b/packages/core/src/features/http/middleware/middleware.types.ts
@@ -18,30 +18,66 @@ export type Next<T = void> = [T] extends [void]
 
 type MaybePromise<T> = T | Promise<T>;
 
-type MiddlewareResult = MaybePromise<Response | undefined | undefined>;
+export type MiddlewareResult = MaybePromise<Response | undefined>;
 
-export type MiddlewareInstance<TOptions = undefined> = [TOptions] extends [undefined]
-  ? {
-      use(next: Next): MiddlewareResult;
-    }
-  : {
-      use(next: Next, options: TOptions): MiddlewareResult;
-    };
+// Middleware that needs options extends MiddlewareWithOptions<TOptions> and
+// reads them via optionsOf() inside use().
+export type MiddlewareInstance = {
+  use(next: Next): MiddlewareResult;
+};
 
-export type MiddlewareClass<TOptions = undefined> = new (
-  ...args: never[]
-) => MiddlewareInstance<TOptions>;
+export type MiddlewareClass = new (...args: never[]) => MiddlewareInstance;
 
 export type RequestContext = Context<Env, string, Input>;
 
-export type MiddlewareEntry<TOptions = unknown> = {
-  readonly middleware: MiddlewareClass<TOptions>;
-  readonly options: TOptions;
+// Structural stand-in for MiddlewareWithOptions<TOptions>'s instance shape,
+// spelled out instead of importing the class so this file stays import-cycle
+// free with middleware-with-options.lib.ts (which imports its types from here).
+// The phantom must sit in parameter (contravariant) position: a plain
+// TOptions-typed field is covariant, making the `never`-bound constraints
+// below reject every subclass instead of accepting them all.
+type OptionsPhantom<TOptions> = {
+  readonly __optionsPhantom: (options: TOptions) => void;
 };
 
-export type MiddlewareInput = MiddlewareClass | MiddlewareEntry<unknown>;
+// Deliberately ONE constructor signature returning an intersection instance
+// type — not an intersection of two constructor types: generic inference
+// through intersected constructor signatures (e.g. ResolverHandle.get) picks
+// up only one branch, silently dropping use() from the inferred type.
+export type AnyMiddlewareWithOptionsClass = new (
+  ...args: never[]
+) => MiddlewareInstance & OptionsPhantom<never>;
 
-export type MiddlewareIdentifier = new (...args: never[]) => object;
+// Deliberately does NOT require use(): optionsOf(Self) is written as a default
+// parameter of Self's own use(), so a use()-requiring constraint would make
+// checking that call depend on resolving the very signature being checked, and
+// TS types `opts` as an implicit any (verified). `.with()` is the side that
+// requires use() (via AnyMiddlewareWithOptionsClass) — it's called after the
+// subclass is fully resolved, so no cycle exists there.
+export type MiddlewareOptionsClass = new (...args: never[]) => OptionsPhantom<never>;
+
+// Extracts the TOptions a concrete MiddlewareWithOptions subclass was declared with.
+export type MiddlewareOptionsOf<C> = C extends new (
+  ...args: never[]
+) => OptionsPhantom<infer T>
+  ? T
+  : never;
+
+// Produced by MiddlewareWithOptions.with(options); this value (not the class)
+// is what identifies the binding everywhere — @UseMiddleware, middlewares:,
+// optionsOf(), resultOf() — since one class can be bound to several option sets.
+// TClass is preserved (not widened to MiddlewareClass) so resultOf() can still
+// recover the concrete middleware's provided-value type through `.middleware`.
+export type BoundMiddleware<
+  TClass extends AnyMiddlewareWithOptionsClass = AnyMiddlewareWithOptionsClass,
+> = {
+  readonly middleware: TClass;
+  readonly options: unknown;
+};
+
+export type MiddlewareInput = MiddlewareClass | BoundMiddleware;
+
+export type MiddlewareIdentifier = MiddlewareClass | BoundMiddleware;
 
 export type ErrorHandlerClass = new (...args: never[]) => ErrorHandlerInstance;
 

--- a/packages/core/src/features/http/middleware/use-middleware.decorator.test.ts
+++ b/packages/core/src/features/http/middleware/use-middleware.decorator.test.ts
@@ -175,4 +175,36 @@ describe('@UseMiddleware', () => {
     };
     void registerBare;
   });
+
+  it('rejects a hand-crafted { middleware, options } object at the type level, even with a valid options shape', () => {
+    @Injectable()
+    class OptionsMiddleware extends MiddlewareWithOptions<{ limit: number }> {
+      async use(next: () => Promise<void>) {
+        await next();
+        return undefined;
+      }
+    }
+
+    // Control: the real .with() binding is accepted (proves the rejection
+    // below is about the hand-crafted shape, not about OptionsMiddleware).
+    const registerBound = () => {
+      @UseMiddleware(OptionsMiddleware.with({ limit: 100 }))
+      @Controller('/test')
+      class TestController {}
+      return TestController;
+    };
+    void registerBound;
+
+    const registerForged = () => {
+      // @ts-expect-error a hand-crafted { middleware, options } object is not
+      // a valid BoundMiddleware — only MiddlewareWithOptions.with() can
+      // produce one (it carries a brand no other code can construct), so this
+      // must be rejected even though `options` has the right shape.
+      @UseMiddleware({ middleware: OptionsMiddleware, options: { limit: 100 } })
+      @Controller('/test')
+      class TestController {}
+      return TestController;
+    };
+    void registerForged;
+  });
 });

--- a/packages/core/src/features/http/middleware/use-middleware.decorator.test.ts
+++ b/packages/core/src/features/http/middleware/use-middleware.decorator.test.ts
@@ -3,7 +3,8 @@ import { Injectable } from '../../../kernel';
 import { getControllerMiddlewareMetadata, getMethodMiddlewareMetadata } from '../routing';
 import { Controller } from '../routing/controller.decorator';
 import { Get } from '../routing/http-method.decorator';
-import type { MiddlewareEntry, MiddlewareInstance } from './middleware.types';
+import type { MiddlewareInstance } from './middleware.types';
+import { MiddlewareWithOptions } from './middleware-with-options.lib';
 import { UseMiddleware } from './use-middleware.decorator';
 
 class TestMiddleware implements MiddlewareInstance {
@@ -84,18 +85,19 @@ describe('@UseMiddleware', () => {
     }).toThrow(/cannot be applied to static methods/);
   });
 
-  it('registers middleware with options on method metadata', () => {
+  it('registers a binding (from .with()) on method metadata, keeping the exact bound object as identity', () => {
     @Injectable()
-    class OptionsMiddleware implements MiddlewareInstance<{ limit: number }> {
-      async use(next: () => Promise<void>, _options: { limit: number }) {
+    class OptionsMiddleware extends MiddlewareWithOptions<{ limit: number }> {
+      async use(next: () => Promise<void>) {
         await next();
         return undefined;
       }
     }
+    const bound = OptionsMiddleware.with({ limit: 100 });
 
     @Controller('/test')
     class TestController {
-      @UseMiddleware(OptionsMiddleware, { limit: 100 })
+      @UseMiddleware(bound)
       @Get('/')
       handler() {
         return {};
@@ -105,28 +107,25 @@ describe('@UseMiddleware', () => {
     const meta = getMethodMiddlewareMetadata(TestController);
     expect(meta).toHaveLength(1);
     expect(meta[0]?.methodName).toBe('handler');
-    const entry = meta[0]?.middlewares[0] as MiddlewareEntry<{ limit: number }>;
-    expect(entry.middleware).toBe(OptionsMiddleware);
-    expect(entry.options).toEqual({ limit: 100 });
+    expect(meta[0]?.middlewares[0]).toBe(bound);
   });
 
-  it('registers middleware with options on controller metadata', () => {
+  it('registers a binding (from .with()) on controller metadata, keeping the exact bound object as identity', () => {
     @Injectable()
-    class OptionsMiddleware implements MiddlewareInstance<{ limit: number }> {
-      async use(next: () => Promise<void>, _options: { limit: number }) {
+    class OptionsMiddleware extends MiddlewareWithOptions<{ limit: number }> {
+      async use(next: () => Promise<void>) {
         await next();
         return undefined;
       }
     }
+    const bound = OptionsMiddleware.with({ limit: 50 });
 
-    @UseMiddleware(OptionsMiddleware, { limit: 50 })
+    @UseMiddleware(bound)
     @Controller('/test')
     class TestController {}
 
     const meta = getControllerMiddlewareMetadata(TestController);
-    const entry = meta?.[0]?.[0] as MiddlewareEntry<{ limit: number }>;
-    expect(entry.middleware).toBe(OptionsMiddleware);
-    expect(entry.options).toEqual({ limit: 50 });
+    expect(meta?.[0]?.[0]).toBe(bound);
   });
 
   it('keeps each @UseMiddleware application as a separate set on the class', () => {
@@ -138,5 +137,42 @@ describe('@UseMiddleware', () => {
     const meta = getControllerMiddlewareMetadata(TestController);
     // Innermost decorator is evaluated first, so [anotherMiddleware] comes first.
     expect(meta).toEqual([[AnotherMiddleware], [TestMiddleware]]);
+  });
+
+  it('accepts a MiddlewareWithOptions<undefined> subclass bare, without .with()', () => {
+    @Injectable()
+    class OptionalConfigMiddleware extends MiddlewareWithOptions {
+      async use(next: () => Promise<void>) {
+        await next();
+        return undefined;
+      }
+    }
+
+    @UseMiddleware(OptionalConfigMiddleware)
+    @Controller('/test')
+    class TestController {}
+
+    const meta = getControllerMiddlewareMetadata(TestController);
+    expect(meta).toEqual([[OptionalConfigMiddleware]]);
+  });
+
+  it('rejects registering an options-required middleware without .with() at the type level', () => {
+    @Injectable()
+    class OptionsMiddleware extends MiddlewareWithOptions<{ limit: number }> {
+      async use(next: () => Promise<void>) {
+        await next();
+        return undefined;
+      }
+    }
+
+    const registerBare = () => {
+      // @ts-expect-error registering the bare class is a type error — there's
+      // no options for OptionsMiddleware to run with without .with()
+      @UseMiddleware(OptionsMiddleware)
+      @Controller('/test')
+      class TestController {}
+      return TestController;
+    };
+    void registerBare;
   });
 });

--- a/packages/core/src/features/http/middleware/use-middleware.decorator.ts
+++ b/packages/core/src/features/http/middleware/use-middleware.decorator.ts
@@ -6,31 +6,34 @@ import {
 } from '@zeltjs/decorator-metadata';
 
 import { ZeltDecoratorUsageError } from '../../../kernel';
-import type { MiddlewareClass } from './middleware.types';
+import type {
+  AnyMiddlewareWithOptionsClass,
+  BoundMiddleware,
+  MiddlewareClass,
+} from './middleware.types';
+import type { MiddlewareWithOptions } from './middleware-with-options.lib';
 
-const toMiddlewareInput = <TOptions>(
-  middleware: MiddlewareClass<TOptions>,
-  options: [] | [TOptions],
-) => {
-  if (options.length === 0) return middleware;
-  return { middleware, options: options[0] };
-};
+// Middleware requiring options must always go through .with(); the bare class
+// is only accepted here when it either isn't a MiddlewareWithOptions subclass
+// at all, or is one declared with undefined options (options optional). This
+// has to be a generic conditional on the candidate M, not a plain type: only
+// inference through M (not a fixed shape) can single out "this particular
+// candidate's own TOptions" and reject it when it's neither of those cases.
+type MiddlewareLike<M extends MiddlewareClass> = M extends new (
+  ...args: never[]
+) => MiddlewareWithOptions<infer TOptions>
+  ? undefined extends TOptions
+    ? M
+    : never
+  : M;
 
-export function UseMiddleware(
-  middleware: MiddlewareClass<undefined>,
-): ClassDecoratorFn & MethodDecoratorFn;
-export function UseMiddleware<TOptions>(
-  middleware: MiddlewareClass<TOptions>,
-  options: TOptions,
-): ClassDecoratorFn & MethodDecoratorFn;
 /** @throws {E} */
-export function UseMiddleware<TOptions>(
-  middleware: MiddlewareClass<TOptions>,
-  ...options: [] | [TOptions]
-): ClassDecoratorFn & MethodDecoratorFn {
+const registerMiddleware = (
+  middleware: MiddlewareClass | BoundMiddleware,
+): ClassDecoratorFn & MethodDecoratorFn => {
   const props = {
     decorator: 'UseMiddleware' as const,
-    middlewares: [toMiddlewareInput(middleware, options)],
+    middlewares: [middleware],
   };
   const classDecorate = createClassDecorator(props);
   const methodDecorate = createMethodDecorator(props, {
@@ -39,4 +42,20 @@ export function UseMiddleware<TOptions>(
   });
 
   return dispatchClassOrMethodDecorator(classDecorate, methodDecorate);
+};
+
+export function UseMiddleware<TClass extends AnyMiddlewareWithOptionsClass>(
+  middleware: BoundMiddleware<TClass>,
+): ClassDecoratorFn & MethodDecoratorFn;
+export function UseMiddleware<M extends MiddlewareClass>(
+  middleware: MiddlewareLike<M>,
+): ClassDecoratorFn & MethodDecoratorFn;
+/**
+ * @throws {ZeltDecoratorUsageError}
+ * @throws {E}
+ */
+export function UseMiddleware(
+  middleware: MiddlewareClass | BoundMiddleware,
+): ClassDecoratorFn & MethodDecoratorFn {
+  return registerMiddleware(middleware);
 }

--- a/packages/core/src/features/http/request/injection/index.ts
+++ b/packages/core/src/features/http/request/injection/index.ts
@@ -6,8 +6,6 @@ export {
   readRequestBody,
   setBodySource,
 } from './body.lib';
-// recordMiddlewareOptions is intra-package only: middleware-guard.lib.ts writes
-// through it, core/src/index.ts does not re-export it.
 export { optionsOf, recordMiddlewareOptions } from './options-of.lib';
 export { setPathParams } from './path-param.lib';
 export type {
@@ -18,6 +16,4 @@ export type {
 } from './request.lib';
 export { request } from './request.lib';
 export type { MiddlewareResultOf } from './result-of.lib';
-// recordMiddlewareResult is intra-package only: middleware-guard.lib.ts writes
-// through it, core/src/index.ts does not re-export it.
 export { recordMiddlewareResult, resultOf } from './result-of.lib';

--- a/packages/core/src/features/http/request/injection/index.ts
+++ b/packages/core/src/features/http/request/injection/index.ts
@@ -6,6 +6,9 @@ export {
   readRequestBody,
   setBodySource,
 } from './body.lib';
+// recordMiddlewareOptions is intra-package only: middleware-guard.lib.ts writes
+// through it, core/src/index.ts does not re-export it.
+export { optionsOf, recordMiddlewareOptions } from './options-of.lib';
 export { setPathParams } from './path-param.lib';
 export type {
   ExtractRequestBody,

--- a/packages/core/src/features/http/request/injection/options-of.lib.test.ts
+++ b/packages/core/src/features/http/request/injection/options-of.lib.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { createApp } from '../../../../app';
+import {
+  runInContext,
+  ZeltContextNotAvailableError,
+  ZeltMiddlewareOptionsUnavailableError,
+} from '../../../../kernel';
+import { http } from '../../http.feature';
+import type { MiddlewareOptionsOf } from '../../middleware';
+import { MiddlewareWithOptions } from '../../middleware';
+import { Middleware } from '../../middleware/middleware.decorator';
+import type { Next } from '../../middleware/middleware.types';
+import { Controller } from '../../routing/controller.decorator';
+import { Get } from '../../routing/http-method.decorator';
+import { optionsOf } from './options-of.lib';
+
+type RateLimitOptions = { limit: number; windowSec: number };
+
+describe('optionsOf', () => {
+  it('reads the options a middleware was bound with, from inside its own use()', async () => {
+    const seen: RateLimitOptions[] = [];
+
+    @Middleware
+    class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+      async use(next: Next): Promise<Response | undefined> {
+        seen.push(optionsOf(RateLimitMiddleware));
+        await next();
+        return undefined;
+      }
+    }
+
+    @Controller('/limited')
+    class LimitedController {
+      @Get('/')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([
+      http({
+        controllers: [LimitedController],
+        middlewares: [RateLimitMiddleware.with({ limit: 100, windowSec: 60 })],
+      }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    const res = await readyApp.http.request('/limited/');
+    expect(res.status).toBe(200);
+    expect(seen).toEqual([{ limit: 100, windowSec: 60 }]);
+  });
+
+  it('keeps two bindings of the same class isolated per route', async () => {
+    const seen: RateLimitOptions[] = [];
+
+    @Middleware
+    class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+      async use(next: Next): Promise<Response | undefined> {
+        seen.push(optionsOf(RateLimitMiddleware));
+        await next();
+        return undefined;
+      }
+    }
+
+    @Controller('/strict')
+    class StrictController {
+      @Get('/')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    @Controller('/lenient')
+    class LenientController {
+      @Get('/')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([
+      http({
+        controllers: [],
+        children: [
+          http({
+            path: '/strict',
+            controllers: [StrictController],
+            middlewares: [RateLimitMiddleware.with({ limit: 1, windowSec: 1 })],
+          }),
+          http({
+            path: '/lenient',
+            controllers: [LenientController],
+            middlewares: [RateLimitMiddleware.with({ limit: 1000, windowSec: 60 })],
+          }),
+        ],
+      }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    await readyApp.http.request('/strict/strict/');
+    await readyApp.http.request('/lenient/lenient/');
+
+    expect(seen).toEqual([
+      { limit: 1, windowSec: 1 },
+      { limit: 1000, windowSec: 60 },
+    ]);
+  });
+
+  it("restores the outer binding's options after a nested binding of the same class finishes", async () => {
+    const seenBefore: RateLimitOptions[] = [];
+    const seenAfter: RateLimitOptions[] = [];
+
+    @Middleware
+    class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+      async use(next: Next): Promise<Response | undefined> {
+        seenBefore.push(optionsOf(RateLimitMiddleware));
+        await next();
+        seenAfter.push(optionsOf(RateLimitMiddleware));
+        return undefined;
+      }
+    }
+
+    @Controller('/inner')
+    class InnerController {
+      @Get('/')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([
+      http({
+        controllers: [],
+        middlewares: [RateLimitMiddleware.with({ limit: 10, windowSec: 1 })],
+        children: [
+          http({
+            path: '/inner',
+            controllers: [InnerController],
+            middlewares: [RateLimitMiddleware.with({ limit: 20, windowSec: 2 })],
+          }),
+        ],
+      }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    const res = await readyApp.http.request('/inner/inner/');
+    expect(res.status).toBe(200);
+
+    // outer's own binding must still read its own options after the nested
+    // binding of the same class has run and restored the shared map.
+    expect(seenBefore).toEqual([
+      { limit: 10, windowSec: 1 },
+      { limit: 20, windowSec: 2 },
+    ]);
+    expect(seenAfter).toEqual([
+      { limit: 20, windowSec: 2 },
+      { limit: 10, windowSec: 1 },
+    ]);
+  });
+
+  it('throws a named error with a resolution hint when the class was never bound via .with()', () => {
+    class UnboundMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+      async use(next: Next): Promise<Response | undefined> {
+        await next();
+        return undefined;
+      }
+    }
+
+    runInContext(() => {
+      expect(() => optionsOf(UnboundMiddleware)).toThrow(ZeltMiddlewareOptionsUnavailableError);
+      expect(() => optionsOf(UnboundMiddleware)).toThrow(/UnboundMiddleware/);
+      expect(() => optionsOf(UnboundMiddleware)).toThrow(/\.with\(/);
+    });
+  });
+
+  it('throws ZeltContextNotAvailableError when called outside entry execution', () => {
+    class SomeMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+      async use(next: Next): Promise<Response | undefined> {
+        await next();
+        return undefined;
+      }
+    }
+
+    expect(() => optionsOf(SomeMiddleware)).toThrow(ZeltContextNotAvailableError);
+  });
+
+  it('supports the self-referencing default-parameter idiom (opts = optionsOf(Self)), unannotated as documented', async () => {
+    const seen: RateLimitOptions[] = [];
+
+    @Middleware
+    class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+      // No parameter type annotation, matching website/docs/middleware.md
+      // exactly. This only type-checks because optionsOf()'s parameter
+      // constraint doesn't require use() to exist (see MiddlewareOptionsClass
+      // in middleware-with-options.lib.ts) — requiring it here would make TS
+      // resolve this very use() signature while checking that constraint,
+      // which is circular.
+      async use(next: Next, opts = optionsOf(RateLimitMiddleware)): Promise<Response | undefined> {
+        seen.push(opts);
+        await next();
+        return undefined;
+      }
+    }
+
+    @Controller('/self-ref')
+    class SelfRefController {
+      @Get('/')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([
+      http({
+        controllers: [SelfRefController],
+        middlewares: [RateLimitMiddleware.with({ limit: 5, windowSec: 5 })],
+      }),
+    ]);
+    const readyApp = await app.createRuntime();
+
+    const res = await readyApp.http.request('/self-ref/');
+    expect(res.status).toBe(200);
+    expect(seen).toEqual([{ limit: 5, windowSec: 5 }]);
+  });
+
+  it('infers the options type from the concrete subclass', () => {
+    class _RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+      async use(next: Next): Promise<Response | undefined> {
+        await next();
+        return undefined;
+      }
+    }
+
+    expectTypeOf<
+      MiddlewareOptionsOf<typeof _RateLimitMiddleware>
+    >().toEqualTypeOf<RateLimitOptions>();
+  });
+});

--- a/packages/core/src/features/http/request/injection/options-of.lib.ts
+++ b/packages/core/src/features/http/request/injection/options-of.lib.ts
@@ -1,0 +1,75 @@
+import { DEFERRED_VALUE_TYPE, unsafeResolveDeferredValue } from '@zeltjs/unsafe-type-lib';
+
+import {
+  createContextKey,
+  getInternal,
+  setInternal,
+  ZeltMiddlewareOptionsUnavailableError,
+} from '../../../../kernel';
+import type {
+  MiddlewareOptionsClass,
+  MiddlewareOptionsOf,
+} from '../../middleware/middleware.types';
+
+// Keyed by the underlying class, not the binding: optionsOf() is called by
+// self-reference (optionsOf(RateLimitMiddleware)) from inside that class's own
+// use(), so at the point it reads, it only ever has the class to look up.
+const MIDDLEWARE_OPTIONS =
+  createContextKey<Map<MiddlewareOptionsClass, unknown>>('zelt:middleware-options');
+
+// The store erases each middleware's options to `unknown`; this phantom handle
+// (mirrors ResultTypeHandle in result-of.lib.ts) lets unsafeResolveDeferredValue
+// narrow it back to the caller's inferred TOptions without an inline `as`.
+class OptionsTypeHandle<T> {
+  declare [DEFERRED_VALUE_TYPE]: T;
+}
+
+/** @throws {ZeltContextNotAvailableError} */
+const getOrCreateStore = (): Map<MiddlewareOptionsClass, unknown> => {
+  const existing = getInternal(MIDDLEWARE_OPTIONS);
+  if (existing) return existing;
+  const created = new Map<MiddlewareOptionsClass, unknown>();
+  setInternal(MIDDLEWARE_OPTIONS, created);
+  return created;
+};
+
+// Called by the middleware guard right before a bound middleware's use() runs.
+// The Map is one shared object per request (context nesting copies key
+// bindings, not the Map a key points at), while one onion chain can hold two
+// bindings of the same class — so isolation comes from save/restore, not
+// context nesting: the caller must invoke the returned callback in a `finally`
+// around the WHOLE use() call, or after next() the outer binding would read
+// the inner binding's options.
+/** @throws {ZeltContextNotAvailableError} */
+export const recordMiddlewareOptions = (
+  middlewareClass: MiddlewareOptionsClass,
+  options: unknown,
+): (() => void) => {
+  const store = getOrCreateStore();
+  const hadPrevious = store.has(middlewareClass);
+  const previous = store.get(middlewareClass);
+  store.set(middlewareClass, options);
+  return () => {
+    if (hadPrevious) {
+      store.set(middlewareClass, previous);
+    } else {
+      store.delete(middlewareClass);
+    }
+  };
+};
+
+// Constrained to MiddlewareOptionsClass, which must not require use() — see
+// its comment for the self-reference cycle a use() requirement creates.
+/** @throws {ZeltContextNotAvailableError | ZeltMiddlewareOptionsUnavailableError} */
+export const optionsOf = <M extends MiddlewareOptionsClass>(
+  middleware: M,
+): MiddlewareOptionsOf<M> => {
+  const store = getInternal(MIDDLEWARE_OPTIONS);
+  if (!store?.has(middleware)) {
+    throw new ZeltMiddlewareOptionsUnavailableError({ middlewareName: middleware.name });
+  }
+  return unsafeResolveDeferredValue(
+    new OptionsTypeHandle<MiddlewareOptionsOf<M>>(),
+    store.get(middleware),
+  );
+};

--- a/packages/core/src/features/http/request/injection/result-of.lib.test.ts
+++ b/packages/core/src/features/http/request/injection/result-of.lib.test.ts
@@ -6,6 +6,7 @@ import {
   ZeltMiddlewareResultUnavailableError,
 } from '../../../../kernel';
 import { http } from '../../http.feature';
+import { MiddlewareWithOptions } from '../../middleware';
 import { Middleware } from '../../middleware/middleware.decorator';
 import type { Next } from '../../middleware/middleware.types';
 import { UseMiddleware } from '../../middleware/use-middleware.decorator';
@@ -105,6 +106,66 @@ describe('resultOf', () => {
     const readyApp = await app.createRuntime();
 
     const res = await readyApp.http.request('/void/');
+    expect(res.status).toBe(200);
+  });
+
+  it('reads the value a bound (MiddlewareWithOptions) middleware passed to next(), via the shared binding', async () => {
+    type AuthOptions = { role: string };
+
+    @Middleware
+    class UserAuthMiddleware extends MiddlewareWithOptions<AuthOptions> {
+      async use(next: Next<{ id: number; role: string }>): Promise<Response | undefined> {
+        await next({ id: 1, role: 'admin' });
+        return undefined;
+      }
+    }
+
+    const adminAuth = UserAuthMiddleware.with({ role: 'admin' });
+
+    @Controller('/admin')
+    class AdminController {
+      @Get('/')
+      get() {
+        const admin = resultOf(adminAuth);
+        return { id: admin.id, role: admin.role };
+      }
+    }
+
+    const app = createApp([http({ controllers: [AdminController], middlewares: [adminAuth] })]);
+    const readyApp = await app.createRuntime();
+
+    const res = await readyApp.http.request('/admin/');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: 1, role: 'admin' });
+  });
+
+  it('throws when resultOf() is given a different .with() call than the one applied to the route, even with identical options', async () => {
+    type AuthOptions = { role: string };
+
+    @Middleware
+    class UserAuthMiddleware extends MiddlewareWithOptions<AuthOptions> {
+      async use(next: Next<{ id: number; role: string }>): Promise<Response | undefined> {
+        await next({ id: 1, role: 'admin' });
+        return undefined;
+      }
+    }
+
+    const applied = UserAuthMiddleware.with({ role: 'admin' });
+    const unapplied = UserAuthMiddleware.with({ role: 'admin' });
+
+    @Controller('/admin-mismatch')
+    class AdminController {
+      @Get('/')
+      get() {
+        expect(() => resultOf(unapplied)).toThrow(ZeltMiddlewareResultUnavailableError);
+        return { ok: true };
+      }
+    }
+
+    const app = createApp([http({ controllers: [AdminController], middlewares: [applied] })]);
+    const readyApp = await app.createRuntime();
+
+    const res = await readyApp.http.request('/admin-mismatch/');
     expect(res.status).toBe(200);
   });
 

--- a/packages/core/src/features/http/request/injection/result-of.lib.ts
+++ b/packages/core/src/features/http/request/injection/result-of.lib.ts
@@ -6,7 +6,11 @@ import {
   setInternal,
   ZeltMiddlewareResultUnavailableError,
 } from '../../../../kernel';
-import type { MiddlewareIdentifier } from '../../middleware/middleware.types';
+import type {
+  BoundMiddleware,
+  MiddlewareClass,
+  MiddlewareIdentifier,
+} from '../../middleware/middleware.types';
 
 // Matching against `Next<infer T>` directly cannot recover T: Next<void> has no
 // parameter for T to occur in, so TS cannot infer through it. Matching the
@@ -30,6 +34,9 @@ export type MiddlewareResultOf<M> = M extends {
       : T
   : never;
 
+const middlewareDisplayName = (middleware: MiddlewareIdentifier): string =>
+  typeof middleware === 'function' ? middleware.name : middleware.middleware.name;
+
 const MIDDLEWARE_RESULTS =
   createContextKey<Map<MiddlewareIdentifier, unknown>>('zelt:middleware-results');
 
@@ -52,16 +59,23 @@ export const recordMiddlewareResult = (identifier: MiddlewareIdentifier, value: 
   setInternal(MIDDLEWARE_RESULTS, new Map([[identifier, value]]));
 };
 
-/** @throws {ZeltContextNotAvailableError | ZeltMiddlewareResultUnavailableError} */
-export const resultOf = <M extends MiddlewareIdentifier>(
+// Two overloads, not one generic over MiddlewareIdentifier: a bare class and a
+// binding resolve their instance type differently (InstanceType<M> vs
+// InstanceType<M['middleware']>), and keeping them separate gives each call
+// site a precise signature instead of a single loosely-inferred one.
+export function resultOf<M extends MiddlewareClass>(
   middleware: M,
-): MiddlewareResultOf<InstanceType<M>> => {
+): MiddlewareResultOf<InstanceType<M>>;
+export function resultOf<M extends BoundMiddleware>(
+  middleware: M,
+): MiddlewareResultOf<InstanceType<M['middleware']>>;
+/** @throws {ZeltContextNotAvailableError | ZeltMiddlewareResultUnavailableError} */
+export function resultOf(middleware: MiddlewareIdentifier): unknown {
   const store = getInternal(MIDDLEWARE_RESULTS);
   if (!store?.has(middleware)) {
-    throw new ZeltMiddlewareResultUnavailableError({ middlewareName: middleware.name });
+    throw new ZeltMiddlewareResultUnavailableError({
+      middlewareName: middlewareDisplayName(middleware),
+    });
   }
-  return unsafeResolveDeferredValue(
-    new ResultTypeHandle<MiddlewareResultOf<InstanceType<M>>>(),
-    store.get(middleware),
-  );
-};
+  return unsafeResolveDeferredValue(new ResultTypeHandle<unknown>(), store.get(middleware));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,7 +103,8 @@ export type {
   HttpMountableRouter,
   HttpOptions,
 } from './features/http/http.types';
-export { fromHonoMiddleware } from './features/http/middleware';
+export type { MiddlewareOptionsClass, MiddlewareOptionsOf } from './features/http/middleware';
+export { fromHonoMiddleware, MiddlewareWithOptions } from './features/http/middleware';
 // HTTP primitives
 export type { AuthRoles, AuthUser } from './features/http/middleware/auth';
 export { currentRoles, currentUser, setUser } from './features/http/middleware/auth';
@@ -113,13 +114,14 @@ export { CorsConfig } from './features/http/middleware/cors/cors.config';
 export { CorsMiddleware } from './features/http/middleware/cors/cors.middleware';
 export { Middleware } from './features/http/middleware/middleware.decorator';
 export type {
+  BoundMiddleware,
   ErrorHandlerClass,
   ErrorHandlerInstance,
   MiddlewareClass,
-  MiddlewareEntry,
   MiddlewareIdentifier,
   MiddlewareInput,
   MiddlewareInstance,
+  MiddlewareResult,
   Next,
   RequestContext,
 } from './features/http/middleware/middleware.types';
@@ -137,7 +139,7 @@ export type {
   MiddlewareResultOf,
   ParsedBody,
 } from './features/http/request/injection';
-export { request, resultOf } from './features/http/request/injection';
+export { optionsOf, request, resultOf } from './features/http/request/injection';
 export type {
   ExtractRequestBody,
   HasRequestBody,
@@ -184,6 +186,7 @@ export {
   ZeltEnvError,
   ZeltLifecycleStateError,
   ZeltMiddlewareExecutionError,
+  ZeltMiddlewareOptionsUnavailableError,
   ZeltMiddlewareResultUnavailableError,
   ZeltNotImplementedError,
   ZeltPluginConfigurationError,

--- a/packages/core/src/kernel/errors/error-classes.lib.ts
+++ b/packages/core/src/kernel/errors/error-classes.lib.ts
@@ -51,6 +51,14 @@ export type ZeltMiddlewareResultUnavailableError = InstanceType<
   typeof ZeltMiddlewareResultUnavailableError
 >;
 
+export const ZeltMiddlewareOptionsUnavailableError = defineError(
+  'ZeltMiddlewareOptionsUnavailableError',
+  coreErrorDefinitions.ZeltMiddlewareOptionsUnavailableError,
+);
+export type ZeltMiddlewareOptionsUnavailableError = InstanceType<
+  typeof ZeltMiddlewareOptionsUnavailableError
+>;
+
 export const ZeltNotImplementedError = defineError(
   'ZeltNotImplementedError',
   coreErrorDefinitions.ZeltNotImplementedError,

--- a/packages/core/src/kernel/errors/error-definitions.lib.ts
+++ b/packages/core/src/kernel/errors/error-definitions.lib.ts
@@ -70,6 +70,11 @@ export const coreErrorDefinitions = {
     `or it has not run yet. Apply it with @UseMiddleware(${ctx.middlewareName}) before calling ` +
     `resultOf(${ctx.middlewareName}).`,
 
+  ZeltMiddlewareOptionsUnavailableError: (ctx: { middlewareName: string }) =>
+    `No options available for middleware '${ctx.middlewareName}'. It is not applied via ` +
+    `${ctx.middlewareName}.with(options) on this route, or it has not run yet. Apply it with ` +
+    `@UseMiddleware(${ctx.middlewareName}.with(options)) before calling optionsOf(${ctx.middlewareName}).`,
+
   ZeltNotImplementedError: (ctx: { className: string; methodName: string }) =>
     `${ctx.className}.${ctx.methodName}() not implemented`,
 

--- a/packages/rate-limit/src/rate-limit.middleware.ts
+++ b/packages/rate-limit/src/rate-limit.middleware.ts
@@ -1,24 +1,38 @@
 import type { Next } from '@zeltjs/core';
-import { Injectable, inject, response, UseMiddleware } from '@zeltjs/core';
+import {
+  inject,
+  Middleware,
+  MiddlewareWithOptions,
+  optionsOf,
+  response,
+  UseMiddleware,
+} from '@zeltjs/core';
 
 import { RateLimitConfig } from './rate-limit.config';
 import { RateLimitExceededException, RateLimitUnavailableException } from './rate-limit.exceptions';
 import { RateLimitService } from './rate-limit.service';
 import type { RateLimitOptions } from './rate-limit.types';
 
-@Injectable()
-export class RateLimitMiddleware {
+@Middleware
+export class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
   constructor(
     private readonly limiter = inject(RateLimitService),
     private readonly config = inject(RateLimitConfig),
-  ) {}
+  ) {
+    super();
+  }
 
   /**
    * @throws {RateLimitExceededException} When rate limit is exceeded (429)
    * @throws {RateLimitUnavailableException} When rate limit service is unavailable (503)
    * @throws {ZeltContextNotAvailableError}
+   * @throws {ZeltMiddlewareOptionsUnavailableError}
    */
-  async use(next: Next, opts: RateLimitOptions, res = response()): Promise<Response | undefined> {
+  async use(
+    next: Next,
+    opts = optionsOf(RateLimitMiddleware),
+    res = response(),
+  ): Promise<Response | undefined> {
     if (!this.config.enabled) {
       await next();
       return undefined;
@@ -53,4 +67,4 @@ export class RateLimitMiddleware {
 
 /** @throws {E} */
 export const RateLimit = (opts: RateLimitOptions): ReturnType<typeof UseMiddleware> =>
-  UseMiddleware(RateLimitMiddleware, opts);
+  UseMiddleware(RateLimitMiddleware.with(opts));

--- a/website/docs/authentication/user-context.md
+++ b/website/docs/authentication/user-context.md
@@ -129,6 +129,9 @@ import { Controller, Get, Authorized, Injectable, inject, currentUser } from '@z
 type FullUser = { preferences: object };
 type SessionUser = { id: string };
 
+const isSessionUser = (u: Record<string, unknown> | undefined): u is SessionUser =>
+  typeof u?.id === 'string';
+
 @Injectable()
 class UserRepository {
   async findById(id: string): Promise<FullUser> {
@@ -144,8 +147,8 @@ class SettingsController {
   @Authorized()
   @Get('/')
   async getSettings() {
-    const user = currentUser() as SessionUser | undefined;
-    if (!user) return;
+    const user = currentUser();
+    if (!isSessionUser(user)) return;
     const fullUser = await this.userRepo.findById(user.id);
     return { preferences: fullUser.preferences };
   }
@@ -170,13 +173,15 @@ For fine-grained permissions, check roles in your service layer:
 ```typescript
 import { currentUser, currentRoles } from '@zeltjs/core';
 interface Post { authorId: string; }
-interface SessionUser { id: string; }
+type SessionUser = { id: string };
+const isSessionUser = (u: Record<string, unknown> | undefined): u is SessionUser =>
+  typeof u?.id === 'string';
 // ---cut---
 function canEdit(post: Post): boolean {
-  const user = currentUser() as SessionUser | undefined;
+  const user = currentUser();
   const roles = currentRoles();
   if (roles.includes('admin')) return true;
-  if (roles.includes('editor') && post.authorId === user?.id) return true;
+  if (roles.includes('editor') && isSessionUser(user) && post.authorId === user.id) return true;
   return false;
 }
 ```

--- a/website/docs/middleware.md
+++ b/website/docs/middleware.md
@@ -204,11 +204,11 @@ export class ProfileController {
 }
 ```
 
-The type is inferred from `Next<T>` and never includes `null` or `undefined`: `AuthMiddleware` short-circuits with a 401 response before it ever calls `next(user)`, so by the time a handler runs, the value is guaranteed to exist. Middleware reads another middleware's value the same way, as a parameter default on its own `use()` method.
+The type reflects `M`'s own `Next<T>` declaration as-is — a middleware declared as `Next<string | undefined>` yields a nullable result. In this example, `AuthMiddleware` short-circuits with a 401 response before it ever calls `next(user)`, so by the time a handler runs, the value is guaranteed to exist. Middleware reads another middleware's value the same way, as a parameter default on its own `use()` method.
 
 ### Reading Requires the Middleware
 
-Calling `resultOf(M)` for a middleware that isn't applied to the route throws immediately, with an error naming the middleware — there is no silent `undefined`. Applying middleware to a route still works exactly as before, with `@UseMiddleware` on a controller or method, or with `middlewares` on a module.
+Calling `resultOf(M)` throws immediately, with an error naming the middleware, in two cases: the middleware isn't applied to the route, or it is applied but never called `next(value)` (so no value was ever recorded). There is no silent `undefined`. Applying middleware to a route still works exactly as before, with `@UseMiddleware` on a controller or method, or with `middlewares` on a module.
 
 ## Dependency Injection
 
@@ -256,26 +256,50 @@ export class AdminController {
 }
 ```
 
-## Parameterized Middleware
+## Middleware with Options
 
-For middleware that requires configuration options, pass options as the second `@UseMiddleware()` argument:
+Middleware that requires configuration extends `MiddlewareWithOptions<TOptions>` and reads its options with `optionsOf()`, as a parameter default — the same pattern as `request()` and `resultOf()`:
 
 ```typescript
-import { Controller, UseMiddleware, Middleware, Post, type Next } from '@zeltjs/core';
+import { Middleware, MiddlewareWithOptions, optionsOf, type Next } from '@zeltjs/core';
 // ---cut---
+interface RateLimitOptions {
+  limit: number;
+  windowSec: number;
+}
+
 @Middleware
-export class RateLimitMiddleware {
-  async use(next: Next, options: { limit: number; windowSec: number }) {
-    const { limit, windowSec } = options;
+export class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+  async use(next: Next, opts = optionsOf(RateLimitMiddleware)) {
+    const { limit, windowSec } = opts;
     // ... rate limiting logic
     await next();
     return undefined;
   }
 }
+```
 
+Pass the options where the middleware is applied, with `.with()`:
+
+```typescript
+import { Controller, Middleware, MiddlewareWithOptions, Post, UseMiddleware, optionsOf, type Next } from '@zeltjs/core';
+
+interface RateLimitOptions {
+  limit: number;
+  windowSec: number;
+}
+
+@Middleware
+class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+  async use(next: Next, opts = optionsOf(RateLimitMiddleware)) {
+    await next();
+    return undefined;
+  }
+}
+// ---cut---
 @Controller('/api')
 export class ApiController {
-  @UseMiddleware(RateLimitMiddleware, { limit: 10, windowSec: 60 })
+  @UseMiddleware(RateLimitMiddleware.with({ limit: 10, windowSec: 60 }))
   @Post('/submit')
   submit() {
     return { submitted: true };
@@ -283,7 +307,46 @@ export class ApiController {
 }
 ```
 
-The options parameter is passed to the middleware's `use()` method at runtime.
+Middleware that takes options is always registered through `.with()`. Registering the bare class is a type error — there would be no options for it to run with.
+
+Middleware without options doesn't extend anything and is registered as the plain class, exactly as in the earlier examples.
+
+### Reading Results from Middleware with Options
+
+To read the result of middleware that takes options, store the return value of `.with()` in a `const` and use that same `const` in both places — where the middleware is applied, and in `resultOf()`:
+
+```typescript
+import { Controller, Get, Middleware, MiddlewareWithOptions, UseMiddleware, optionsOf, resultOf, type Next } from '@zeltjs/core';
+
+interface AuthOptions {
+  role: 'admin' | 'member';
+}
+
+@Middleware
+class UserAuthMiddleware extends MiddlewareWithOptions<AuthOptions> {
+  async use(next: Next<{ id: number; role: string }>, opts = optionsOf(UserAuthMiddleware)) {
+    await next({ id: 1, role: opts.role });
+    return undefined;
+  }
+}
+// ---cut---
+// user-auth.middleware.ts
+export const adminAuth = UserAuthMiddleware.with({ role: 'admin' });
+
+// admin.controller.ts
+@UseMiddleware(adminAuth)
+@Controller('/admin')
+export class AdminController {
+  @Get('/me')
+  me(admin = resultOf(adminAuth)) {
+    return { id: admin.id, role: admin.role };
+  }
+}
+```
+
+Each `.with()` call counts as its own middleware. If a route is registered with one `.with()` call and `resultOf()` receives another — even with identical options — the two don't match: `resultOf()` sees a middleware that isn't applied to the route and throws. Always share a single `const`.
+
+The same middleware class can be applied multiple times with different options. Each application runs independently, and each `const` reads its own result.
 
 ## Request Flow
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/middleware.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/middleware.md
@@ -256,26 +256,50 @@ export class AdminController {
 }
 ```
 
-## Parameterized Middleware {#parameterized-middleware}
+## Middleware with Options {#middleware-with-options}
 
-設定オプションが必要なmiddlewareでは、2番目の`@UseMiddleware()`引数としてオプションを渡します:
+設定が必要なmiddlewareは`MiddlewareWithOptions<TOptions>`を継承し、オプションを`optionsOf()`でパラメータデフォルト値として読み取ります — `request()`や`resultOf()`と同じパターンです:
 
 ```typescript
-import { Controller, UseMiddleware, Middleware, Post, type Next } from '@zeltjs/core';
+import { Middleware, MiddlewareWithOptions, optionsOf, type Next } from '@zeltjs/core';
 // ---cut---
+interface RateLimitOptions {
+  limit: number;
+  windowSec: number;
+}
+
 @Middleware
-export class RateLimitMiddleware {
-  async use(next: Next, options: { limit: number; windowSec: number }) {
-    const { limit, windowSec } = options;
+export class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+  async use(next: Next, opts = optionsOf(RateLimitMiddleware)) {
+    const { limit, windowSec } = opts;
     // ... レート制限ロジック
     await next();
     return undefined;
   }
 }
+```
 
+オプションは、middlewareを適用する場所で`.with()`を使って渡します:
+
+```typescript
+import { Controller, Middleware, MiddlewareWithOptions, Post, UseMiddleware, optionsOf, type Next } from '@zeltjs/core';
+
+interface RateLimitOptions {
+  limit: number;
+  windowSec: number;
+}
+
+@Middleware
+class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
+  async use(next: Next, opts = optionsOf(RateLimitMiddleware)) {
+    await next();
+    return undefined;
+  }
+}
+// ---cut---
 @Controller('/api')
 export class ApiController {
-  @UseMiddleware(RateLimitMiddleware, { limit: 10, windowSec: 60 })
+  @UseMiddleware(RateLimitMiddleware.with({ limit: 10, windowSec: 60 }))
   @Post('/submit')
   submit() {
     return { submitted: true };
@@ -283,7 +307,46 @@ export class ApiController {
 }
 ```
 
-optionsパラメータは実行時にmiddlewareの`use()`メソッドへ渡されます。
+オプションを取るmiddlewareの登録は常に`.with()`を通して行います。素のクラスをそのまま登録すると型エラーになります — 実行に使うオプションが存在しないためです。
+
+オプションを持たないmiddlewareは何も継承せず、これまでの例のとおり素のクラスをそのまま登録します。
+
+### オプション付きmiddlewareの結果を読む {#reading-results-from-middleware-with-options}
+
+オプションを取るmiddlewareの結果を読むには、`.with()`の戻り値を`const`に入れ、middlewareを適用する場所と`resultOf()`の両方で同じ`const`を使います:
+
+```typescript
+import { Controller, Get, Middleware, MiddlewareWithOptions, UseMiddleware, optionsOf, resultOf, type Next } from '@zeltjs/core';
+
+interface AuthOptions {
+  role: 'admin' | 'member';
+}
+
+@Middleware
+class UserAuthMiddleware extends MiddlewareWithOptions<AuthOptions> {
+  async use(next: Next<{ id: number; role: string }>, opts = optionsOf(UserAuthMiddleware)) {
+    await next({ id: 1, role: opts.role });
+    return undefined;
+  }
+}
+// ---cut---
+// user-auth.middleware.ts
+export const adminAuth = UserAuthMiddleware.with({ role: 'admin' });
+
+// admin.controller.ts
+@UseMiddleware(adminAuth)
+@Controller('/admin')
+export class AdminController {
+  @Get('/me')
+  me(admin = resultOf(adminAuth)) {
+    return { id: admin.id, role: admin.role };
+  }
+}
+```
+
+`.with()`は呼び出しごとに、それぞれ別のmiddlewareとして扱われます。ルートの登録に使った`.with()`と`resultOf()`に渡した`.with()`が別の呼び出しだと、たとえオプションが同一でも両者は一致しません — `resultOf()`からはルートに適用されていないmiddlewareに見え、例外になります。必ず1つの`const`を共有してください。
+
+同じmiddlewareクラスを異なるオプションで複数回適用することもできます。それぞれの適用は独立して実行され、各`const`は自分の結果を読み取ります。
 
 ## Request Flow {#request-flow}
 


### PR DESCRIPTION
## Summary

Replaces the second-argument options form of `@UseMiddleware` with a binding model:

- Middleware that needs options extends `MiddlewareWithOptions<TOptions>` and reads its options with `optionsOf()` as a `use()` parameter default — the same declaration pattern as `request()` and `resultOf()`.
- Options are passed at the application site via `Class.with(options)`. The returned binding value — not the class — is the middleware identity everywhere (`@UseMiddleware`, `middlewares:`, `resultOf()`), so one class can be bound to several option sets, each running and resolving `resultOf()` independently.
- Registering a bare options-requiring class is a type error; optionless middleware keeps registering as the plain class.
- The middleware contract collapses to `use(next)` — the per-options conditional type on `MiddlewareInstance` is gone.

Docs (en/ja) were written first as the spec ("Middleware with Options" section) and the implementation was verified against them; all doc code blocks are twoslash-checked.

## Breaking changes

- `@UseMiddleware(M, options)` second-argument form is removed → use `@UseMiddleware(M.with(options))`.
- `use(next, options)` implementations must extend `MiddlewareWithOptions<TOptions>` and read `opts = optionsOf(Self)` as a parameter default.
- `MiddlewareEntry` type removed → `BoundMiddleware<TClass>`.
- `@zeltjs/rate-limit`'s `RateLimit(opts)` helper keeps its public surface (now `.with()`-based internally).

## Type-level design (verified by tsc experiments)

- Options phantom sits in contravariant (function-parameter) position; a covariant field would make the `never`-bound subclass constraints reject everything.
- No `abstract use()` on the base class: it would create a self-reference cycle with the documented `opts = optionsOf(Self)` default-parameter pattern (implicit any). `use()` is required only on the `.with()` side, where the subclass is already fully resolved.
- Structural `OptionsPhantom` lives in `middleware.types.ts` to keep the type/base-class dependency one-directional (no import cycles).

## Verification

- root build / typecheck / lint (eslint, oxlint, depcruise, cycle check, throw-trace): pass
- root tests: 1202 passed; core: 561 passed
- integration (`./integration/scripts/run-tests.sh dist`): 10/11 pass, incl. new binding e2e scenarios (shared-const resolution, two independent bindings of one class, unapplied-binding error, bare-class type error). ec-backend failure is a pre-existing native-addon ABI environment issue, unrelated to this change (its sources are untouched).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791188919&installation_model_id=21678&pr_number=319&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F319&signature=e19b1c82d0f4230e650a313d019609beb223f9d13ae2af3a3e39c9641cfc13fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - オプション付きミドルウェアを `.with()` で登録できるようになりました。
  - ミドルウェア内で `optionsOf()` を使って設定を取得できます。
  - 同じミドルウェアを異なる設定で複数適用でき、`resultOf()` で実行結果を取得できます。
  - 未適用・未実行の設定参照時に、原因を示すエラーが表示されます。
  - レート制限ミドルウェアが新しい登録方式に対応しました。

- **ドキュメント**
  - ミドルウェアの設定、結果取得、ユーザー情報の型安全な扱いに関する説明と例を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->