### PR TITLE
refactor(core)!: make middleware accessor names explicit

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -45,7 +45,7 @@
     {
       "includes": [
         "packages/core/src/features/http/middleware/middleware.types.ts",
-        "packages/core/src/features/http/request/injection/result-of.lib.ts"
+        "packages/core/src/features/http/request/injection/middleware-value.lib.ts"
       ],
       "linter": {
         "rules": {

--- a/integration/hello-world/src/interceptor.middleware.ts
+++ b/integration/hello-world/src/interceptor.middleware.ts
@@ -2,7 +2,7 @@ import type { Next } from '@zeltjs/core';
 import {
   Middleware,
   MiddlewareWithOptions,
-  optionsOf,
+  middlewareOptions,
   requestContext,
   response,
 } from '@zeltjs/core';
@@ -26,7 +26,7 @@ export class TransformMiddleware {
 
 @Middleware
 export class StatusMiddleware extends MiddlewareWithOptions<{ statusCode: 200 | 400 | 500 }> {
-  async use(next: Next, options = optionsOf(StatusMiddleware)) {
+  async use(next: Next, options = middlewareOptions(StatusMiddleware)) {
     await next();
     const c = requestContext();
     const original = await c.res.json();
@@ -39,7 +39,7 @@ export class HeaderMiddleware extends MiddlewareWithOptions<{
   headerName: string;
   headerValue: string;
 }> {
-  async use(next: Next, options = optionsOf(HeaderMiddleware), res = response()) {
+  async use(next: Next, options = middlewareOptions(HeaderMiddleware), res = response()) {
     res.header(options.headerName, options.headerValue);
     await next();
     return undefined;

--- a/integration/hello-world/src/transform.middleware.ts
+++ b/integration/hello-world/src/transform.middleware.ts
@@ -1,5 +1,5 @@
 import type { Next } from '@zeltjs/core';
-import { Middleware, MiddlewareWithOptions, optionsOf, response } from '@zeltjs/core';
+import { Middleware, MiddlewareWithOptions, middlewareOptions, response } from '@zeltjs/core';
 
 @Middleware
 export class TransformMiddleware {
@@ -14,7 +14,7 @@ export class HeaderMiddleware extends MiddlewareWithOptions<{
   headerName: string;
   headerValue: string;
 }> {
-  async use(next: Next, options = optionsOf(HeaderMiddleware), res = response()) {
+  async use(next: Next, options = middlewareOptions(HeaderMiddleware), res = response()) {
     res.header(options.headerName, options.headerValue);
     await next();
     return undefined;

--- a/integration/scopes/e2e/middleware-context.spec.ts
+++ b/integration/scopes/e2e/middleware-context.spec.ts
@@ -22,7 +22,7 @@ describe('Middleware <-> handler context integration', () => {
   });
 
   describe('context isolation between middleware and handler', () => {
-    it('exposes middleware-provided values to the handler via resultOf()', async () => {
+    it('exposes middleware-provided values to the handler via middlewareValue()', async () => {
       const res = await testApp.http.request('/middleware/context?id=req-A');
       expect(res.status).toBe(200);
       const body = (await res.json()) as ContextResponse;

--- a/integration/scopes/e2e/options-binding.spec.ts
+++ b/integration/scopes/e2e/options-binding.spec.ts
@@ -21,7 +21,7 @@ describe('Middleware with Options binding', () => {
     await shutdownAll();
   });
 
-  it('connects @UseMiddleware and resultOf() through a shared const binding', async () => {
+  it('connects @UseMiddleware and middlewareValue() through a shared const binding', async () => {
     const res = await testApp.http.request('/options/admin/me');
     expect(res.status).toBe(200);
     const body = (await res.json()) as AuthResponse;
@@ -48,8 +48,8 @@ describe('Middleware with Options binding', () => {
     expect(body.member).toEqual({ id: 'user-member', role: 'member' });
   });
 
-  it('fails when resultOf() reads a binding that is not applied to the route', async () => {
-    // Only memberAuth is applied to this route; reading adminAuth's result
+  it('fails when middlewareValue() reads a binding that is not applied to the route', async () => {
+    // Only memberAuth is applied to this route; reading adminAuth's value
     // must fail because that exact binding never ran here.
     const res = await testApp.http.request('/options/member-only/read-unapplied-binding');
     expect(res.status).toBe(500);

--- a/integration/scopes/e2e/request-scope.spec.ts
+++ b/integration/scopes/e2e/request-scope.spec.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { app } from '../src/app';
 import { RequestIdService } from '../src/request-id.service';
 
-describe('Request-scoped data via a middleware-provided value and resultOf()', () => {
+describe('Request-scoped data via a middleware-provided value and middlewareValue()', () => {
   let testApp: Awaited<ReturnType<(typeof app)['createRuntime']>>;
   let serviceCallsAtStart = 0;
 

--- a/integration/scopes/src/middleware.controller.ts
+++ b/integration/scopes/src/middleware.controller.ts
@@ -1,5 +1,5 @@
 import type { Next } from '@zeltjs/core';
-import { Controller, Get, Middleware, request, resultOf, UseMiddleware } from '@zeltjs/core';
+import { Controller, Get, Middleware, middlewareValue, request, UseMiddleware } from '@zeltjs/core';
 
 type RequestIdentity = {
   requestId: string;
@@ -19,13 +19,13 @@ export class AssignIdMiddleware {
 }
 
 // Class middleware: appends a tag to the chain. Demonstrates that multiple
-// middlewares can read the same upstream result (via resultOf) and mutate
+// middlewares can read the same upstream value (via middlewareValue) and mutate
 // the shared array without leaking across requests, because the store is
 // request-scoped (AsyncLocalStorage).
 @Middleware
 export class AppendStageOneMiddleware {
   async use(next: Next<string>): Promise<Response | undefined> {
-    const { chain } = resultOf(AssignIdMiddleware);
+    const { chain } = middlewareValue(AssignIdMiddleware);
     chain.push('stage-one');
     await next('stage-one');
     return undefined;
@@ -35,7 +35,7 @@ export class AppendStageOneMiddleware {
 @Middleware
 export class AppendStageTwoMiddleware {
   async use(next: Next<string>): Promise<Response | undefined> {
-    const { chain } = resultOf(AssignIdMiddleware);
+    const { chain } = middlewareValue(AssignIdMiddleware);
     chain.push('stage-two');
     await next('stage-two');
     return undefined;
@@ -62,12 +62,12 @@ export class MiddlewareController {
   @Get('/context')
   read(req = request()) {
     const id = req.queryParam('id');
-    const { requestId, chain } = resultOf(AssignIdMiddleware);
+    const { requestId, chain } = middlewareValue(AssignIdMiddleware);
     return {
       idFromQuery: id,
       requestId,
       // The last middleware in the chain provides the tag the handler reads.
-      middlewareTag: resultOf(AppendStageTwoMiddleware),
+      middlewareTag: middlewareValue(AppendStageTwoMiddleware),
       middlewareChain: chain,
     };
   }
@@ -75,10 +75,10 @@ export class MiddlewareController {
   @Get('/fail-safe')
   @UseMiddleware(ConditionalFailMiddleware)
   failSafe() {
-    const { requestId, chain } = resultOf(AssignIdMiddleware);
+    const { requestId, chain } = middlewareValue(AssignIdMiddleware);
     return {
       requestId,
-      middlewareTag: resultOf(AppendStageTwoMiddleware),
+      middlewareTag: middlewareValue(AppendStageTwoMiddleware),
       middlewareChain: chain,
     };
   }

--- a/integration/scopes/src/options-binding.controller.ts
+++ b/integration/scopes/src/options-binding.controller.ts
@@ -1,27 +1,27 @@
-import { Controller, Get, resultOf, UseMiddleware } from '@zeltjs/core';
+import { Controller, Get, middlewareValue, UseMiddleware } from '@zeltjs/core';
 
 import { adminAuth, memberAuth } from './user-auth.middleware';
 
 // Doc's adminAuth scenario: the const bound at the class is the same const
-// read via resultOf() in the handler.
+// read via middlewareValue() in the handler.
 @UseMiddleware(adminAuth)
 @Controller('/options/admin')
 export class AdminBoundController {
   @Get('/me')
   me() {
-    const admin = resultOf(adminAuth);
+    const admin = middlewareValue(adminAuth);
     return { id: admin.id, role: admin.role };
   }
 }
 
 // A second, independent binding of the same UserAuthMiddleware class.
-// Verifies that two .with() calls on one class don't share results/options.
+// Verifies that two .with() calls on one class don't share values/options.
 @UseMiddleware(memberAuth)
 @Controller('/options/member')
 export class MemberBoundController {
   @Get('/me')
   me() {
-    const member = resultOf(memberAuth);
+    const member = middlewareValue(memberAuth);
     return { id: member.id, role: member.role };
   }
 }
@@ -34,20 +34,20 @@ export class BothBoundController {
   @UseMiddleware(adminAuth)
   @UseMiddleware(memberAuth)
   me() {
-    const admin = resultOf(adminAuth);
-    const member = resultOf(memberAuth);
+    const admin = middlewareValue(adminAuth);
+    const member = middlewareValue(memberAuth);
     return { admin, member };
   }
 }
 
-// Only memberAuth is applied here; reading adminAuth's result must fail
+// Only memberAuth is applied here; reading adminAuth's value must fail
 // because that exact binding never ran on this route.
 @UseMiddleware(memberAuth)
 @Controller('/options/member-only')
 export class MemberOnlyController {
   @Get('/read-unapplied-binding')
   me() {
-    const admin = resultOf(adminAuth);
+    const admin = middlewareValue(adminAuth);
     return { id: admin.id, role: admin.role };
   }
 }

--- a/integration/scopes/src/scopes.controller.ts
+++ b/integration/scopes/src/scopes.controller.ts
@@ -4,8 +4,8 @@ import {
   Get,
   inject,
   Middleware,
+  middlewareValue,
   request,
-  resultOf,
   UseMiddleware,
 } from '@zeltjs/core';
 
@@ -15,7 +15,7 @@ import { RequestIdService } from './request-id.service';
 
 // Provides a fresh, mutable per-request state bucket. Demonstrates the
 // "counter/trace" shape: a middleware allocates a mutable object and hands
-// it downstream via `next(value)`; the handler reads it via resultOf() and
+// it downstream via `next(value)`; the handler reads it via middlewareValue() and
 // passes it explicitly to the singleton service instead of the service
 // reaching into request-scoped storage itself.
 @Middleware
@@ -51,7 +51,7 @@ export class ScopesController {
   @UseMiddleware(RequestStateMiddleware)
   request(req = request()) {
     const id = req.header('X-Request-Id') ?? 'anonymous';
-    const state = resultOf(RequestStateMiddleware);
+    const state = middlewareValue(RequestStateMiddleware);
     const first = this.requestIds.tick(state, 'begin');
     const second = this.requestIds.tick(state, 'end');
     return {
@@ -67,7 +67,7 @@ export class ScopesController {
   async overlap(req = request()) {
     const id = req.queryParam('id') ?? 'missing';
     const delay = req.queryParam('delay');
-    const state = resultOf(RequestStateMiddleware);
+    const state = middlewareValue(RequestStateMiddleware);
     this.requestIds.tick(state, 'start');
     const ms = Number(delay ?? '0');
     if (ms > 0) {

--- a/integration/scopes/src/user-auth.middleware.ts
+++ b/integration/scopes/src/user-auth.middleware.ts
@@ -1,5 +1,5 @@
 import type { Next } from '@zeltjs/core';
-import { Middleware, MiddlewareWithOptions, optionsOf } from '@zeltjs/core';
+import { Middleware, MiddlewareWithOptions, middlewareOptions } from '@zeltjs/core';
 
 export type RoleAuthOptions = {
   role: string;
@@ -12,14 +12,14 @@ export type AuthenticatedUser = {
 
 // Mirrors the doc's "Middleware with Options" example: a middleware that
 // needs configuration extends MiddlewareWithOptions<TOptions> and reads it
-// via optionsOf() as a use() parameter default. It hands its result
-// downstream via next(value) so resultOf() at the applied binding's exact
+// via middlewareOptions() as a use() parameter default. It hands its value
+// downstream via next(value) so middlewareValue() at the applied binding's exact
 // identity can read it back.
 @Middleware
 export class UserAuthMiddleware extends MiddlewareWithOptions<RoleAuthOptions> {
   async use(
     next: Next<AuthenticatedUser>,
-    opts = optionsOf(UserAuthMiddleware),
+    opts = middlewareOptions(UserAuthMiddleware),
   ): Promise<Response | undefined> {
     await next({ id: `user-${opts.role}`, role: opts.role });
     return undefined;
@@ -28,7 +28,7 @@ export class UserAuthMiddleware extends MiddlewareWithOptions<RoleAuthOptions> {
 
 // Two distinct bindings of the same class. Each .with() call is its own
 // middleware identity — sharing these consts (not re-calling .with()) is
-// what lets @UseMiddleware and resultOf()/optionsOf() agree on which
+// what lets @UseMiddleware and middlewareValue()/middlewareOptions() agree on which
 // binding they mean.
 export const adminAuth = UserAuthMiddleware.with({ role: 'admin' });
 export const memberAuth = UserAuthMiddleware.with({ role: 'member' });

--- a/packages/cli/src/studio/analyzer.integration.test.ts
+++ b/packages/cli/src/studio/analyzer.integration.test.ts
@@ -56,7 +56,7 @@ describe('studio analyzer (integration)', () => {
     expect(loggingMiddleware.contract).toEqual([
       {
         name: 'use',
-        // Next<T = void> is a conditional type since the middleware-results
+        // Next<T = void> is a conditional type since the middleware-values
         // change; TS resolves the default application eagerly and drops the
         // alias, so the analyzer sees the expanded shape. Restoring the alias
         // name in the graph is tracked as a separate studio improvement.

--- a/packages/core/src/features/http/app.test.ts
+++ b/packages/core/src/features/http/app.test.ts
@@ -15,7 +15,7 @@ import { SecureHeadersMiddleware } from './middleware/secure-headers/secure-head
 import { SkipMiddleware } from './middleware/skip-middleware.decorator';
 import { UseMiddleware } from './middleware/use-middleware.decorator';
 import { registerAfterResponseCallback } from './request';
-import { optionsOf, request, resultOf } from './request/injection';
+import { middlewareOptions, middlewareValue, request } from './request/injection';
 import { response } from './response';
 import { Controller } from './routing/controller.decorator';
 import { Get, Post } from './routing/http-method.decorator';
@@ -136,7 +136,7 @@ describe('createApp() — fetch', () => {
       async get(req = request()) {
         return {
           body: await req.body(),
-          requestId: resultOf(TagMiddleware),
+          requestId: middlewareValue(TagMiddleware),
           url: req.url(),
         };
       }
@@ -148,13 +148,13 @@ describe('createApp() — fetch', () => {
       async get(req = request()) {
         const outerBefore = {
           body: await req.body(),
-          requestId: resultOf(TagMiddleware),
+          requestId: middlewareValue(TagMiddleware),
           url: req.url(),
         };
         const res = await fetchInner();
         const outerAfter = {
           body: await req.body(),
-          requestId: resultOf(TagMiddleware),
+          requestId: middlewareValue(TagMiddleware),
           url: req.url(),
         };
         return { inner: await res.json(), outerAfter, outerBefore };
@@ -736,7 +736,7 @@ describe('middleware', () => {
     class TestController {
       @Get('/')
       get() {
-        return { value: resultOf(DIMiddleware) };
+        return { value: middlewareValue(DIMiddleware) };
       }
     }
 
@@ -747,7 +747,7 @@ describe('middleware', () => {
     expect(await res.json()).toEqual({ value: 'injected-value' });
   });
 
-  it('middleware can pass a typed result to the handler via resultOf()', async () => {
+  it('middleware can pass a typed value to the handler via middlewareValue()', async () => {
     @Middleware
     class SetUserMiddleware {
       async use(next: Next<{ id: number; name: string }>): Promise<Response | undefined> {
@@ -760,7 +760,7 @@ describe('middleware', () => {
     class TestController {
       @Get('/')
       get() {
-        const user = resultOf(SetUserMiddleware);
+        const user = middlewareValue(SetUserMiddleware);
         return { userId: user.id, userName: user.name };
       }
     }
@@ -1818,7 +1818,7 @@ describe('warmup option', () => {
     @Middleware
     class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
       async use(next: Next, res = response()): Promise<Response | undefined> {
-        const options = optionsOf(RateLimitMiddleware);
+        const options = middlewareOptions(RateLimitMiddleware);
         res.header('X-RateLimit-Limit', String(options.limit));
         res.header('X-RateLimit-Window', String(options.windowSec));
         await next();
@@ -1849,14 +1849,14 @@ describe('warmup option', () => {
     await readyApp.shutdown();
   });
 
-  it('applies a binding with @UseMiddleware and reads its result via the shared const, as documented', async () => {
+  it('applies a binding with @UseMiddleware and reads its value via the shared const, as documented', async () => {
     type AuthOptions = { role: string };
 
     @Middleware
     class UserAuthMiddleware extends MiddlewareWithOptions<AuthOptions> {
       async use(
         next: Next<{ id: number; role: string }>,
-        opts = optionsOf(UserAuthMiddleware),
+        opts = middlewareOptions(UserAuthMiddleware),
       ): Promise<Response | undefined> {
         await next({ id: 1, role: opts.role });
         return undefined;
@@ -1869,7 +1869,7 @@ describe('warmup option', () => {
     @Controller('/admin')
     class AdminController {
       @Get('/me')
-      me(admin = resultOf(adminAuth)) {
+      me(admin = middlewareValue(adminAuth)) {
         return { id: admin.id, role: admin.role };
       }
     }

--- a/packages/core/src/features/http/middleware/middleware-guard.lib.ts
+++ b/packages/core/src/features/http/middleware/middleware-guard.lib.ts
@@ -4,7 +4,7 @@ import { findTargetHandler } from 'hono/utils/handler';
 
 import type { ResolverHandle } from '../../../kernel';
 import { createContextKey, getInternal, setInternal } from '../../../kernel';
-import { recordMiddlewareOptions, recordMiddlewareResult } from '../request/injection';
+import { recordMiddlewareOptions, recordMiddlewareValue } from '../request/injection';
 import type { HonoMiddleware, MiddlewareIdentifier, MiddlewareInput } from './middleware.types';
 
 const SKIPPED_MIDDLEWARES = Symbol('zelt:skipped-middlewares');
@@ -32,17 +32,17 @@ export const middlewareIdentity = (input: MiddlewareInput): MiddlewareIdentifier
 
 // Wraps Hono's zero-arg next() so middleware can pass a value through
 // next(value); arguments.length distinguishes an explicit next(undefined) — a
-// legitimate Next<undefined> contract — from a bare next(). Results are keyed
+// legitimate Next<undefined> contract — from a bare next(). Values are keyed
 // by the registered value itself: for a binding, the bound object, never its
 // class, which would collide two bindings of the same class.
 /** @throws {ZeltContextNotAvailableError} */
-const captureNextResult = (
+const captureNextValue = (
   key: MiddlewareInput,
   next: () => Promise<void>,
 ): ((...args: unknown[]) => Promise<void>) => {
   return async (...args: unknown[]) => {
     if (args.length > 0) {
-      recordMiddlewareResult(key, args[0]);
+      recordMiddlewareValue(key, args[0]);
     }
     await next();
   };
@@ -58,7 +58,7 @@ export const resolveMiddleware = (
       throw new TypeError('Invalid middleware class. Missing use() method.');
     }
     const instance = resolver.get(middleware);
-    return async (_c, next) => await instance.use(captureNextResult(middleware, next));
+    return async (_c, next) => await instance.use(captureNextValue(middleware, next));
   }
   if (!checkMiddlewareClass(middleware.middleware)) {
     throw new TypeError('Invalid middleware class. Missing use() method.');
@@ -69,7 +69,7 @@ export const resolveMiddleware = (
     // use() call, not just after next() — see its doc for why.
     const restoreOptions = recordMiddlewareOptions(middleware.middleware, middleware.options);
     try {
-      return await instance.use(captureNextResult(middleware, next));
+      return await instance.use(captureNextValue(middleware, next));
     } finally {
       restoreOptions();
     }

--- a/packages/core/src/features/http/middleware/middleware-with-options.lib.test.ts
+++ b/packages/core/src/features/http/middleware/middleware-with-options.lib.test.ts
@@ -32,7 +32,7 @@ describe('MiddlewareWithOptions.with()', () => {
     expect(bound.options).toEqual({ limit: 1, windowSec: 1 });
   });
 
-  it('preserves the concrete class (not widened to MiddlewareClass) so optionsOf()/resultOf() can recover it', () => {
+  it('preserves the concrete class (not widened to MiddlewareClass) so middlewareOptions()/middlewareValue() can recover it', () => {
     const bound = RateLimitMiddleware.with({ limit: 1, windowSec: 1 });
     expectTypeOf(bound.middleware).toEqualTypeOf<typeof RateLimitMiddleware>();
   });

--- a/packages/core/src/features/http/middleware/middleware-with-options.lib.ts
+++ b/packages/core/src/features/http/middleware/middleware-with-options.lib.ts
@@ -8,8 +8,8 @@ import { BOUND_MIDDLEWARE_BRAND } from './middleware.types';
 /**
  * Base class for middleware that needs configuration. Bind options with the
  * static `.with()` factory; the returned value is the middleware's identity
- * everywhere it's used (`@UseMiddleware`, `middlewares:`, `optionsOf()`,
- * `resultOf()`), so store it in a `const` and reuse that reference — calling
+ * everywhere it's used (`@UseMiddleware`, `middlewares:`, `middlewareOptions()`,
+ * `middlewareValue()`), so store it in a `const` and reuse that reference — calling
  * `.with()` again, even with identical options, produces a different identity.
  */
 export abstract class MiddlewareWithOptions<TOptions = undefined> {

--- a/packages/core/src/features/http/middleware/middleware.types.ts
+++ b/packages/core/src/features/http/middleware/middleware.types.ts
@@ -21,7 +21,7 @@ type MaybePromise<T> = T | Promise<T>;
 export type MiddlewareResult = MaybePromise<Response | undefined>;
 
 // Middleware that needs options extends MiddlewareWithOptions<TOptions> and
-// reads them via optionsOf() inside use().
+// reads them via middlewareOptions() inside use().
 export type MiddlewareInstance = {
   use(next: Next): MiddlewareResult;
 };
@@ -48,7 +48,7 @@ export type AnyMiddlewareWithOptionsClass = new (
   ...args: never[]
 ) => MiddlewareInstance & OptionsPhantom<never>;
 
-// Deliberately does NOT require use(): optionsOf(Self) is written as a default
+// Deliberately does NOT require use(): middlewareOptions(Self) is written as a default
 // parameter of Self's own use(), so a use()-requiring constraint would make
 // checking that call depend on resolving the very signature being checked, and
 // TS types `opts` as an implicit any (verified). `.with()` is the side that
@@ -78,8 +78,8 @@ export const BOUND_MIDDLEWARE_BRAND: unique symbol = Symbol('zelt:bound-middlewa
 
 // Produced by MiddlewareWithOptions.with(options); this value (not the class)
 // is what identifies the binding everywhere — @UseMiddleware, middlewares:,
-// optionsOf(), resultOf() — since one class can be bound to several option sets.
-// TClass is preserved (not widened to MiddlewareClass) so resultOf() can still
+// middlewareOptions(), middlewareValue() — since one class can be bound to several option sets.
+// TClass is preserved (not widened to MiddlewareClass) so middlewareValue() can still
 // recover the concrete middleware's provided-value type through `.middleware`.
 export type BoundMiddleware<
   TClass extends AnyMiddlewareWithOptionsClass = AnyMiddlewareWithOptionsClass,

--- a/packages/core/src/features/http/request/injection/index.ts
+++ b/packages/core/src/features/http/request/injection/index.ts
@@ -6,7 +6,9 @@ export {
   readRequestBody,
   setBodySource,
 } from './body.lib';
-export { optionsOf, recordMiddlewareOptions } from './options-of.lib';
+export { middlewareOptions, recordMiddlewareOptions } from './middleware-options.lib';
+export type { MiddlewareValueOf } from './middleware-value.lib';
+export { middlewareValue, recordMiddlewareValue } from './middleware-value.lib';
 export { setPathParams } from './path-param.lib';
 export type {
   ExtractRequestBody,
@@ -15,5 +17,3 @@ export type {
   RequestBodyAccessor,
 } from './request.lib';
 export { request } from './request.lib';
-export type { MiddlewareResultOf } from './result-of.lib';
-export { recordMiddlewareResult, resultOf } from './result-of.lib';

--- a/packages/core/src/features/http/request/injection/middleware-options.lib.test.ts
+++ b/packages/core/src/features/http/request/injection/middleware-options.lib.test.ts
@@ -12,18 +12,18 @@ import { Middleware } from '../../middleware/middleware.decorator';
 import type { Next } from '../../middleware/middleware.types';
 import { Controller } from '../../routing/controller.decorator';
 import { Get } from '../../routing/http-method.decorator';
-import { optionsOf } from './options-of.lib';
+import { middlewareOptions } from './middleware-options.lib';
 
 type RateLimitOptions = { limit: number; windowSec: number };
 
-describe('optionsOf', () => {
+describe('middlewareOptions', () => {
   it('reads the options a middleware was bound with, from inside its own use()', async () => {
     const seen: RateLimitOptions[] = [];
 
     @Middleware
     class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
       async use(next: Next): Promise<Response | undefined> {
-        seen.push(optionsOf(RateLimitMiddleware));
+        seen.push(middlewareOptions(RateLimitMiddleware));
         await next();
         return undefined;
       }
@@ -56,7 +56,7 @@ describe('optionsOf', () => {
     @Middleware
     class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
       async use(next: Next): Promise<Response | undefined> {
-        seen.push(optionsOf(RateLimitMiddleware));
+        seen.push(middlewareOptions(RateLimitMiddleware));
         await next();
         return undefined;
       }
@@ -113,9 +113,9 @@ describe('optionsOf', () => {
     @Middleware
     class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
       async use(next: Next): Promise<Response | undefined> {
-        seenBefore.push(optionsOf(RateLimitMiddleware));
+        seenBefore.push(middlewareOptions(RateLimitMiddleware));
         await next();
-        seenAfter.push(optionsOf(RateLimitMiddleware));
+        seenAfter.push(middlewareOptions(RateLimitMiddleware));
         return undefined;
       }
     }
@@ -167,9 +167,11 @@ describe('optionsOf', () => {
     }
 
     runInContext(() => {
-      expect(() => optionsOf(UnboundMiddleware)).toThrow(ZeltMiddlewareOptionsUnavailableError);
-      expect(() => optionsOf(UnboundMiddleware)).toThrow(/UnboundMiddleware/);
-      expect(() => optionsOf(UnboundMiddleware)).toThrow(/\.with\(/);
+      expect(() => middlewareOptions(UnboundMiddleware)).toThrow(
+        ZeltMiddlewareOptionsUnavailableError,
+      );
+      expect(() => middlewareOptions(UnboundMiddleware)).toThrow(/UnboundMiddleware/);
+      expect(() => middlewareOptions(UnboundMiddleware)).toThrow(/\.with\(/);
     });
   });
 
@@ -181,21 +183,24 @@ describe('optionsOf', () => {
       }
     }
 
-    expect(() => optionsOf(SomeMiddleware)).toThrow(ZeltContextNotAvailableError);
+    expect(() => middlewareOptions(SomeMiddleware)).toThrow(ZeltContextNotAvailableError);
   });
 
-  it('supports the self-referencing default-parameter idiom (opts = optionsOf(Self)), unannotated as documented', async () => {
+  it('supports the self-referencing default-parameter idiom (opts = middlewareOptions(Self)), unannotated as documented', async () => {
     const seen: RateLimitOptions[] = [];
 
     @Middleware
     class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
       // No parameter type annotation, matching website/docs/middleware.md
-      // exactly. This only type-checks because optionsOf()'s parameter
+      // exactly. This only type-checks because middlewareOptions()'s parameter
       // constraint doesn't require use() to exist (see MiddlewareOptionsClass
       // in middleware-with-options.lib.ts) — requiring it here would make TS
       // resolve this very use() signature while checking that constraint,
       // which is circular.
-      async use(next: Next, opts = optionsOf(RateLimitMiddleware)): Promise<Response | undefined> {
+      async use(
+        next: Next,
+        opts = middlewareOptions(RateLimitMiddleware),
+      ): Promise<Response | undefined> {
         seen.push(opts);
         await next();
         return undefined;

--- a/packages/core/src/features/http/request/injection/middleware-options.lib.ts
+++ b/packages/core/src/features/http/request/injection/middleware-options.lib.ts
@@ -11,14 +11,14 @@ import type {
   MiddlewareOptionsOf,
 } from '../../middleware/middleware.types';
 
-// Keyed by the underlying class, not the binding: optionsOf() is called by
-// self-reference (optionsOf(RateLimitMiddleware)) from inside that class's own
+// Keyed by the underlying class, not the binding: middlewareOptions() is called by
+// self-reference (middlewareOptions(RateLimitMiddleware)) from inside that class's own
 // use(), so at the point it reads, it only ever has the class to look up.
 const MIDDLEWARE_OPTIONS =
   createContextKey<Map<MiddlewareOptionsClass, unknown>>('zelt:middleware-options');
 
 // The store erases each middleware's options to `unknown`; this phantom handle
-// (mirrors ResultTypeHandle in result-of.lib.ts) lets unsafeResolveDeferredValue
+// (mirrors ValueTypeHandle in middleware-value.lib.ts) lets unsafeResolveDeferredValue
 // narrow it back to the caller's inferred TOptions without an inline `as`.
 class OptionsTypeHandle<T> {
   declare [DEFERRED_VALUE_TYPE]: T;
@@ -61,7 +61,7 @@ export const recordMiddlewareOptions = (
 // Constrained to MiddlewareOptionsClass, which must not require use() — see
 // its comment for the self-reference cycle a use() requirement creates.
 /** @throws {ZeltContextNotAvailableError | ZeltMiddlewareOptionsUnavailableError} */
-export const optionsOf = <M extends MiddlewareOptionsClass>(
+export const middlewareOptions = <M extends MiddlewareOptionsClass>(
   middleware: M,
 ): MiddlewareOptionsOf<M> => {
   const store = getInternal(MIDDLEWARE_OPTIONS);

--- a/packages/core/src/features/http/request/injection/middleware-value.lib.test.ts
+++ b/packages/core/src/features/http/request/injection/middleware-value.lib.test.ts
@@ -3,7 +3,7 @@ import { createApp } from '../../../../app';
 import {
   runInContext,
   ZeltContextNotAvailableError,
-  ZeltMiddlewareResultUnavailableError,
+  ZeltMiddlewareValueUnavailableError,
 } from '../../../../kernel';
 import { http } from '../../http.feature';
 import { MiddlewareWithOptions } from '../../middleware';
@@ -12,10 +12,10 @@ import type { Next } from '../../middleware/middleware.types';
 import { UseMiddleware } from '../../middleware/use-middleware.decorator';
 import { Controller } from '../../routing/controller.decorator';
 import { Get } from '../../routing/http-method.decorator';
-import type { MiddlewareResultOf } from './result-of.lib';
-import { resultOf } from './result-of.lib';
+import type { MiddlewareValueOf } from './middleware-value.lib';
+import { middlewareValue } from './middleware-value.lib';
 
-describe('resultOf', () => {
+describe('middlewareValue', () => {
   it('reads the value a middleware passed to next() from the handler', async () => {
     @Middleware
     class GreetingMiddleware {
@@ -30,7 +30,7 @@ describe('resultOf', () => {
     class GreetController {
       @Get('/')
       get() {
-        return { greeting: resultOf(GreetingMiddleware) };
+        return { greeting: middlewareValue(GreetingMiddleware) };
       }
     }
 
@@ -42,7 +42,7 @@ describe('resultOf', () => {
     expect(await res.json()).toEqual({ greeting: 'hello' });
   });
 
-  it("lets a downstream middleware read an upstream middleware's result via resultOf()", async () => {
+  it("lets a downstream middleware read an upstream middleware's value via middlewareValue()", async () => {
     const seenByDownstream: number[] = [];
 
     @Middleware
@@ -56,7 +56,7 @@ describe('resultOf', () => {
     @Middleware
     class DownstreamMiddleware {
       async use(next: Next): Promise<Response | undefined> {
-        seenByDownstream.push(resultOf(UpstreamMiddleware));
+        seenByDownstream.push(middlewareValue(UpstreamMiddleware));
         await next();
         return undefined;
       }
@@ -83,7 +83,7 @@ describe('resultOf', () => {
     expect(seenByDownstream).toEqual([42]);
   });
 
-  it('does not record a result when next() is called with no arguments', async () => {
+  it('does not record a value when next() is called with no arguments', async () => {
     @Middleware
     class VoidMiddleware {
       async use(next: Next): Promise<Response | undefined> {
@@ -97,7 +97,7 @@ describe('resultOf', () => {
     class VoidController {
       @Get('/')
       get() {
-        expect(() => resultOf(VoidMiddleware)).toThrow(ZeltMiddlewareResultUnavailableError);
+        expect(() => middlewareValue(VoidMiddleware)).toThrow(ZeltMiddlewareValueUnavailableError);
         return { ok: true };
       }
     }
@@ -126,7 +126,7 @@ describe('resultOf', () => {
     class AdminController {
       @Get('/')
       get() {
-        const admin = resultOf(adminAuth);
+        const admin = middlewareValue(adminAuth);
         return { id: admin.id, role: admin.role };
       }
     }
@@ -139,7 +139,7 @@ describe('resultOf', () => {
     expect(await res.json()).toEqual({ id: 1, role: 'admin' });
   });
 
-  it('throws when resultOf() is given a different .with() call than the one applied to the route, even with identical options', async () => {
+  it('throws when middlewareValue() is given a different .with() call than the one applied to the route, even with identical options', async () => {
     type AuthOptions = { role: string };
 
     @Middleware
@@ -157,7 +157,7 @@ describe('resultOf', () => {
     class AdminController {
       @Get('/')
       get() {
-        expect(() => resultOf(unapplied)).toThrow(ZeltMiddlewareResultUnavailableError);
+        expect(() => middlewareValue(unapplied)).toThrow(ZeltMiddlewareValueUnavailableError);
         return { ok: true };
       }
     }
@@ -179,9 +179,11 @@ describe('resultOf', () => {
     }
 
     runInContext(() => {
-      expect(() => resultOf(UnappliedMiddleware)).toThrow(ZeltMiddlewareResultUnavailableError);
-      expect(() => resultOf(UnappliedMiddleware)).toThrow(/UnappliedMiddleware/);
-      expect(() => resultOf(UnappliedMiddleware)).toThrow(/@UseMiddleware/);
+      expect(() => middlewareValue(UnappliedMiddleware)).toThrow(
+        ZeltMiddlewareValueUnavailableError,
+      );
+      expect(() => middlewareValue(UnappliedMiddleware)).toThrow(/UnappliedMiddleware/);
+      expect(() => middlewareValue(UnappliedMiddleware)).toThrow(/@UseMiddleware/);
     });
   });
 
@@ -194,7 +196,7 @@ describe('resultOf', () => {
       }
     }
 
-    expect(() => resultOf(SomeMiddleware)).toThrow(ZeltContextNotAvailableError);
+    expect(() => middlewareValue(SomeMiddleware)).toThrow(ZeltContextNotAvailableError);
   });
 
   it('infers the value type from a middleware exposing Next<T>', () => {
@@ -204,7 +206,7 @@ describe('resultOf', () => {
       }
     }
 
-    expectTypeOf<MiddlewareResultOf<InstanceType<typeof _TypedMiddleware>>>().toEqualTypeOf<{
+    expectTypeOf<MiddlewareValueOf<InstanceType<typeof _TypedMiddleware>>>().toEqualTypeOf<{
       id: number;
     }>();
   });
@@ -216,7 +218,7 @@ describe('resultOf', () => {
       }
     }
 
-    expectTypeOf<MiddlewareResultOf<InstanceType<typeof _VoidMiddleware>>>().toBeNever();
+    expectTypeOf<MiddlewareValueOf<InstanceType<typeof _VoidMiddleware>>>().toBeNever();
   });
 
   it('treats Next<undefined> as a value contract, not as the value-less Next', () => {
@@ -227,11 +229,11 @@ describe('resultOf', () => {
     }
 
     expectTypeOf<
-      MiddlewareResultOf<InstanceType<typeof _ExplicitUndefinedMiddleware>>
+      MiddlewareValueOf<InstanceType<typeof _ExplicitUndefinedMiddleware>>
     >().toEqualTypeOf<undefined>();
   });
 
-  it('records an explicit undefined passed to next() and exposes it via resultOf()', async () => {
+  it('records an explicit undefined passed to next() and exposes it via middlewareValue()', async () => {
     let readValue: unknown = 'not-read';
 
     @Middleware
@@ -247,7 +249,7 @@ describe('resultOf', () => {
     class ExplicitUndefinedController {
       @Get('/')
       get() {
-        readValue = resultOf(ExplicitUndefinedMiddleware);
+        readValue = middlewareValue(ExplicitUndefinedMiddleware);
         return { ok: true };
       }
     }

--- a/packages/core/src/features/http/request/injection/middleware-value.lib.ts
+++ b/packages/core/src/features/http/request/injection/middleware-value.lib.ts
@@ -4,7 +4,7 @@ import {
   createContextKey,
   getInternal,
   setInternal,
-  ZeltMiddlewareResultUnavailableError,
+  ZeltMiddlewareValueUnavailableError,
 } from '../../../../kernel';
 import type {
   BoundMiddleware,
@@ -17,11 +17,11 @@ import type {
 // parameter shape works for value-providing middleware, but a value-less
 // `next: () => Promise<void>` still matches with no inference site, leaving T
 // as void — so exactly-void (and unknown, its no-signal sibling) must collapse
-// to never: middleware that provides nothing has no readable result. The check
+// to never: middleware that provides nothing has no readable value. The check
 // must be EXACT (double conditional): plain `[T] extends [void]` also captures
 // T = undefined, and Next<undefined> is a real "provides explicit undefined"
-// contract whose result must stay readable as `undefined`.
-export type MiddlewareResultOf<M> = M extends {
+// contract whose value must stay readable as `undefined`.
+export type MiddlewareValueOf<M> = M extends {
   use(next: (value: infer T) => unknown, ...args: never[]): unknown;
 }
   ? // biome-ignore lint/suspicious/noConfusingVoidType: void vs undefined is the point of this check; biome's unsafe fix to `undefined` breaks never-collapsing
@@ -37,45 +37,45 @@ export type MiddlewareResultOf<M> = M extends {
 const middlewareDisplayName = (middleware: MiddlewareIdentifier): string =>
   typeof middleware === 'function' ? middleware.name : middleware.middleware.name;
 
-const MIDDLEWARE_RESULTS =
-  createContextKey<Map<MiddlewareIdentifier, unknown>>('zelt:middleware-results');
+const MIDDLEWARE_VALUES =
+  createContextKey<Map<MiddlewareIdentifier, unknown>>('zelt:middleware-values');
 
-// The store erases each middleware's result to `unknown`; this phantom handle
+// The store erases each middleware's value to `unknown`; this phantom handle
 // (mirrors ContextKey in context-key.lib.ts) lets unsafeResolveDeferredValue
 // narrow it back to the caller's inferred T without an inline `as`.
-class ResultTypeHandle<T> {
+class ValueTypeHandle<T> {
   declare [DEFERRED_VALUE_TYPE]: T;
 }
 
 // Written only by middleware-guard.lib.ts: it wraps the next() passed into
 // instance.use() and calls this when next() is invoked with a value.
 /** @throws {ZeltContextNotAvailableError} */
-export const recordMiddlewareResult = (identifier: MiddlewareIdentifier, value: unknown): void => {
-  const store = getInternal(MIDDLEWARE_RESULTS);
+export const recordMiddlewareValue = (identifier: MiddlewareIdentifier, value: unknown): void => {
+  const store = getInternal(MIDDLEWARE_VALUES);
   if (store) {
     store.set(identifier, value);
     return;
   }
-  setInternal(MIDDLEWARE_RESULTS, new Map([[identifier, value]]));
+  setInternal(MIDDLEWARE_VALUES, new Map([[identifier, value]]));
 };
 
 // Two overloads, not one generic over MiddlewareIdentifier: a bare class and a
 // binding resolve their instance type differently (InstanceType<M> vs
 // InstanceType<M['middleware']>), and keeping them separate gives each call
 // site a precise signature instead of a single loosely-inferred one.
-export function resultOf<M extends MiddlewareClass>(
+export function middlewareValue<M extends MiddlewareClass>(
   middleware: M,
-): MiddlewareResultOf<InstanceType<M>>;
-export function resultOf<M extends BoundMiddleware>(
+): MiddlewareValueOf<InstanceType<M>>;
+export function middlewareValue<M extends BoundMiddleware>(
   middleware: M,
-): MiddlewareResultOf<InstanceType<M['middleware']>>;
-/** @throws {ZeltContextNotAvailableError | ZeltMiddlewareResultUnavailableError} */
-export function resultOf(middleware: MiddlewareIdentifier): unknown {
-  const store = getInternal(MIDDLEWARE_RESULTS);
+): MiddlewareValueOf<InstanceType<M['middleware']>>;
+/** @throws {ZeltContextNotAvailableError | ZeltMiddlewareValueUnavailableError} */
+export function middlewareValue(middleware: MiddlewareIdentifier): unknown {
+  const store = getInternal(MIDDLEWARE_VALUES);
   if (!store?.has(middleware)) {
-    throw new ZeltMiddlewareResultUnavailableError({
+    throw new ZeltMiddlewareValueUnavailableError({
       middlewareName: middlewareDisplayName(middleware),
     });
   }
-  return unsafeResolveDeferredValue(new ResultTypeHandle<unknown>(), store.get(middleware));
+  return unsafeResolveDeferredValue(new ValueTypeHandle<unknown>(), store.get(middleware));
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -136,10 +136,10 @@ export {
   ValidationFailedException,
 } from './features/http/request';
 export type {
-  MiddlewareResultOf,
+  MiddlewareValueOf,
   ParsedBody,
 } from './features/http/request/injection';
-export { optionsOf, request, resultOf } from './features/http/request/injection';
+export { middlewareOptions, middlewareValue, request } from './features/http/request/injection';
 export type {
   ExtractRequestBody,
   HasRequestBody,
@@ -187,7 +187,7 @@ export {
   ZeltLifecycleStateError,
   ZeltMiddlewareExecutionError,
   ZeltMiddlewareOptionsUnavailableError,
-  ZeltMiddlewareResultUnavailableError,
+  ZeltMiddlewareValueUnavailableError,
   ZeltNotImplementedError,
   ZeltPluginConfigurationError,
   ZeltRouteConfigurationError,

--- a/packages/core/src/kernel/errors/error-classes.lib.ts
+++ b/packages/core/src/kernel/errors/error-classes.lib.ts
@@ -43,12 +43,12 @@ export const ZeltMiddlewareExecutionError = defineError(
 );
 export type ZeltMiddlewareExecutionError = InstanceType<typeof ZeltMiddlewareExecutionError>;
 
-export const ZeltMiddlewareResultUnavailableError = defineError(
-  'ZeltMiddlewareResultUnavailableError',
-  coreErrorDefinitions.ZeltMiddlewareResultUnavailableError,
+export const ZeltMiddlewareValueUnavailableError = defineError(
+  'ZeltMiddlewareValueUnavailableError',
+  coreErrorDefinitions.ZeltMiddlewareValueUnavailableError,
 );
-export type ZeltMiddlewareResultUnavailableError = InstanceType<
-  typeof ZeltMiddlewareResultUnavailableError
+export type ZeltMiddlewareValueUnavailableError = InstanceType<
+  typeof ZeltMiddlewareValueUnavailableError
 >;
 
 export const ZeltMiddlewareOptionsUnavailableError = defineError(

--- a/packages/core/src/kernel/errors/error-definitions.lib.ts
+++ b/packages/core/src/kernel/errors/error-definitions.lib.ts
@@ -65,15 +65,15 @@ export const coreErrorDefinitions = {
     middlewareName: string;
   }) => `next() called multiple times in middleware '${ctx.middlewareName}'`,
 
-  ZeltMiddlewareResultUnavailableError: (ctx: { middlewareName: string }) =>
-    `No result available for middleware '${ctx.middlewareName}'. It is not applied to this route, ` +
+  ZeltMiddlewareValueUnavailableError: (ctx: { middlewareName: string }) =>
+    `No value available for middleware '${ctx.middlewareName}'. It is not applied to this route, ` +
     `or it has not run yet. Apply it with @UseMiddleware(${ctx.middlewareName}) before calling ` +
-    `resultOf(${ctx.middlewareName}).`,
+    `middlewareValue(${ctx.middlewareName}).`,
 
   ZeltMiddlewareOptionsUnavailableError: (ctx: { middlewareName: string }) =>
     `No options available for middleware '${ctx.middlewareName}'. It is not applied via ` +
     `${ctx.middlewareName}.with(options) on this route, or it has not run yet. Apply it with ` +
-    `@UseMiddleware(${ctx.middlewareName}.with(options)) before calling optionsOf(${ctx.middlewareName}).`,
+    `@UseMiddleware(${ctx.middlewareName}.with(options)) before calling middlewareOptions(${ctx.middlewareName}).`,
 
   ZeltNotImplementedError: (ctx: { className: string; methodName: string }) =>
     `${ctx.className}.${ctx.methodName}() not implemented`,

--- a/packages/rate-limit/src/rate-limit.middleware.ts
+++ b/packages/rate-limit/src/rate-limit.middleware.ts
@@ -3,7 +3,7 @@ import {
   inject,
   Middleware,
   MiddlewareWithOptions,
-  optionsOf,
+  middlewareOptions,
   response,
   UseMiddleware,
 } from '@zeltjs/core';
@@ -30,7 +30,7 @@ export class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions>
    */
   async use(
     next: Next,
-    opts = optionsOf(RateLimitMiddleware),
+    opts = middlewareOptions(RateLimitMiddleware),
     res = response(),
   ): Promise<Response | undefined> {
     if (!this.config.enabled) {

--- a/website/docs/authentication/user-context.md
+++ b/website/docs/authentication/user-context.md
@@ -92,7 +92,7 @@ class ProfileController {
 
 `currentUser()` always returns `Record<string, unknown> | undefined` — the shape passed to `setUser()` isn't tracked at the type level, so reading a specific field requires a manual assertion or narrowing.
 
-For a value with a concrete, narrowed type available to handlers, provide it through a middleware instead: declare it with `Next<T>` and pass it to `next(value)`, then read it with `resultOf(M)`. See [Middleware Results](../middleware.md#middleware-results) for details.
+For a value with a concrete, narrowed type available to handlers, provide it through a middleware instead: declare it with `Next<T>` and pass it to `next(value)`, then read it with `middlewareValue(M)`. See [Middleware Values](../middleware.md#middleware-values) for details.
 
 ## User Design Best Practices
 

--- a/website/docs/middleware.md
+++ b/website/docs/middleware.md
@@ -152,9 +152,9 @@ More specific middleware attachment wins over a class-level skip. If a controlle
 
 `CorsMiddleware` and `SecureHeadersMiddleware` are auto-registered on every HTTP app. See [HTTP Security](./http-security.md) for their defaults, configuration options, skip examples, and CORS preflight behavior.
 
-## Middleware Results
+## Middleware Values
 
-Middleware can provide a typed value to the code that runs after it. Providing a value uses the `Next<T>` type together with `next(value)`; reading it uses `resultOf(M)`. There are no string keys or module augmentation to maintain.
+Middleware can provide a typed value to the code that runs after it. Providing a value uses the `Next<T>` type together with `next(value)`; reading it uses `middlewareValue(M)`. There are no string keys or module augmentation to maintain.
 
 ### Providing a Value
 
@@ -181,10 +181,10 @@ Because `Next<T>` requires an argument, calling `next()` without a value is a ty
 
 ### Reading a Value
 
-Handlers — and other middleware — read a provided value with `resultOf(M)`, passed as a parameter default:
+Handlers — and other middleware — read a provided value with `middlewareValue(M)`, passed as a parameter default:
 
 ```typescript
-import { Controller, Get, Middleware, UseMiddleware, request, resultOf, type Next } from '@zeltjs/core';
+import { Controller, Get, Middleware, UseMiddleware, request, middlewareValue, type Next } from '@zeltjs/core';
 
 @Middleware
 class AuthMiddleware {
@@ -198,17 +198,17 @@ class AuthMiddleware {
 @Controller('/profile')
 export class ProfileController {
   @Get('/')
-  getProfile(user = resultOf(AuthMiddleware)) {
+  getProfile(user = middlewareValue(AuthMiddleware)) {
     return { id: user.id, name: user.name };
   }
 }
 ```
 
-The type reflects `M`'s own `Next<T>` declaration as-is — a middleware declared as `Next<string | undefined>` yields a nullable result. In this example, `AuthMiddleware` short-circuits with a 401 response before it ever calls `next(user)`, so by the time a handler runs, the value is guaranteed to exist. Middleware reads another middleware's value the same way, as a parameter default on its own `use()` method.
+The type reflects `M`'s own `Next<T>` declaration as-is — a middleware declared as `Next<string | undefined>` yields a nullable value. In this example, `AuthMiddleware` short-circuits with a 401 response before it ever calls `next(user)`, so by the time a handler runs, the value is guaranteed to exist. Middleware reads another middleware's value the same way, as a parameter default on its own `use()` method.
 
 ### Reading Requires the Middleware
 
-Calling `resultOf(M)` throws immediately, with an error naming the middleware, in two cases: the middleware isn't applied to the route, or it is applied but never called `next(value)` (so no value was ever recorded). There is no silent `undefined`. Applying middleware to a route still works exactly as before, with `@UseMiddleware` on a controller or method, or with `middlewares` on a module.
+Calling `middlewareValue(M)` throws immediately, with an error naming the middleware, in two cases: the middleware isn't applied to the route, or it is applied but never called `next(value)` (so no value was ever recorded). There is no silent `undefined`. Applying middleware to a route still works exactly as before, with `@UseMiddleware` on a controller or method, or with `middlewares` on a module.
 
 ## Dependency Injection
 
@@ -258,10 +258,10 @@ export class AdminController {
 
 ## Middleware with Options
 
-Middleware that requires configuration extends `MiddlewareWithOptions<TOptions>` and reads its options with `optionsOf()`, as a parameter default — the same pattern as `request()` and `resultOf()`:
+Middleware that requires configuration extends `MiddlewareWithOptions<TOptions>` and reads its options with `middlewareOptions()`, as a parameter default — the same pattern as `request()` and `middlewareValue()`:
 
 ```typescript
-import { Middleware, MiddlewareWithOptions, optionsOf, type Next } from '@zeltjs/core';
+import { Middleware, MiddlewareWithOptions, middlewareOptions, type Next } from '@zeltjs/core';
 // ---cut---
 interface RateLimitOptions {
   limit: number;
@@ -270,7 +270,7 @@ interface RateLimitOptions {
 
 @Middleware
 export class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
-  async use(next: Next, opts = optionsOf(RateLimitMiddleware)) {
+  async use(next: Next, opts = middlewareOptions(RateLimitMiddleware)) {
     const { limit, windowSec } = opts;
     // ... rate limiting logic
     await next();
@@ -282,7 +282,7 @@ export class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions>
 Pass the options where the middleware is applied, with `.with()`:
 
 ```typescript
-import { Controller, Middleware, MiddlewareWithOptions, Post, UseMiddleware, optionsOf, type Next } from '@zeltjs/core';
+import { Controller, Middleware, MiddlewareWithOptions, Post, UseMiddleware, middlewareOptions, type Next } from '@zeltjs/core';
 
 interface RateLimitOptions {
   limit: number;
@@ -291,7 +291,7 @@ interface RateLimitOptions {
 
 @Middleware
 class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
-  async use(next: Next, opts = optionsOf(RateLimitMiddleware)) {
+  async use(next: Next, opts = middlewareOptions(RateLimitMiddleware)) {
     await next();
     return undefined;
   }
@@ -311,12 +311,12 @@ Middleware that takes options is always registered through `.with()`. Registerin
 
 Middleware without options doesn't extend anything and is registered as the plain class, exactly as in the earlier examples.
 
-### Reading Results from Middleware with Options
+### Reading Values from Middleware with Options
 
-To read the result of middleware that takes options, store the return value of `.with()` in a `const` and use that same `const` in both places — where the middleware is applied, and in `resultOf()`:
+To read the value provided by middleware that takes options, store the return value of `.with()` in a `const` and use that same `const` in both places — where the middleware is applied, and in `middlewareValue()`:
 
 ```typescript
-import { Controller, Get, Middleware, MiddlewareWithOptions, UseMiddleware, optionsOf, resultOf, type Next } from '@zeltjs/core';
+import { Controller, Get, Middleware, MiddlewareWithOptions, UseMiddleware, middlewareOptions, middlewareValue, type Next } from '@zeltjs/core';
 
 interface AuthOptions {
   role: 'admin' | 'member';
@@ -324,7 +324,7 @@ interface AuthOptions {
 
 @Middleware
 class UserAuthMiddleware extends MiddlewareWithOptions<AuthOptions> {
-  async use(next: Next<{ id: number; role: string }>, opts = optionsOf(UserAuthMiddleware)) {
+  async use(next: Next<{ id: number; role: string }>, opts = middlewareOptions(UserAuthMiddleware)) {
     await next({ id: 1, role: opts.role });
     return undefined;
   }
@@ -338,15 +338,15 @@ export const adminAuth = UserAuthMiddleware.with({ role: 'admin' });
 @Controller('/admin')
 export class AdminController {
   @Get('/me')
-  me(admin = resultOf(adminAuth)) {
+  me(admin = middlewareValue(adminAuth)) {
     return { id: admin.id, role: admin.role };
   }
 }
 ```
 
-Each `.with()` call counts as its own middleware. If a route is registered with one `.with()` call and `resultOf()` receives another — even with identical options — the two don't match: `resultOf()` sees a middleware that isn't applied to the route and throws. Always share a single `const`.
+Each `.with()` call counts as its own middleware. If a route is registered with one `.with()` call and `middlewareValue()` receives another — even with identical options — the two don't match: `middlewareValue()` sees a middleware that isn't applied to the route and throws. Always share a single `const`.
 
-The same middleware class can be applied multiple times with different options. Each application runs independently, and each `const` reads its own result.
+The same middleware class can be applied multiple times with different options. Each application runs independently, and each `const` reads its own value.
 
 ## Request Flow
 
@@ -408,7 +408,7 @@ class MethodMiddleware {
 
 ## Common Patterns
 
-Middleware is written as classes. Use `request()`, `response()`, and `resultOf()` for framework primitives.
+Middleware is written as classes. Use `request()`, `response()`, and `middlewareValue()` for framework primitives.
 
 ### Restrict Access
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/authentication/user-context.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/authentication/user-context.md
@@ -92,7 +92,7 @@ class ProfileController {
 
 `currentUser()` は常に `Record<string, unknown> | undefined` を返します。`setUser()` に渡した形は型レベルでは追跡されないため、特定のフィールドを読み取るには手動でのアサーションや絞り込みが必要です。
 
-handlerで利用できる、具体的に絞り込まれた型の値が必要な場合は、代わりにmiddleware経由で提供します。`Next<T>` に宣言して `next(value)` に渡し、`resultOf(M)` で読み取ります。詳細は[Middleware Results](../middleware.md#middleware-results)を参照してください。
+handlerで利用できる、具体的に絞り込まれた型の値が必要な場合は、代わりにmiddleware経由で提供します。`Next<T>` に宣言して `next(value)` に渡し、`middlewareValue(M)` で読み取ります。詳細は[Middleware Values](../middleware.md#middleware-values)を参照してください。
 
 ## User設計のBest Practices {#user-design-best-practices}
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/middleware.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/middleware.md
@@ -152,9 +152,9 @@ export class PublicController {
 
 `CorsMiddleware`と`SecureHeadersMiddleware`は、全てのHTTPアプリで自動的に登録されます。デフォルト設定、設定オプション、skipの例、CORSプリフライトの挙動については[HTTP Security](./http-security.md)を参照してください。
 
-## Middleware Results {#middleware-results}
+## Middleware Values {#middleware-values}
 
-middlewareは、後続のコードに型付きの値を提供できます。値の提供には `Next<T>` 型と `next(value)` を、読み取りには `resultOf(M)` を使います。文字列キーやmodule augmentationを管理する必要はありません。
+middlewareは、後続のコードに型付きの値を提供できます。値の提供には `Next<T>` 型と `next(value)` を、読み取りには `middlewareValue(M)` を使います。文字列キーやmodule augmentationを管理する必要はありません。
 
 ### Providing a Value {#providing-a-value}
 
@@ -181,10 +181,10 @@ export class AuthMiddleware {
 
 ### Reading a Value {#reading-a-value}
 
-handler、そして他のmiddlewareも、提供された値をパラメータのデフォルト値として渡す `resultOf(M)` で読み取ります。
+handler、そして他のmiddlewareも、提供された値をパラメータのデフォルト値として渡す `middlewareValue(M)` で読み取ります。
 
 ```typescript
-import { Controller, Get, Middleware, UseMiddleware, request, resultOf, type Next } from '@zeltjs/core';
+import { Controller, Get, Middleware, UseMiddleware, request, middlewareValue, type Next } from '@zeltjs/core';
 
 @Middleware
 class AuthMiddleware {
@@ -198,7 +198,7 @@ class AuthMiddleware {
 @Controller('/profile')
 export class ProfileController {
   @Get('/')
-  getProfile(user = resultOf(AuthMiddleware)) {
+  getProfile(user = middlewareValue(AuthMiddleware)) {
     return { id: user.id, name: user.name };
   }
 }
@@ -208,7 +208,7 @@ export class ProfileController {
 
 ### Reading Requires the Middleware {#reading-requires-the-middleware}
 
-`resultOf(M)` の呼び出しは、次の2つの場合に即座にそのmiddleware名を含むエラーをスローします — ルートにそのmiddlewareが適用されていない場合、そして適用されていても`next(value)`が一度も呼ばれておらず値が記録されていない場合です。黙って`undefined`が返ることはありません。middlewareをルートに適用する方法自体は従来どおりで、controllerやmethodへの`@UseMiddleware`、またはmoduleの`middlewares`を使います。
+`middlewareValue(M)` の呼び出しは、次の2つの場合に即座にそのmiddleware名を含むエラーをスローします — ルートにそのmiddlewareが適用されていない場合、そして適用されていても`next(value)`が一度も呼ばれておらず値が記録されていない場合です。黙って`undefined`が返ることはありません。middlewareをルートに適用する方法自体は従来どおりで、controllerやmethodへの`@UseMiddleware`、またはmoduleの`middlewares`を使います。
 
 ## Dependency Injection {#dependency-injection}
 
@@ -258,10 +258,10 @@ export class AdminController {
 
 ## Middleware with Options {#middleware-with-options}
 
-設定が必要なmiddlewareは`MiddlewareWithOptions<TOptions>`を継承し、オプションを`optionsOf()`でパラメータデフォルト値として読み取ります — `request()`や`resultOf()`と同じパターンです:
+設定が必要なmiddlewareは`MiddlewareWithOptions<TOptions>`を継承し、オプションを`middlewareOptions()`でパラメータデフォルト値として読み取ります — `request()`や`middlewareValue()`と同じパターンです:
 
 ```typescript
-import { Middleware, MiddlewareWithOptions, optionsOf, type Next } from '@zeltjs/core';
+import { Middleware, MiddlewareWithOptions, middlewareOptions, type Next } from '@zeltjs/core';
 // ---cut---
 interface RateLimitOptions {
   limit: number;
@@ -270,7 +270,7 @@ interface RateLimitOptions {
 
 @Middleware
 export class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
-  async use(next: Next, opts = optionsOf(RateLimitMiddleware)) {
+  async use(next: Next, opts = middlewareOptions(RateLimitMiddleware)) {
     const { limit, windowSec } = opts;
     // ... レート制限ロジック
     await next();
@@ -282,7 +282,7 @@ export class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions>
 オプションは、middlewareを適用する場所で`.with()`を使って渡します:
 
 ```typescript
-import { Controller, Middleware, MiddlewareWithOptions, Post, UseMiddleware, optionsOf, type Next } from '@zeltjs/core';
+import { Controller, Middleware, MiddlewareWithOptions, Post, UseMiddleware, middlewareOptions, type Next } from '@zeltjs/core';
 
 interface RateLimitOptions {
   limit: number;
@@ -291,7 +291,7 @@ interface RateLimitOptions {
 
 @Middleware
 class RateLimitMiddleware extends MiddlewareWithOptions<RateLimitOptions> {
-  async use(next: Next, opts = optionsOf(RateLimitMiddleware)) {
+  async use(next: Next, opts = middlewareOptions(RateLimitMiddleware)) {
     await next();
     return undefined;
   }
@@ -311,12 +311,12 @@ export class ApiController {
 
 オプションを持たないmiddlewareは何も継承せず、これまでの例のとおり素のクラスをそのまま登録します。
 
-### オプション付きmiddlewareの結果を読む {#reading-results-from-middleware-with-options}
+### オプション付きmiddlewareの値を読む {#reading-values-from-middleware-with-options}
 
-オプションを取るmiddlewareの結果を読むには、`.with()`の戻り値を`const`に入れ、middlewareを適用する場所と`resultOf()`の両方で同じ`const`を使います:
+オプションを取るmiddlewareが提供する値を読むには、`.with()`の戻り値を`const`に入れ、middlewareを適用する場所と`middlewareValue()`の両方で同じ`const`を使います:
 
 ```typescript
-import { Controller, Get, Middleware, MiddlewareWithOptions, UseMiddleware, optionsOf, resultOf, type Next } from '@zeltjs/core';
+import { Controller, Get, Middleware, MiddlewareWithOptions, UseMiddleware, middlewareOptions, middlewareValue, type Next } from '@zeltjs/core';
 
 interface AuthOptions {
   role: 'admin' | 'member';
@@ -324,7 +324,7 @@ interface AuthOptions {
 
 @Middleware
 class UserAuthMiddleware extends MiddlewareWithOptions<AuthOptions> {
-  async use(next: Next<{ id: number; role: string }>, opts = optionsOf(UserAuthMiddleware)) {
+  async use(next: Next<{ id: number; role: string }>, opts = middlewareOptions(UserAuthMiddleware)) {
     await next({ id: 1, role: opts.role });
     return undefined;
   }
@@ -338,15 +338,15 @@ export const adminAuth = UserAuthMiddleware.with({ role: 'admin' });
 @Controller('/admin')
 export class AdminController {
   @Get('/me')
-  me(admin = resultOf(adminAuth)) {
+  me(admin = middlewareValue(adminAuth)) {
     return { id: admin.id, role: admin.role };
   }
 }
 ```
 
-`.with()`は呼び出しごとに、それぞれ別のmiddlewareとして扱われます。ルートの登録に使った`.with()`と`resultOf()`に渡した`.with()`が別の呼び出しだと、たとえオプションが同一でも両者は一致しません — `resultOf()`からはルートに適用されていないmiddlewareに見え、例外になります。必ず1つの`const`を共有してください。
+`.with()`は呼び出しごとに、それぞれ別のmiddlewareとして扱われます。ルートの登録に使った`.with()`と`middlewareValue()`に渡した`.with()`が別の呼び出しだと、たとえオプションが同一でも両者は一致しません — `middlewareValue()`からはルートに適用されていないmiddlewareに見え、例外になります。必ず1つの`const`を共有してください。
 
-同じmiddlewareクラスを異なるオプションで複数回適用することもできます。それぞれの適用は独立して実行され、各`const`は自分の結果を読み取ります。
+同じmiddlewareクラスを異なるオプションで複数回適用することもできます。それぞれの適用は独立して実行され、各`const`は自分の値を読み取ります。
 
 ## Request Flow {#request-flow}
 
@@ -408,7 +408,7 @@ class MethodMiddleware {
 
 ## Common Patterns {#common-patterns}
 
-Middlewareはクラスとして記述します。フレームワークのprimitiveには`request()`、`response()`、`resultOf()`を使います。
+Middlewareはクラスとして記述します。フレームワークのprimitiveには`request()`、`response()`、`middlewareValue()`を使います。
 
 ### Restrict Access {#restrict-access}
 


### PR DESCRIPTION
## Summary
- rename `resultOf` to `middlewareValue` so the accessor names the value propagated by middleware
- rename `optionsOf` to `middlewareOptions` and align related types, errors, internals, and file names
- update integrations and English/Japanese docs without retaining legacy aliases

## Breaking changes
- `resultOf` → `middlewareValue`
- `optionsOf` → `middlewareOptions`
- `MiddlewareResultOf` → `MiddlewareValueOf`
- `ZeltMiddlewareResultUnavailableError` → `ZeltMiddlewareValueUnavailableError`

## Testing
- `pnpm precommit`
- `pnpm test:integration scopes`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeltjs/codesmith/zelt/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791632996&installation_model_id=21678&pr_number=321&repository=zeltjs%2Fzelt&return_to=https%3A%2F%2Fgithub.com%2Fzeltjs%2Fzelt%2Fpull%2F321&signature=0e800a61c6e73e3d5871c22d9a38467806e2455e34e82557df07c6dd445bf934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更点**
  - ミドルウェア値の取得APIを `resultOf` から `middlewareValue` に変更しました。
  - ミドルウェアオプションの取得APIを `optionsOf` から `middlewareOptions` に変更しました。
  - 関連する型名・エラー名も「Result」から「Value」へ変更しました。
  - 既存のミドルウェア動作や値の取得ロジックに変更はありません。

- **ドキュメント**
  - APIリファレンス、コード例、用語を新しい名称に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->